### PR TITLE
docs: add initial README with architecture overview and setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Bastion
 
-ERC-4337 smart account system with session keys and an EVM event indexer,
+ERC-4337 smart account system with session key support and an EVM event indexer,
 sharing a single SvelteKit frontend.
 
 Built with Foundry (Solidity), Go (`net/http`), and SvelteKit 2
@@ -55,7 +55,7 @@ bastion/
 
 - [Foundry](https://getfoundry.sh/) (forge, cast, anvil)
 - [Node.js](https://nodejs.org/) v20+ and [pnpm](https://pnpm.io/) v9+
-- [Go](https://go.dev/) 1.22+
+- [Go](https://go.dev/) 1.25+
 - PostgreSQL 15+ (for the indexer — not yet implemented)
 
 ## Setup

--- a/README.md
+++ b/README.md
@@ -1,0 +1,110 @@
+# Bastion
+
+ERC-4337 smart account system with session keys and an EVM event indexer,
+sharing a single SvelteKit frontend.
+
+Built with Foundry (Solidity), Go (`net/http`), and SvelteKit 2
+(Svelte 5, viem, permissionless.js).
+
+## Architecture
+
+```
+┌──────────────┐     UserOps      ┌─────────────┐     handleOps     ┌────────────┐
+│   Frontend   │ ───────────────► │   Bundler   │ ────────────────► │ EntryPoint │
+│  (SvelteKit) │                  │  (Pimlico)  │                   │   (v0.7)   │
+└──────┬───────┘                  └─────────────┘                   └─────┬──────┘
+       │                                                                  │
+       │  REST / WebSocket                              validateUserOp + execute
+       │                                                                  │
+┌──────▼───────┐                                                  ┌───────▼──────┐
+│   Indexer    │   eth_getLogs / eth_subscribe                    │ SmartAccount │
+│    (Go)      │ ◄──────────────────────────────────────────────  │  (Solidity)  │
+└──────────────┘                                                  └──────────────┘
+```
+
+**Part 1 — Smart Contracts:** ERC-4337 compliant SmartAccount with ECDSA
+owner validation and session keys, deployed via CREATE2 factory. Demo
+contracts (Counter, FaucetToken) for interaction.
+
+**Part 2 — EVM Indexer:** Go backend indexing `UserOperationEvent` from
+EntryPoint v0.7. PostgreSQL persistence, REST API, WebSocket live feed.
+
+**Shared Frontend:** SvelteKit app for wallet connection, smart account
+deployment, owner/session key interactions, and indexer dashboard.
+
+## Directory Structure
+
+```
+bastion/
+├── contracts/          # Foundry — Solidity sources, tests, deploy scripts
+│   ├── src/            # Contract source files
+│   ├── test/           # Foundry tests (*.t.sol)
+│   ├── script/         # Deployment scripts
+│   └── lib/            # Git submodule deps (forge-std, OZ, account-abstraction, solady)
+├── indexer/            # Go module — EVM event indexer
+│   ├── cmd/indexer/    # Entry point (main.go)
+│   └── internal/       # Internal packages (api/, indexer/, db/)
+├── frontend/           # SvelteKit 2 — shared between both pillars
+│   └── src/lib/        # Utilities, stores, contract ABIs
+├── scripts/            # Build/tooling scripts (export-abis.sh)
+└── Makefile            # Orchestrates all three components
+```
+
+## Prerequisites
+
+- [Foundry](https://getfoundry.sh/) (forge, cast, anvil)
+- [Node.js](https://nodejs.org/) v20+ and [pnpm](https://pnpm.io/) v9+
+- [Go](https://go.dev/) 1.22+
+- PostgreSQL 15+ (for the indexer — not yet implemented)
+
+## Setup
+
+### Contracts
+
+```sh
+cd contracts
+forge build       # Compile
+forge test -vvv   # Run tests
+```
+
+### Frontend
+
+```sh
+cd frontend
+pnpm install
+pnpm dev          # Dev server on http://localhost:5173
+```
+
+### Indexer
+
+```sh
+cd indexer
+go build ./cmd/indexer
+go run ./cmd/indexer   # Starts on http://localhost:3001
+```
+
+### Makefile (all components)
+
+```sh
+make build    # Build contracts + frontend + indexer
+make test     # Run all test suites
+```
+
+## Contracts
+
+| Contract | Description | Status |
+|----------|-------------|--------|
+| `SmartAccount` | ERC-4337 account with ECDSA validation, `execute`/`executeBatch`, proxy-compatible | Implemented |
+| `SmartAccountFactory` | CREATE2 deployment of SmartAccount proxies | Not started |
+| `Counter` | Per-account counters — `increment()`, `getCount(address)` | Not started |
+| `FaucetToken` | ERC-20 with `claim()` faucet | Not started |
+
+**EntryPoint v0.7:** `0x0000000071727De22E5E9d8BAf0edAc6f37da032`
+
+<!-- ## Contract Addresses (Sepolia)
+
+Deployed addresses will be added after Issue #7. -->
+
+<!-- ## Demo Walkthrough
+
+Step-by-step demo guide will be added once the frontend is functional. -->

--- a/README.md
+++ b/README.md
@@ -23,14 +23,15 @@ Built with Foundry (Solidity), Go (`net/http`), and SvelteKit 2
 ```
 
 **Part 1 — Smart Contracts:** ERC-4337 compliant SmartAccount with ECDSA
-owner validation and session keys, deployed via CREATE2 factory. Demo
-contracts (Counter, FaucetToken) for interaction.
+owner validation and session key support, deployed via CREATE2 factory.
+Demo contracts (Counter, FaucetToken) for interaction.
 
-**Part 2 — EVM Indexer:** Go backend indexing `UserOperationEvent` from
-EntryPoint v0.7. PostgreSQL persistence, REST API, WebSocket live feed.
+**Part 2 — EVM Indexer:** Go backend that indexes `UserOperationEvent`
+from EntryPoint v0.7. PostgreSQL persistence, REST API, WebSocket live
+feed.
 
 **Shared Frontend:** SvelteKit app for wallet connection, smart account
-deployment, owner/session key interactions, and indexer dashboard.
+deployment, owner and session key interactions, and indexer dashboard.
 
 ## Directory Structure
 
@@ -94,9 +95,9 @@ make test     # Run all test suites
 
 | Contract | Description | Status |
 |----------|-------------|--------|
-| `SmartAccount` | ERC-4337 account with ECDSA validation, `execute`/`executeBatch`, proxy-compatible | Implemented |
+| `SmartAccount` | ERC-4337 account — ECDSA owner validation, `execute`/`executeBatch`, proxy-compatible | Implemented |
 | `SmartAccountFactory` | CREATE2 deployment of SmartAccount proxies | Not started |
-| `Counter` | Per-account counters — `increment()`, `getCount(address)` | Not started |
+| `Counter` | Scaffold — needs rewrite to per-account spec (`getCount(address)`) | Scaffold |
 | `FaucetToken` | ERC-20 with `claim()` faucet | Not started |
 
 **EntryPoint v0.7:** `0x0000000071727De22E5E9d8BAf0edAc6f37da032`

--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
 # Bastion
 
-ERC-4337 smart account system with session key support and an EVM event indexer,
-sharing a single SvelteKit frontend.
+ERC-4337 smart account system with session key support and an EVM event indexer, sharing a single SvelteKit frontend.
 
-Built with Foundry (Solidity), Go (`net/http`), and SvelteKit 2
-(Svelte 5, viem, permissionless.js).
+Built with Foundry (Solidity), Go (`net/http`), and SvelteKit 2 (Svelte 5, viem, permissionless.js).
 
 ## Architecture
 
@@ -22,16 +20,11 @@ Built with Foundry (Solidity), Go (`net/http`), and SvelteKit 2
 └──────────────┘                                                  └──────────────┘
 ```
 
-**Part 1 — Smart Contracts:** ERC-4337 compliant SmartAccount with ECDSA
-owner validation and session key support, deployed via CREATE2 factory.
-Demo contracts (Counter, FaucetToken) for interaction.
+**Part 1 — Smart Contracts:** ERC-4337 compliant SmartAccount with ECDSA owner validation and session key support, deployed via CREATE2 factory. Demo contracts (Counter, FaucetToken) for interaction.
 
-**Part 2 — EVM Indexer:** Go backend that indexes `UserOperationEvent`
-from EntryPoint v0.7. PostgreSQL persistence, REST API, WebSocket live
-feed.
+**Part 2 — EVM Indexer:** Go backend that indexes `UserOperationEvent` from EntryPoint v0.7, with PostgreSQL persistence, REST API, and WebSocket live feed.
 
-**Shared Frontend:** SvelteKit app for wallet connection, smart account
-deployment, owner and session key interactions, and indexer dashboard.
+**Shared Frontend:** SvelteKit app for wallet connection, smart account deployment, owner and session key interactions, and indexer dashboard.
 
 ## Directory Structure
 
@@ -56,7 +49,7 @@ bastion/
 - [Foundry](https://getfoundry.sh/) (forge, cast, anvil)
 - [Node.js](https://nodejs.org/) v20+ and [pnpm](https://pnpm.io/) v9+
 - [Go](https://go.dev/) 1.25+
-- PostgreSQL 15+ (for the indexer — not yet implemented)
+- [PostgreSQL](https://www.postgresql.org/) 15+
 
 ## Setup
 


### PR DESCRIPTION
## What

Add the initial README with project overview, architecture diagram, directory structure, prerequisites, setup instructions, and contract status table.

## Why

Exam requires a root README with full setup instructions for all three components. Building it incrementally — this v1 covers what exists today. Will be updated as features land.

## Scope

- [ ] Contracts
- [ ] Backend
- [ ] Frontend
- [ ] Tooling / CI
- [x] Documentation
- [ ] Test

## How to verify

Read the README. Verify the setup commands work:

```sh
cd contracts && forge build && forge test -vvv
cd frontend && pnpm install && pnpm build
cd indexer && go build ./cmd/indexer
```

## Related issues

Relates to #25 (will be closed when README is finalized in v0.4)