### PR TITLE
feat(contracts): implement SmartAccount with ECDSA validation and execution

### DIFF
--- a/contracts/src/SmartAccount.sol
+++ b/contracts/src/SmartAccount.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.28;
 
 import {BaseAccount} from "@account-abstraction/contracts/core/BaseAccount.sol";

--- a/contracts/src/SmartAccount.sol
+++ b/contracts/src/SmartAccount.sol
@@ -84,24 +84,23 @@ contract SmartAccount is BaseAccount, Initializable {
     ///         The flow (called by BaseAccount.validateUserOp):
     ///         1. `userOpHash` is the hash of the UserOp (already includes entryPoint + chainId).
     ///         2. We convert it to an Ethereum Signed Message hash (prepend "\x19Ethereum Signed Message:\n32").
-    ///         3. ECDSA.recover extracts the signer address from the signature.
-    ///         4. If signer == owner → return 0 (success). Otherwise → return 1 (failure, no revert).
+    ///         3. ECDSA.tryRecover extracts the signer — returns an error instead of reverting
+    ///            on malformed signatures (wrong length, invalid s, etc.).
+    ///         4. If any error OR signer != owner → return 1 (SIG_VALIDATION_FAILED, no revert).
     ///
     /// @inheritdoc BaseAccount
     function _validateSignature(
         PackedUserOperation calldata userOp,
         bytes32 userOpHash
     ) internal view override returns (uint256 validationData) {
-        // Convert the raw hash to an eth_sign compatible hash.
-        // This is what wallets (MetaMask) actually sign — they prepend the EIP-191 prefix.
         bytes32 ethSignedHash = userOpHash.toEthSignedMessageHash();
 
-        // Recover the signer. If the signature is invalid, this returns address(0).
-        address recovered = ethSignedHash.recover(userOp.signature);
+        // tryRecover returns (address, RecoverError, bytes32) — never reverts.
+        // recover would revert on malformed sigs, violating the ERC-4337 spec:
+        // validateUserOp must return SIG_VALIDATION_FAILED on bad sigs, not revert.
+        (address recovered, ECDSA.RecoverError err,) = ethSignedHash.tryRecover(userOp.signature);
 
-        // SIG_VALIDATION_FAILED (1) tells the EntryPoint the sig is bad — without reverting.
-        // Reverting would be a hard failure (bad nonce, malformed data), not a sig mismatch.
-        if (recovered != owner) {
+        if (err != ECDSA.RecoverError.NoError || recovered != owner) {
             return SIG_VALIDATION_FAILED;
         }
         return SIG_VALIDATION_SUCCESS;

--- a/contracts/src/SmartAccount.sol
+++ b/contracts/src/SmartAccount.sol
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import {BaseAccount} from "@account-abstraction/contracts/core/BaseAccount.sol";
+import {IEntryPoint} from "@account-abstraction/contracts/interfaces/IEntryPoint.sol";
+import {PackedUserOperation} from "@account-abstraction/contracts/interfaces/PackedUserOperation.sol";
+import {SIG_VALIDATION_FAILED, SIG_VALIDATION_SUCCESS} from "@account-abstraction/contracts/core/Helpers.sol";
+import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+import {MessageHashUtils} from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
+import {Initializable} from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
+
+/// @title SmartAccount
+/// @notice ERC-4337 compliant smart account with ECDSA owner validation.
+///         Designed to be deployed as a proxy via SmartAccountFactory (CREATE2).
+///         Session key support will be added in a subsequent issue.
+contract SmartAccount is BaseAccount, Initializable {
+    using ECDSA for bytes32;
+    using MessageHashUtils for bytes32;
+
+    // ───────────────────────────── Storage ─────────────────────────────
+
+    /// @notice The EOA that owns this account and can sign UserOperations.
+    address public owner;
+
+    /// @notice The canonical EntryPoint v0.7 contract. Set once at construction
+    ///         and shared across all proxies (lives in the implementation, not storage).
+    IEntryPoint private immutable _ENTRY_POINT;
+
+    // ───────────────────────────── Events ──────────────────────────────
+
+    event SmartAccountInitialized(IEntryPoint indexed entryPoint, address indexed owner);
+
+    // ───────────────────────────── Errors ──────────────────────────────
+
+    error OnlyOwnerOrEntryPoint();
+    error OnlyOwner();
+    error CallFailed(bytes returnData);
+
+    // ───────────────────────────── Modifiers ───────────────────────────
+
+    /// @notice Restricts to the EntryPoint (during UserOp execution) or the owner (direct calls).
+    modifier onlyOwnerOrEntryPoint() {
+        _checkOwnerOrEntryPoint();
+        _;
+    }
+
+    /// @notice Restricts to the owner only.
+    modifier onlyOwner() {
+        _checkOwner();
+        _;
+    }
+
+    // ─────────────────────────── Constructor ───────────────────────────
+
+    /// @notice Sets the EntryPoint. Called once on the *implementation* contract.
+    ///         `_disableInitializers()` prevents anyone from calling `initialize`
+    ///         on the implementation itself — only proxies can be initialized.
+    /// @param entryPoint_ The EntryPoint v0.7 address (same on all EVM chains).
+    constructor(IEntryPoint entryPoint_) {
+        _ENTRY_POINT = entryPoint_;
+        _disableInitializers();
+    }
+
+    // ─────────────────────────── Initializer ───────────────────────────
+
+    /// @notice Initializes a proxy clone. Called once by the factory during CREATE2 deployment.
+    /// @param owner_ The EOA that will own this smart account.
+    function initialize(address owner_) external initializer {
+        require(owner_ != address(0), "invalid owner");
+        owner = owner_;
+        emit SmartAccountInitialized(_ENTRY_POINT, owner_);
+    }
+
+    // ──────────────────── BaseAccount implementation ───────────────────
+
+    /// @inheritdoc BaseAccount
+    function entryPoint() public view override returns (IEntryPoint) {
+        return _ENTRY_POINT;
+    }
+
+    /// @notice Validates the UserOperation signature.
+    ///         Recovers the signer from the signature and checks it matches the owner.
+    ///
+    ///         The flow (called by BaseAccount.validateUserOp):
+    ///         1. `userOpHash` is the hash of the UserOp (already includes entryPoint + chainId).
+    ///         2. We convert it to an Ethereum Signed Message hash (prepend "\x19Ethereum Signed Message:\n32").
+    ///         3. ECDSA.recover extracts the signer address from the signature.
+    ///         4. If signer == owner → return 0 (success). Otherwise → return 1 (failure, no revert).
+    ///
+    /// @inheritdoc BaseAccount
+    function _validateSignature(
+        PackedUserOperation calldata userOp,
+        bytes32 userOpHash
+    ) internal view override returns (uint256 validationData) {
+        // Convert the raw hash to an eth_sign compatible hash.
+        // This is what wallets (MetaMask) actually sign — they prepend the EIP-191 prefix.
+        bytes32 ethSignedHash = userOpHash.toEthSignedMessageHash();
+
+        // Recover the signer. If the signature is invalid, this returns address(0).
+        address recovered = ethSignedHash.recover(userOp.signature);
+
+        // SIG_VALIDATION_FAILED (1) tells the EntryPoint the sig is bad — without reverting.
+        // Reverting would be a hard failure (bad nonce, malformed data), not a sig mismatch.
+        if (recovered != owner) {
+            return SIG_VALIDATION_FAILED;
+        }
+        return SIG_VALIDATION_SUCCESS;
+    }
+
+    // ──────────────────────────── Execution ────────────────────────────
+
+    /// @notice Execute a single call from this account.
+    ///         Called by the EntryPoint after successful validation (via userOp.callData),
+    ///         or directly by the owner for convenience.
+    /// @param target  The contract (or EOA) to call.
+    /// @param value   The ETH value to send.
+    /// @param data    The calldata (function selector + arguments).
+    function execute(address target, uint256 value, bytes calldata data) external onlyOwnerOrEntryPoint {
+        (bool success, bytes memory returnData) = target.call{value: value}(data);
+        if (!success) {
+            revert CallFailed(returnData);
+        }
+    }
+
+    /// @notice Execute multiple calls in a single UserOperation.
+    ///         Useful for batching (e.g., approve + swap in one op).
+    /// @param targets  Array of addresses to call.
+    /// @param values   Array of ETH values to send.
+    /// @param calldatas Array of calldata payloads.
+    function executeBatch(
+        address[] calldata targets,
+        uint256[] calldata values,
+        bytes[] calldata calldatas
+    ) external onlyOwnerOrEntryPoint {
+        require(targets.length == values.length && values.length == calldatas.length, "length mismatch");
+        for (uint256 i = 0; i < targets.length; i++) {
+            (bool success, bytes memory returnData) = targets[i].call{value: values[i]}(calldatas[i]);
+            if (!success) {
+                revert CallFailed(returnData);
+            }
+        }
+    }
+
+    // ───────────────────────────── Receive ─────────────────────────────
+
+    /// @notice Accept ETH deposits. The account needs ETH to pay for gas
+    ///         (deposited to the EntryPoint, or held directly).
+    receive() external payable {}
+
+    // ──────────────────────── Internal helpers ─────────────────────────
+
+    function _checkOwnerOrEntryPoint() internal view {
+        if (msg.sender != address(entryPoint()) && msg.sender != owner) {
+            revert OnlyOwnerOrEntryPoint();
+        }
+    }
+
+    function _checkOwner() internal view {
+        if (msg.sender != owner) {
+            revert OnlyOwner();
+        }
+    }
+}

--- a/contracts/test/SmartAccount.t.sol
+++ b/contracts/test/SmartAccount.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.28;
 
 import {Test} from "forge-std/Test.sol";

--- a/contracts/test/SmartAccount.t.sol
+++ b/contracts/test/SmartAccount.t.sol
@@ -1,0 +1,216 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+import {Test} from "forge-std/Test.sol";
+import {EntryPoint} from "@account-abstraction/contracts/core/EntryPoint.sol";
+import {IEntryPoint} from "@account-abstraction/contracts/interfaces/IEntryPoint.sol";
+import {PackedUserOperation} from "@account-abstraction/contracts/interfaces/PackedUserOperation.sol";
+import {MessageHashUtils} from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
+import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import {SmartAccount} from "../src/SmartAccount.sol";
+import {Counter} from "../src/Counter.sol";
+
+contract SmartAccountTest is Test {
+    using MessageHashUtils for bytes32;
+
+    // ───────────────────────────── State ───────────────────────────────
+
+    EntryPoint public entryPoint;
+    SmartAccount public account;
+    Counter public counter;
+
+    address public owner;
+    uint256 public ownerKey;
+    address public stranger;
+    address payable public beneficiary;
+
+    // ───────────────────────────── Setup ───────────────────────────────
+
+    function setUp() public {
+        entryPoint = new EntryPoint();
+        (owner, ownerKey) = makeAddrAndKey("owner");
+        stranger = makeAddr("stranger");
+
+        // Deploy implementation, then an ERC1967Proxy that delegatecalls initialize(owner)
+        SmartAccount implementation = new SmartAccount(IEntryPoint(address(entryPoint)));
+        bytes memory initData = abi.encodeCall(SmartAccount.initialize, (owner));
+        ERC1967Proxy proxy = new ERC1967Proxy(address(implementation), initData);
+        account = SmartAccount(payable(address(proxy)));
+
+        // Fund: EntryPoint deposit (gas for UserOps) + direct ETH (for value-forwarding tests)
+        entryPoint.depositTo{value: 1 ether}(address(account));
+        vm.deal(address(account), 1 ether);
+
+        counter = new Counter();
+        beneficiary = payable(makeAddr("beneficiary"));
+    }
+
+    // ───────────────────────────── Helpers ─────────────────────────────
+
+    /// @notice Packs two uint128 values into a single bytes32.
+    ///         Used for accountGasLimits (verificationGas | callGas)
+    ///         and gasFees (maxPriorityFee | maxFee).
+    function _packGas(uint256 upper, uint256 lower) internal pure returns (bytes32) {
+        return bytes32((upper << 128) | lower);
+    }
+
+    /// @notice Builds a PackedUserOperation with sensible gas defaults.
+    function _buildUserOp(bytes memory callData) internal view returns (PackedUserOperation memory) {
+        return PackedUserOperation({
+            sender: address(account),
+            nonce: account.getNonce(),
+            initCode: "",
+            callData: callData,
+            accountGasLimits: _packGas(200_000, 200_000),
+            preVerificationGas: 50_000,
+            gasFees: _packGas(1 gwei, 1 gwei),
+            paymasterAndData: "",
+            signature: ""
+        });
+    }
+
+    /// @notice Must be `external` so the struct is passed as calldata —
+    ///         getUserOpHash requires calldata, and memory→calldata conversion
+    ///         only happens at an external call boundary.
+    function getUserOpHash(PackedUserOperation calldata userOp) external view returns (bytes32) {
+        return entryPoint.getUserOpHash(userOp);
+    }
+
+    /// @notice Signs a UserOp: compute hash → EIP-191 prefix → vm.sign → pack (r, s, v).
+    function _signUserOp(
+        PackedUserOperation memory userOp,
+        uint256 privateKey
+    ) internal view returns (bytes memory) {
+        bytes32 userOpHash = this.getUserOpHash(userOp);
+        bytes32 ethSignedHash = userOpHash.toEthSignedMessageHash();
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, ethSignedHash);
+        return abi.encodePacked(r, s, v);
+    }
+
+    // ────────────────────── Initialization tests ──────────────────────
+
+    function test_initialize_setsOwner() public view {
+        assertEq(account.owner(), owner);
+    }
+
+    function test_initialize_setsEntryPoint() public view {
+        assertEq(address(account.entryPoint()), address(entryPoint));
+    }
+
+    function test_initialize_cannotReinitialize() public {
+        vm.expectRevert();
+        account.initialize(stranger);
+    }
+
+    function test_initialize_revertsOnZeroAddress() public {
+        SmartAccount impl = new SmartAccount(IEntryPoint(address(entryPoint)));
+        bytes memory initData = abi.encodeCall(SmartAccount.initialize, (address(0)));
+
+        vm.expectRevert("invalid owner");
+        new ERC1967Proxy(address(impl), initData);
+    }
+
+    // ───────────────── Signature validation tests ─────────────────────
+
+    function test_validateUserOp_validOwnerSignature() public {
+        PackedUserOperation memory userOp = _buildUserOp("");
+        userOp.signature = _signUserOp(userOp, ownerKey);
+
+        // Must pass the real userOpHash — _validateSignature uses it to recover the signer
+        bytes32 userOpHash = this.getUserOpHash(userOp);
+
+        vm.prank(address(entryPoint));
+        uint256 validationData = account.validateUserOp(userOp, userOpHash, 0);
+        assertEq(validationData, 0); // SIG_VALIDATION_SUCCESS
+    }
+
+    function test_validateUserOp_wrongSigner() public {
+        (, uint256 wrongKey) = makeAddrAndKey("wrong");
+
+        PackedUserOperation memory userOp = _buildUserOp("");
+        userOp.signature = _signUserOp(userOp, wrongKey);
+        bytes32 userOpHash = this.getUserOpHash(userOp);
+
+        vm.prank(address(entryPoint));
+        uint256 validationData = account.validateUserOp(userOp, userOpHash, 0);
+        assertEq(validationData, 1); // SIG_VALIDATION_FAILED
+    }
+
+    function test_validateUserOp_onlyEntryPoint() public {
+        PackedUserOperation memory userOp = _buildUserOp("");
+        userOp.signature = _signUserOp(userOp, ownerKey);
+
+        vm.prank(stranger);
+        vm.expectRevert("account: not from EntryPoint");
+        account.validateUserOp(userOp, bytes32(0), 0);
+    }
+
+    // ──────────────────────── Execution tests ─────────────────────────
+
+    function test_execute_fromEntryPoint() public {
+        // Full ERC-4337 flow: handleOps → validateUserOp → execute → counter.increment
+        bytes memory callData = abi.encodeCall(
+            SmartAccount.execute,
+            (address(counter), 0, abi.encodeCall(Counter.increment, ()))
+        );
+        PackedUserOperation memory userOp = _buildUserOp(callData);
+        userOp.signature = _signUserOp(userOp, ownerKey);
+
+        PackedUserOperation[] memory ops = new PackedUserOperation[](1);
+        ops[0] = userOp;
+        entryPoint.handleOps(ops, beneficiary);
+
+        assertEq(counter.number(), 1);
+    }
+
+    function test_execute_fromOwner() public {
+        vm.prank(owner);
+        account.execute(address(counter), 0, abi.encodeCall(Counter.increment, ()));
+        assertEq(counter.number(), 1);
+    }
+
+    function test_execute_revertsFromStranger() public {
+        vm.prank(stranger);
+        vm.expectRevert(SmartAccount.OnlyOwnerOrEntryPoint.selector);
+        account.execute(address(counter), 0, abi.encodeCall(Counter.increment, ()));
+    }
+
+    function test_executeBatch_works() public {
+        address[] memory targets = new address[](2);
+        targets[0] = address(counter);
+        targets[1] = address(counter);
+
+        uint256[] memory values = new uint256[](2);
+
+        bytes[] memory calldatas = new bytes[](2);
+        calldatas[0] = abi.encodeCall(Counter.increment, ());
+        calldatas[1] = abi.encodeCall(Counter.increment, ());
+
+        vm.prank(owner);
+        account.executeBatch(targets, values, calldatas);
+        assertEq(counter.number(), 2);
+    }
+
+    function test_executeBatch_revertsOnLengthMismatch() public {
+        address[] memory targets = new address[](2);
+        uint256[] memory values = new uint256[](1); // mismatch
+        bytes[] memory calldatas = new bytes[](2);
+
+        vm.prank(owner);
+        vm.expectRevert("length mismatch");
+        account.executeBatch(targets, values, calldatas);
+    }
+
+    // ─────────────────────── Receive ETH test ─────────────────────────
+
+    function test_receiveEth() public {
+        uint256 balanceBefore = address(account).balance;
+
+        vm.deal(stranger, 1 ether);
+        vm.prank(stranger);
+        (bool success,) = address(account).call{value: 0.5 ether}("");
+
+        assertTrue(success);
+        assertEq(address(account).balance, balanceBefore + 0.5 ether);
+    }
+}

--- a/contracts/test/SmartAccount.t.sol
+++ b/contracts/test/SmartAccount.t.sol
@@ -136,6 +136,16 @@ contract SmartAccountTest is Test {
         assertEq(validationData, 1); // SIG_VALIDATION_FAILED
     }
 
+    function test_validateUserOp_malformedSignature() public {
+        PackedUserOperation memory userOp = _buildUserOp("");
+        userOp.signature = hex"dead"; // too short — not a valid 65-byte ECDSA sig
+        bytes32 userOpHash = this.getUserOpHash(userOp);
+
+        vm.prank(address(entryPoint));
+        uint256 validationData = account.validateUserOp(userOp, userOpHash, 0);
+        assertEq(validationData, 1); // SIG_VALIDATION_FAILED, no revert
+    }
+
     function test_validateUserOp_onlyEntryPoint() public {
         PackedUserOperation memory userOp = _buildUserOp("");
         userOp.signature = _signUserOp(userOp, ownerKey);


### PR DESCRIPTION
## What

Implement the core `SmartAccount` contract — ERC-4337 compliant smart account with ECDSA owner validation, `execute`/`executeBatch`, and proxy-compatible initialization. Includes a 14-test suite.

## Why

This is the foundation contract for the entire project. Everything else (session keys, factory, frontend flows) builds on top of it.

## Scope

- [x] Contracts
- [ ] Backend
- [ ] Frontend
- [ ] Tooling / CI
- [ ] Documentation
- [x] Test

## How to verify

```sh
cd contracts && forge test -vvv --match-contract SmartAccountTest
```

All 14 tests should pass: initialization (4), signature validation (4), execution (5), receive ETH (1).

## Related issues

Closes #1