### PR TITLE
Session key system for SmartAccount

### DIFF
--- a/contracts/src/SmartAccount.sol
+++ b/contracts/src/SmartAccount.sol
@@ -133,7 +133,11 @@ contract SmartAccount is BaseAccount, Initializable {
 
     // ──────────────────── Session key management ───────────────────────
 
-    /// @notice Register a new session key. Only the owner can call this.
+    /// @notice Register a new session key. Callable by the owner directly or
+    ///         via the EntryPoint (owner-signed UserOp). Session keys cannot
+    ///         reach this function: _validateSessionKey requires the outer call
+    ///         to be execute(), and a self-call via execute has msg.sender =
+    ///         address(this), which fails the modifier.
     /// @param key             The session key address (will sign UserOps).
     /// @param allowedTarget   The contract this key may call.
     /// @param allowedSelector The function selector this key may invoke.
@@ -145,7 +149,7 @@ contract SmartAccount is BaseAccount, Initializable {
         bytes4 allowedSelector,
         uint48 validAfter,
         uint48 validUntil
-    ) external onlyOwner {
+    ) external onlyOwnerOrEntryPoint {
         if (
             key == address(0) ||
             allowedTarget == address(0) ||
@@ -169,9 +173,11 @@ contract SmartAccount is BaseAccount, Initializable {
         emit SessionKeyAdded(key, validUntil);
     }
 
-    /// @notice Revoke a session key. Only the owner can call this.
+    /// @notice Revoke a session key. Callable by the owner directly or via the
+    ///         EntryPoint (owner-signed UserOp). Same security rationale as
+    ///         registerSessionKey — session keys cannot reach this function.
     /// @param key The session key address to revoke.
-    function revokeSessionKey(address key) external onlyOwner {
+    function revokeSessionKey(address key) external onlyOwnerOrEntryPoint {
         if (sessionKeys[key].validUntil == 0) {
             revert SessionKeyNotRegistered(key);
         }

--- a/contracts/src/SmartAccount.sol
+++ b/contracts/src/SmartAccount.sol
@@ -4,15 +4,14 @@ pragma solidity ^0.8.28;
 import {BaseAccount} from "@account-abstraction/contracts/core/BaseAccount.sol";
 import {IEntryPoint} from "@account-abstraction/contracts/interfaces/IEntryPoint.sol";
 import {PackedUserOperation} from "@account-abstraction/contracts/interfaces/PackedUserOperation.sol";
-import {SIG_VALIDATION_FAILED, SIG_VALIDATION_SUCCESS} from "@account-abstraction/contracts/core/Helpers.sol";
+import {SIG_VALIDATION_FAILED, SIG_VALIDATION_SUCCESS, _packValidationData} from "@account-abstraction/contracts/core/Helpers.sol";
 import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 import {MessageHashUtils} from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
 import {Initializable} from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
 
 /// @title SmartAccount
-/// @notice ERC-4337 compliant smart account with ECDSA owner validation.
+/// @notice ERC-4337 compliant smart account with ECDSA owner validation and session keys.
 ///         Designed to be deployed as a proxy via SmartAccountFactory (CREATE2).
-///         Session key support will be added in a subsequent issue.
 contract SmartAccount is BaseAccount, Initializable {
     using ECDSA for bytes32;
     using MessageHashUtils for bytes32;
@@ -26,15 +25,38 @@ contract SmartAccount is BaseAccount, Initializable {
     ///         and shared across all proxies (lives in the implementation, not storage).
     IEntryPoint private immutable _ENTRY_POINT;
 
+    /// @notice Configuration for a session key — scoped, time-bounded execution rights.
+    struct SessionKeyData {
+        address allowedTarget;
+        bytes4 allowedSelector;
+        uint48 validAfter;
+        uint48 validUntil;
+    }
+
+    /// @notice Registered session keys. A key with `validUntil == 0` is not registered.
+    mapping(address => SessionKeyData) public sessionKeys;
+
     // ───────────────────────────── Events ──────────────────────────────
 
-    event SmartAccountInitialized(IEntryPoint indexed entryPoint, address indexed owner);
+    event SmartAccountInitialized(
+        IEntryPoint indexed entryPoint,
+        address indexed owner
+    );
+
+    /// @notice Emitted when the owner registers a new session key (exam spec name).
+    event SessionKeyAdded(address indexed key, uint256 expiry);
+
+    /// @notice Emitted when the owner revokes a session key (exam spec name).
+    event SessionKeyRevoked(address indexed key);
 
     // ───────────────────────────── Errors ──────────────────────────────
 
     error OnlyOwnerOrEntryPoint();
     error OnlyOwner();
     error CallFailed(bytes returnData);
+    error SessionKeyAlreadyRegistered(address key);
+    error SessionKeyNotRegistered(address key);
+    error InvalidSessionKeyParams();
 
     // ───────────────────────────── Modifiers ───────────────────────────
 
@@ -44,7 +66,6 @@ contract SmartAccount is BaseAccount, Initializable {
         _;
     }
 
-    /// @notice Restricts to the owner only.
     modifier onlyOwner() {
         _checkOwner();
         _;
@@ -78,15 +99,17 @@ contract SmartAccount is BaseAccount, Initializable {
         return _ENTRY_POINT;
     }
 
-    /// @notice Validates the UserOperation signature.
-    ///         Recovers the signer from the signature and checks it matches the owner.
+    /// @notice Validates the UserOperation signature against the owner or a session key.
     ///
-    ///         The flow (called by BaseAccount.validateUserOp):
-    ///         1. `userOpHash` is the hash of the UserOp (already includes entryPoint + chainId).
-    ///         2. We convert it to an Ethereum Signed Message hash (prepend "\x19Ethereum Signed Message:\n32").
-    ///         3. ECDSA.tryRecover extracts the signer — returns an error instead of reverting
-    ///            on malformed signatures (wrong length, invalid s, etc.).
-    ///         4. If any error OR signer != owner → return 1 (SIG_VALIDATION_FAILED, no revert).
+    ///         Flow:
+    ///         1. Recover the signer from the signature (tryRecover — never reverts).
+    ///         2. If signer == owner → return success (owner can do anything).
+    ///         3. If signer is a registered session key → parse userOp.callData to enforce
+    ///            target + selector restrictions, return packed validationData with time bounds.
+    ///         4. Otherwise → return SIG_VALIDATION_FAILED.
+    ///
+    ///         Session key enforcement happens here (not in execute) because userOp.callData
+    ///         is signed — it cannot be tampered with between validation and execution.
     ///
     /// @inheritdoc BaseAccount
     function _validateSignature(
@@ -95,15 +118,60 @@ contract SmartAccount is BaseAccount, Initializable {
     ) internal view override returns (uint256 validationData) {
         bytes32 ethSignedHash = userOpHash.toEthSignedMessageHash();
 
-        // tryRecover returns (address, RecoverError, bytes32) — never reverts.
-        // recover would revert on malformed sigs, violating the ERC-4337 spec:
-        // validateUserOp must return SIG_VALIDATION_FAILED on bad sigs, not revert.
-        (address recovered, ECDSA.RecoverError err,) = ethSignedHash.tryRecover(userOp.signature);
-
-        if (err != ECDSA.RecoverError.NoError || recovered != owner) {
+        (address recovered, ECDSA.RecoverError err, ) = ethSignedHash
+            .tryRecover(userOp.signature);
+        if (err != ECDSA.RecoverError.NoError) {
             return SIG_VALIDATION_FAILED;
         }
-        return SIG_VALIDATION_SUCCESS;
+
+        if (recovered == owner) {
+            return SIG_VALIDATION_SUCCESS;
+        }
+
+        return _validateSessionKey(recovered, userOp.callData);
+    }
+
+    // ──────────────────── Session key management ───────────────────────
+
+    /// @notice Register a new session key. Only the owner can call this.
+    /// @param key             The session key address (will sign UserOps).
+    /// @param allowedTarget   The contract this key may call.
+    /// @param allowedSelector The function selector this key may invoke.
+    /// @param validAfter      Timestamp after which the key is active.
+    /// @param validUntil      Timestamp after which the key expires. Must be > 0.
+    function registerSessionKey(
+        address key,
+        address allowedTarget,
+        bytes4 allowedSelector,
+        uint48 validAfter,
+        uint48 validUntil
+    ) external onlyOwner {
+        if (key == address(0) || validUntil == 0 || validUntil <= validAfter) {
+            revert InvalidSessionKeyParams();
+        }
+        if (sessionKeys[key].validUntil != 0) {
+            revert SessionKeyAlreadyRegistered(key);
+        }
+
+        sessionKeys[key] = SessionKeyData({
+            allowedTarget: allowedTarget,
+            allowedSelector: allowedSelector,
+            validAfter: validAfter,
+            validUntil: validUntil
+        });
+
+        emit SessionKeyAdded(key, validUntil);
+    }
+
+    /// @notice Revoke a session key. Only the owner can call this.
+    /// @param key The session key address to revoke.
+    function revokeSessionKey(address key) external onlyOwner {
+        if (sessionKeys[key].validUntil == 0) {
+            revert SessionKeyNotRegistered(key);
+        }
+
+        delete sessionKeys[key];
+        emit SessionKeyRevoked(key);
     }
 
     // ──────────────────────────── Execution ────────────────────────────
@@ -114,8 +182,14 @@ contract SmartAccount is BaseAccount, Initializable {
     /// @param target  The contract (or EOA) to call.
     /// @param value   The ETH value to send.
     /// @param data    The calldata (function selector + arguments).
-    function execute(address target, uint256 value, bytes calldata data) external onlyOwnerOrEntryPoint {
-        (bool success, bytes memory returnData) = target.call{value: value}(data);
+    function execute(
+        address target,
+        uint256 value,
+        bytes calldata data
+    ) external onlyOwnerOrEntryPoint {
+        (bool success, bytes memory returnData) = target.call{value: value}(
+            data
+        );
         if (!success) {
             revert CallFailed(returnData);
         }
@@ -131,9 +205,15 @@ contract SmartAccount is BaseAccount, Initializable {
         uint256[] calldata values,
         bytes[] calldata calldatas
     ) external onlyOwnerOrEntryPoint {
-        require(targets.length == values.length && values.length == calldatas.length, "length mismatch");
+        require(
+            targets.length == values.length &&
+                values.length == calldatas.length,
+            "length mismatch"
+        );
         for (uint256 i = 0; i < targets.length; i++) {
-            (bool success, bytes memory returnData) = targets[i].call{value: values[i]}(calldatas[i]);
+            (bool success, bytes memory returnData) = targets[i].call{
+                value: values[i]
+            }(calldatas[i]);
             if (!success) {
                 revert CallFailed(returnData);
             }
@@ -147,6 +227,61 @@ contract SmartAccount is BaseAccount, Initializable {
     receive() external payable {}
 
     // ──────────────────────── Internal helpers ─────────────────────────
+
+    /// @notice Validates a session key's permissions by parsing userOp.callData.
+    ///
+    ///         callData layout for execute(address,uint256,bytes):
+    ///         [0:4]   — execute selector (0xb61d27f6)
+    ///         [4:36]  — target address (left-padded to 32 bytes)
+    ///         [36:68] — value (uint256)
+    ///         [68:100] — offset to bytes data
+    ///         [100:132] — length of bytes data
+    ///         [132:136] — inner function selector (first 4 bytes of data)
+    ///
+    /// @param signer  The recovered session key address.
+    /// @param callData The full userOp.callData.
+    /// @return validationData Packed (sigFailed, validUntil, validAfter) or SIG_VALIDATION_FAILED.
+    function _validateSessionKey(
+        address signer,
+        bytes calldata callData
+    ) internal view returns (uint256) {
+        SessionKeyData storage sk = sessionKeys[signer];
+
+        if (sk.validUntil == 0) {
+            return SIG_VALIDATION_FAILED;
+        }
+
+        // Session keys can only call execute — not executeBatch or anything else
+        if (
+            callData.length < 4 || bytes4(callData[:4]) != this.execute.selector
+        ) {
+            return SIG_VALIDATION_FAILED;
+        }
+
+        if (callData.length < 100) {
+            return SIG_VALIDATION_FAILED;
+        }
+
+        address target = address(bytes20(callData[16:36]));
+
+        if (target != sk.allowedTarget) {
+            return SIG_VALIDATION_FAILED;
+        }
+
+        if (callData.length >= 136) {
+            bytes4 innerSelector = bytes4(callData[132:136]);
+            if (innerSelector != sk.allowedSelector) {
+                return SIG_VALIDATION_FAILED;
+            }
+        } else {
+            // No inner calldata (empty data) — fail if a selector restriction is set
+            if (sk.allowedSelector != bytes4(0)) {
+                return SIG_VALIDATION_FAILED;
+            }
+        }
+
+        return _packValidationData(false, sk.validUntil, sk.validAfter);
+    }
 
     function _checkOwnerOrEntryPoint() internal view {
         if (msg.sender != address(entryPoint()) && msg.sender != owner) {

--- a/contracts/src/SmartAccount.sol
+++ b/contracts/src/SmartAccount.sol
@@ -146,7 +146,13 @@ contract SmartAccount is BaseAccount, Initializable {
         uint48 validAfter,
         uint48 validUntil
     ) external onlyOwner {
-        if (key == address(0) || validUntil == 0 || validUntil <= validAfter) {
+        if (
+            key == address(0) ||
+            allowedTarget == address(0) ||
+            allowedSelector == bytes4(0) ||
+            validUntil == 0 ||
+            validUntil <= validAfter
+        ) {
             revert InvalidSessionKeyParams();
         }
         if (sessionKeys[key].validUntil != 0) {
@@ -231,12 +237,18 @@ contract SmartAccount is BaseAccount, Initializable {
     /// @notice Validates a session key's permissions by parsing userOp.callData.
     ///
     ///         callData layout for execute(address,uint256,bytes):
-    ///         [0:4]   — execute selector (0xb61d27f6)
-    ///         [4:36]  — target address (left-padded to 32 bytes)
-    ///         [36:68] — value (uint256)
-    ///         [68:100] — offset to bytes data
+    ///         [0:4]     — execute selector (0xb61d27f6)
+    ///         [4:36]    — target address (left-padded to 32 bytes)
+    ///         [36:68]   — value (uint256)
+    ///         [68:100]  — offset to bytes data (must be 0x60 for canonical encoding)
     ///         [100:132] — length of bytes data
     ///         [132:136] — inner function selector (first 4 bytes of data)
+    ///
+    ///         Security invariants:
+    ///         - Offset must equal 0x60 (canonical ABI encoding). Non-canonical offsets
+    ///           would let an attacker place the allowed selector where we check while
+    ///           encoding a different selector where Solidity actually decodes.
+    ///         - Value must be 0. Session keys cannot transfer ETH.
     ///
     /// @param signer  The recovered session key address.
     /// @param callData The full userOp.callData.
@@ -251,14 +263,12 @@ contract SmartAccount is BaseAccount, Initializable {
             return SIG_VALIDATION_FAILED;
         }
 
-        // Session keys can only call execute — not executeBatch or anything else
+        // Session keys can only call execute — not executeBatch or anything else.
+        // Minimum length: 4 (selector) + 3×32 (head) = 100 bytes.
         if (
-            callData.length < 4 || bytes4(callData[:4]) != this.execute.selector
+            callData.length < 100 ||
+            bytes4(callData[:4]) != this.execute.selector
         ) {
-            return SIG_VALIDATION_FAILED;
-        }
-
-        if (callData.length < 100) {
             return SIG_VALIDATION_FAILED;
         }
 
@@ -268,16 +278,28 @@ contract SmartAccount is BaseAccount, Initializable {
             return SIG_VALIDATION_FAILED;
         }
 
+        // Session keys cannot transfer ETH — enforce value == 0.
+        if (uint256(bytes32(callData[36:68])) != 0) {
+            return SIG_VALIDATION_FAILED;
+        }
+
+        // Reject non-canonical ABI encoding. The dynamic `bytes` offset must be
+        // exactly 0x60 (96) for execute(address,uint256,bytes) — three 32-byte
+        // head slots. A different offset would let an attacker place the allowed
+        // selector at [132:136] while Solidity decodes from a different position.
+        if (uint256(bytes32(callData[68:100])) != 0x60) {
+            return SIG_VALIDATION_FAILED;
+        }
+
         if (callData.length >= 136) {
             bytes4 innerSelector = bytes4(callData[132:136]);
             if (innerSelector != sk.allowedSelector) {
                 return SIG_VALIDATION_FAILED;
             }
         } else {
-            // No inner calldata (empty data) — fail if a selector restriction is set
-            if (sk.allowedSelector != bytes4(0)) {
-                return SIG_VALIDATION_FAILED;
-            }
+            // No inner calldata (empty data) — always fail since session keys
+            // must target a specific selector (zero selectors rejected at registration).
+            return SIG_VALIDATION_FAILED;
         }
 
         return _packValidationData(false, sk.validUntil, sk.validAfter);

--- a/contracts/src/SmartAccount.sol
+++ b/contracts/src/SmartAccount.sol
@@ -249,6 +249,9 @@ contract SmartAccount is BaseAccount, Initializable {
     ///           would let an attacker place the allowed selector where we check while
     ///           encoding a different selector where Solidity actually decodes.
     ///         - Value must be 0. Session keys cannot transfer ETH.
+    ///         - data.length (at [100:132]) must be >= 4 and callData must be long enough
+    ///           to contain it. Otherwise an attacker could set length to 0, append trailing
+    ///           bytes with the allowed selector, and have execute forward empty calldata.
     ///
     /// @param signer  The recovered session key address.
     /// @param callData The full userOp.callData.
@@ -291,14 +294,18 @@ contract SmartAccount is BaseAccount, Initializable {
             return SIG_VALIDATION_FAILED;
         }
 
-        if (callData.length >= 136) {
-            bytes4 innerSelector = bytes4(callData[132:136]);
-            if (innerSelector != sk.allowedSelector) {
-                return SIG_VALIDATION_FAILED;
-            }
-        } else {
-            // No inner calldata (empty data) — always fail since session keys
-            // must target a specific selector (zero selectors rejected at registration).
+        // Validate the ABI-encoded data length. Without this check, an attacker
+        // could set data.length to 0 while appending trailing bytes past position 132.
+        // Our selector check would read the trailing bytes and pass, but Solidity's
+        // abi.decode would see length 0 and forward empty calldata to the target
+        // (hitting its fallback/receive instead of the allowed function).
+        uint256 dataLen = uint256(bytes32(callData[100:132]));
+        if (dataLen < 4 || callData.length < 132 + dataLen) {
+            return SIG_VALIDATION_FAILED;
+        }
+
+        bytes4 innerSelector = bytes4(callData[132:136]);
+        if (innerSelector != sk.allowedSelector) {
             return SIG_VALIDATION_FAILED;
         }
 

--- a/contracts/src/SmartAccount.sol
+++ b/contracts/src/SmartAccount.sol
@@ -267,9 +267,11 @@ contract SmartAccount is BaseAccount, Initializable {
         }
 
         // Session keys can only call execute — not executeBatch or anything else.
-        // Minimum length: 4 (selector) + 3×32 (head) = 100 bytes.
+        // Minimum length: 4 (selector) + 3×32 (head) + 32 (data length) + 4 (inner selector) = 136.
+        // Anything shorter would cause out-of-bounds reads below, reverting instead of
+        // returning SIG_VALIDATION_FAILED (which violates the ERC-4337 spec).
         if (
-            callData.length < 100 ||
+            callData.length < 136 ||
             bytes4(callData[:4]) != this.execute.selector
         ) {
             return SIG_VALIDATION_FAILED;
@@ -299,8 +301,11 @@ contract SmartAccount is BaseAccount, Initializable {
         // Our selector check would read the trailing bytes and pass, but Solidity's
         // abi.decode would see length 0 and forward empty calldata to the target
         // (hitting its fallback/receive instead of the allowed function).
+        // Use (callData.length - 132) instead of (132 + dataLen) to avoid overflow
+        // if dataLen is a huge value (e.g. type(uint256).max). The subtraction is
+        // safe because callData.length >= 136 is guaranteed by the check above.
         uint256 dataLen = uint256(bytes32(callData[100:132]));
-        if (dataLen < 4 || callData.length < 132 + dataLen) {
+        if (dataLen < 4 || dataLen > callData.length - 132) {
             return SIG_VALIDATION_FAILED;
         }
 

--- a/contracts/test/SmartAccount.t.sol
+++ b/contracts/test/SmartAccount.t.sol
@@ -673,6 +673,71 @@ contract SmartAccountTest is Test {
         assertEq(validationData, 1); // SIG_VALIDATION_FAILED
     }
 
+    function test_validateUserOp_sessionKey_truncatedCallData() public {
+        (address sessionKey, uint256 sessionPrivKey) = makeAddrAndKey("sessionKey");
+
+        vm.prank(owner);
+        account.registerSessionKey(
+            sessionKey,
+            address(counter),
+            Counter.increment.selector,
+            uint48(100),
+            uint48(5000)
+        );
+
+        // Craft calldata that is 100 bytes — long enough to pass a naive >= 100
+        // check but too short for the [100:132] slice. Must return
+        // SIG_VALIDATION_FAILED, not revert.
+        bytes memory truncated = abi.encodePacked(
+            SmartAccount.execute.selector,               // [0:4]   outer selector
+            bytes32(uint256(uint160(address(counter)))),  // [4:36]  target
+            bytes32(uint256(0)),                          // [36:68] value
+            bytes32(uint256(0x60))                        // [68:100] canonical offset
+            // nothing beyond 100 — triggers OOB without the length fix
+        );
+
+        PackedUserOperation memory userOp = _buildUserOp(truncated);
+        userOp.signature = _signUserOp(userOp, sessionPrivKey);
+        bytes32 userOpHash = this.getUserOpHash(userOp);
+
+        vm.prank(address(entryPoint));
+        uint256 validationData = account.validateUserOp(userOp, userOpHash, 0);
+        assertEq(validationData, 1); // SIG_VALIDATION_FAILED, no revert
+    }
+
+    function test_validateUserOp_sessionKey_hugeDataLen() public {
+        (address sessionKey, uint256 sessionPrivKey) = makeAddrAndKey("sessionKey");
+
+        vm.prank(owner);
+        account.registerSessionKey(
+            sessionKey,
+            address(counter),
+            Counter.increment.selector,
+            uint48(100),
+            uint48(5000)
+        );
+
+        // Craft calldata with a huge data.length that would overflow 132 + dataLen.
+        // Must return SIG_VALIDATION_FAILED, not revert with arithmetic overflow.
+        bytes memory malicious = abi.encodePacked(
+            SmartAccount.execute.selector,               // [0:4]   outer selector
+            bytes32(uint256(uint160(address(counter)))),  // [4:36]  target
+            bytes32(uint256(0)),                          // [36:68] value
+            bytes32(uint256(0x60)),                       // [68:100] canonical offset
+            bytes32(type(uint256).max),                   // [100:132] huge dataLen
+            Counter.increment.selector,                   // [132:136] inner selector
+            bytes28(0)                                    // [136:164] padding
+        );
+
+        PackedUserOperation memory userOp = _buildUserOp(malicious);
+        userOp.signature = _signUserOp(userOp, sessionPrivKey);
+        bytes32 userOpHash = this.getUserOpHash(userOp);
+
+        vm.prank(address(entryPoint));
+        uint256 validationData = account.validateUserOp(userOp, userOpHash, 0);
+        assertEq(validationData, 1); // SIG_VALIDATION_FAILED, no revert
+    }
+
     // ──────────── Session key full EntryPoint flow test ───────────────
 
     function test_execute_sessionKey_fullFlow() public {

--- a/contracts/test/SmartAccount.t.sol
+++ b/contracts/test/SmartAccount.t.sol
@@ -356,7 +356,7 @@ contract SmartAccountTest is Test {
         (address sessionKey,) = makeAddrAndKey("sessionKey");
 
         vm.prank(stranger);
-        vm.expectRevert(SmartAccount.OnlyOwner.selector);
+        vm.expectRevert(SmartAccount.OnlyOwnerOrEntryPoint.selector);
         account.registerSessionKey(
             sessionKey,
             address(counter),
@@ -364,6 +364,24 @@ contract SmartAccountTest is Test {
             uint48(1000),
             uint48(2000)
         );
+    }
+
+    function test_registerSessionKey_viaEntryPoint() public {
+        (address sessionKey,) = makeAddrAndKey("sessionKey");
+
+        bytes memory callData = abi.encodeCall(
+            SmartAccount.registerSessionKey,
+            (sessionKey, address(counter), Counter.increment.selector, uint48(1000), uint48(2000))
+        );
+        PackedUserOperation memory userOp = _buildUserOp(callData);
+        userOp.signature = _signUserOp(userOp, ownerKey);
+
+        PackedUserOperation[] memory ops = new PackedUserOperation[](1);
+        ops[0] = userOp;
+        entryPoint.handleOps(ops, beneficiary);
+
+        (, , , uint48 validUntil) = account.sessionKeys(sessionKey);
+        assertEq(validUntil, 2000);
     }
 
     // ─────────────────── Session key revocation tests ─────────────────
@@ -425,8 +443,35 @@ contract SmartAccountTest is Test {
         );
 
         vm.prank(stranger);
-        vm.expectRevert(SmartAccount.OnlyOwner.selector);
+        vm.expectRevert(SmartAccount.OnlyOwnerOrEntryPoint.selector);
         account.revokeSessionKey(sessionKey);
+    }
+
+    function test_revokeSessionKey_viaEntryPoint() public {
+        (address sessionKey,) = makeAddrAndKey("sessionKey");
+
+        vm.prank(owner);
+        account.registerSessionKey(
+            sessionKey,
+            address(counter),
+            Counter.increment.selector,
+            uint48(1000),
+            uint48(2000)
+        );
+
+        bytes memory callData = abi.encodeCall(
+            SmartAccount.revokeSessionKey,
+            (sessionKey)
+        );
+        PackedUserOperation memory userOp = _buildUserOp(callData);
+        userOp.signature = _signUserOp(userOp, ownerKey);
+
+        PackedUserOperation[] memory ops = new PackedUserOperation[](1);
+        ops[0] = userOp;
+        entryPoint.handleOps(ops, beneficiary);
+
+        (, , , uint48 validUntil) = account.sessionKeys(sessionKey);
+        assertEq(validUntil, 0);
     }
 
     // ──────────────── Session key validation tests (unit) ─────────────

--- a/contracts/test/SmartAccount.t.sol
+++ b/contracts/test/SmartAccount.t.sol
@@ -223,4 +223,357 @@ contract SmartAccountTest is Test {
         assertTrue(success);
         assertEq(address(account).balance, balanceBefore + 0.5 ether);
     }
+
+    // ───────────────── Session key registration tests ─────────────────
+
+    function test_registerSessionKey_emitsEvent() public {
+        (address sessionKey,) = makeAddrAndKey("sessionKey");
+
+        vm.expectEmit(true, false, false, true);
+        emit SmartAccount.SessionKeyAdded(sessionKey, 2000);
+
+        vm.prank(owner);
+        account.registerSessionKey(
+            sessionKey,
+            address(counter),
+            Counter.increment.selector,
+            uint48(1000),
+            uint48(2000)
+        );
+    }
+
+    function test_registerSessionKey_storesData() public {
+        (address sessionKey,) = makeAddrAndKey("sessionKey");
+
+        vm.prank(owner);
+        account.registerSessionKey(
+            sessionKey,
+            address(counter),
+            Counter.increment.selector,
+            uint48(1000),
+            uint48(2000)
+        );
+
+        (address target, bytes4 selector, uint48 validAfter, uint48 validUntil) = account.sessionKeys(sessionKey);
+        assertEq(target, address(counter));
+        assertEq(selector, Counter.increment.selector);
+        assertEq(validAfter, 1000);
+        assertEq(validUntil, 2000);
+    }
+
+    function test_registerSessionKey_revertsZeroAddress() public {
+        vm.prank(owner);
+        vm.expectRevert(SmartAccount.InvalidSessionKeyParams.selector);
+        account.registerSessionKey(
+            address(0),
+            address(counter),
+            Counter.increment.selector,
+            uint48(1000),
+            uint48(2000)
+        );
+    }
+
+    function test_registerSessionKey_revertsZeroValidUntil() public {
+        (address sessionKey,) = makeAddrAndKey("sessionKey");
+
+        vm.prank(owner);
+        vm.expectRevert(SmartAccount.InvalidSessionKeyParams.selector);
+        account.registerSessionKey(
+            sessionKey,
+            address(counter),
+            Counter.increment.selector,
+            uint48(1000),
+            uint48(0)
+        );
+    }
+
+    function test_registerSessionKey_revertsValidUntilLteValidAfter() public {
+        (address sessionKey,) = makeAddrAndKey("sessionKey");
+
+        vm.prank(owner);
+        vm.expectRevert(SmartAccount.InvalidSessionKeyParams.selector);
+        account.registerSessionKey(
+            sessionKey,
+            address(counter),
+            Counter.increment.selector,
+            uint48(2000),
+            uint48(2000) // equal — should fail
+        );
+    }
+
+    function test_registerSessionKey_revertsDuplicate() public {
+        (address sessionKey,) = makeAddrAndKey("sessionKey");
+
+        vm.prank(owner);
+        account.registerSessionKey(
+            sessionKey,
+            address(counter),
+            Counter.increment.selector,
+            uint48(1000),
+            uint48(2000)
+        );
+
+        vm.prank(owner);
+        vm.expectRevert(abi.encodeWithSelector(SmartAccount.SessionKeyAlreadyRegistered.selector, sessionKey));
+        account.registerSessionKey(
+            sessionKey,
+            address(counter),
+            Counter.increment.selector,
+            uint48(1000),
+            uint48(2000)
+        );
+    }
+
+    function test_registerSessionKey_revertsFromStranger() public {
+        (address sessionKey,) = makeAddrAndKey("sessionKey");
+
+        vm.prank(stranger);
+        vm.expectRevert(SmartAccount.OnlyOwner.selector);
+        account.registerSessionKey(
+            sessionKey,
+            address(counter),
+            Counter.increment.selector,
+            uint48(1000),
+            uint48(2000)
+        );
+    }
+
+    // ─────────────────── Session key revocation tests ─────────────────
+
+    function test_revokeSessionKey_emitsEvent() public {
+        (address sessionKey,) = makeAddrAndKey("sessionKey");
+
+        vm.prank(owner);
+        account.registerSessionKey(
+            sessionKey,
+            address(counter),
+            Counter.increment.selector,
+            uint48(1000),
+            uint48(2000)
+        );
+
+        vm.expectEmit(true, false, false, false);
+        emit SmartAccount.SessionKeyRevoked(sessionKey);
+
+        vm.prank(owner);
+        account.revokeSessionKey(sessionKey);
+    }
+
+    function test_revokeSessionKey_deletesData() public {
+        (address sessionKey,) = makeAddrAndKey("sessionKey");
+
+        vm.prank(owner);
+        account.registerSessionKey(
+            sessionKey,
+            address(counter),
+            Counter.increment.selector,
+            uint48(1000),
+            uint48(2000)
+        );
+
+        vm.prank(owner);
+        account.revokeSessionKey(sessionKey);
+
+        (, , , uint48 validUntil) = account.sessionKeys(sessionKey);
+        assertEq(validUntil, 0);
+    }
+
+    function test_revokeSessionKey_revertsIfNotRegistered() public {
+        vm.prank(owner);
+        vm.expectRevert(abi.encodeWithSelector(SmartAccount.SessionKeyNotRegistered.selector, stranger));
+        account.revokeSessionKey(stranger);
+    }
+
+    function test_revokeSessionKey_revertsFromStranger() public {
+        (address sessionKey,) = makeAddrAndKey("sessionKey");
+
+        vm.prank(owner);
+        account.registerSessionKey(
+            sessionKey,
+            address(counter),
+            Counter.increment.selector,
+            uint48(1000),
+            uint48(2000)
+        );
+
+        vm.prank(stranger);
+        vm.expectRevert(SmartAccount.OnlyOwner.selector);
+        account.revokeSessionKey(sessionKey);
+    }
+
+    // ──────────────── Session key validation tests (unit) ─────────────
+
+    function test_validateUserOp_sessionKey_validOp() public {
+        (address sessionKey, uint256 sessionPrivKey) = makeAddrAndKey("sessionKey");
+
+        vm.prank(owner);
+        account.registerSessionKey(
+            sessionKey,
+            address(counter),
+            Counter.increment.selector,
+            uint48(100),
+            uint48(5000)
+        );
+
+        bytes memory callData = abi.encodeCall(
+            SmartAccount.execute,
+            (address(counter), 0, abi.encodeCall(Counter.increment, ()))
+        );
+        PackedUserOperation memory userOp = _buildUserOp(callData);
+        userOp.signature = _signUserOp(userOp, sessionPrivKey);
+        bytes32 userOpHash = this.getUserOpHash(userOp);
+
+        vm.prank(address(entryPoint));
+        uint256 validationData = account.validateUserOp(userOp, userOpHash, 0);
+
+        assertNotEq(validationData, 0);
+        assertNotEq(validationData, 1);
+
+        // Decode: lowest 160 bits = aggregator (0), next 48 bits = validUntil, next 48 bits = validAfter
+        uint48 validUntil = uint48(validationData >> 160);
+        uint48 validAfter = uint48(validationData >> 208);
+        assertEq(validUntil, 5000);
+        assertEq(validAfter, 100);
+    }
+
+    function test_validateUserOp_sessionKey_wrongTarget() public {
+        (address sessionKey, uint256 sessionPrivKey) = makeAddrAndKey("sessionKey");
+        address wrongTarget = makeAddr("wrongTarget");
+
+        vm.prank(owner);
+        account.registerSessionKey(
+            sessionKey,
+            address(counter),
+            Counter.increment.selector,
+            uint48(100),
+            uint48(5000)
+        );
+
+        bytes memory callData = abi.encodeCall(
+            SmartAccount.execute,
+            (wrongTarget, 0, abi.encodeCall(Counter.increment, ()))
+        );
+        PackedUserOperation memory userOp = _buildUserOp(callData);
+        userOp.signature = _signUserOp(userOp, sessionPrivKey);
+        bytes32 userOpHash = this.getUserOpHash(userOp);
+
+        vm.prank(address(entryPoint));
+        uint256 validationData = account.validateUserOp(userOp, userOpHash, 0);
+        assertEq(validationData, 1); // SIG_VALIDATION_FAILED
+    }
+
+    function test_validateUserOp_sessionKey_wrongSelector() public {
+        (address sessionKey, uint256 sessionPrivKey) = makeAddrAndKey("sessionKey");
+
+        vm.prank(owner);
+        account.registerSessionKey(
+            sessionKey,
+            address(counter),
+            Counter.increment.selector, // only increment allowed
+            uint48(100),
+            uint48(5000)
+        );
+
+        bytes memory callData = abi.encodeCall(
+            SmartAccount.execute,
+            (address(counter), 0, abi.encodeCall(Counter.setNumber, (42)))
+        );
+        PackedUserOperation memory userOp = _buildUserOp(callData);
+        userOp.signature = _signUserOp(userOp, sessionPrivKey);
+        bytes32 userOpHash = this.getUserOpHash(userOp);
+
+        vm.prank(address(entryPoint));
+        uint256 validationData = account.validateUserOp(userOp, userOpHash, 0);
+        assertEq(validationData, 1); // SIG_VALIDATION_FAILED
+    }
+
+    function test_validateUserOp_sessionKey_executeBatchRejected() public {
+        (address sessionKey, uint256 sessionPrivKey) = makeAddrAndKey("sessionKey");
+
+        vm.prank(owner);
+        account.registerSessionKey(
+            sessionKey,
+            address(counter),
+            Counter.increment.selector,
+            uint48(100),
+            uint48(5000)
+        );
+
+        address[] memory targets = new address[](1);
+        targets[0] = address(counter);
+        uint256[] memory values = new uint256[](1);
+        bytes[] memory calldatas = new bytes[](1);
+        calldatas[0] = abi.encodeCall(Counter.increment, ());
+
+        bytes memory callData = abi.encodeCall(
+            SmartAccount.executeBatch,
+            (targets, values, calldatas)
+        );
+        PackedUserOperation memory userOp = _buildUserOp(callData);
+        userOp.signature = _signUserOp(userOp, sessionPrivKey);
+        bytes32 userOpHash = this.getUserOpHash(userOp);
+
+        vm.prank(address(entryPoint));
+        uint256 validationData = account.validateUserOp(userOp, userOpHash, 0);
+        assertEq(validationData, 1); // SIG_VALIDATION_FAILED
+    }
+
+    function test_validateUserOp_sessionKey_revokedKeyFails() public {
+        (address sessionKey, uint256 sessionPrivKey) = makeAddrAndKey("sessionKey");
+
+        vm.prank(owner);
+        account.registerSessionKey(
+            sessionKey,
+            address(counter),
+            Counter.increment.selector,
+            uint48(100),
+            uint48(5000)
+        );
+
+        vm.prank(owner);
+        account.revokeSessionKey(sessionKey);
+
+        bytes memory callData = abi.encodeCall(
+            SmartAccount.execute,
+            (address(counter), 0, abi.encodeCall(Counter.increment, ()))
+        );
+        PackedUserOperation memory userOp = _buildUserOp(callData);
+        userOp.signature = _signUserOp(userOp, sessionPrivKey);
+        bytes32 userOpHash = this.getUserOpHash(userOp);
+
+        vm.prank(address(entryPoint));
+        uint256 validationData = account.validateUserOp(userOp, userOpHash, 0);
+        assertEq(validationData, 1); // SIG_VALIDATION_FAILED
+    }
+
+    // ──────────── Session key full EntryPoint flow test ───────────────
+
+    function test_execute_sessionKey_fullFlow() public {
+        (address sessionKey, uint256 sessionPrivKey) = makeAddrAndKey("sessionKey");
+
+        uint48 validAfter = uint48(block.timestamp);
+        uint48 validUntil = uint48(block.timestamp + 1 hours);
+
+        vm.prank(owner);
+        account.registerSessionKey(
+            sessionKey,
+            address(counter),
+            Counter.increment.selector,
+            validAfter,
+            validUntil
+        );
+
+        bytes memory callData = abi.encodeCall(
+            SmartAccount.execute,
+            (address(counter), 0, abi.encodeCall(Counter.increment, ()))
+        );
+        PackedUserOperation memory userOp = _buildUserOp(callData);
+        userOp.signature = _signUserOp(userOp, sessionPrivKey);
+
+        PackedUserOperation[] memory ops = new PackedUserOperation[](1);
+        ops[0] = userOp;
+        entryPoint.handleOps(ops, beneficiary);
+
+        assertEq(counter.number(), 1);
+    }
 }

--- a/contracts/test/SmartAccount.t.sol
+++ b/contracts/test/SmartAccount.t.sol
@@ -638,6 +638,41 @@ contract SmartAccountTest is Test {
         assertEq(validationData, 1); // SIG_VALIDATION_FAILED
     }
 
+    function test_validateUserOp_sessionKey_zeroDataLength() public {
+        (address sessionKey, uint256 sessionPrivKey) = makeAddrAndKey("sessionKey");
+
+        vm.prank(owner);
+        account.registerSessionKey(
+            sessionKey,
+            address(counter),
+            Counter.increment.selector,
+            uint48(100),
+            uint48(5000)
+        );
+
+        // Craft calldata where data.length is 0 but trailing bytes contain the
+        // allowed selector at [132:136]. Without the dataLen check, our validation
+        // would read the trailing bytes and pass, while execute would forward empty
+        // calldata (hitting the target's fallback instead of increment).
+        bytes memory malicious = abi.encodePacked(
+            SmartAccount.execute.selector,               // [0:4]   outer selector
+            bytes32(uint256(uint160(address(counter)))),  // [4:36]  target
+            bytes32(uint256(0)),                          // [36:68] value
+            bytes32(uint256(0x60)),                       // [68:100] canonical offset
+            bytes32(uint256(0)),                          // [100:132] data.length = 0
+            Counter.increment.selector,                   // [132:136] trailing decoy
+            bytes28(0)                                    // [136:164] padding
+        );
+
+        PackedUserOperation memory userOp = _buildUserOp(malicious);
+        userOp.signature = _signUserOp(userOp, sessionPrivKey);
+        bytes32 userOpHash = this.getUserOpHash(userOp);
+
+        vm.prank(address(entryPoint));
+        uint256 validationData = account.validateUserOp(userOp, userOpHash, 0);
+        assertEq(validationData, 1); // SIG_VALIDATION_FAILED
+    }
+
     // ──────────── Session key full EntryPoint flow test ───────────────
 
     function test_execute_sessionKey_fullFlow() public {

--- a/contracts/test/SmartAccount.t.sol
+++ b/contracts/test/SmartAccount.t.sol
@@ -273,6 +273,34 @@ contract SmartAccountTest is Test {
         );
     }
 
+    function test_registerSessionKey_revertsZeroTarget() public {
+        (address sessionKey,) = makeAddrAndKey("sessionKey");
+
+        vm.prank(owner);
+        vm.expectRevert(SmartAccount.InvalidSessionKeyParams.selector);
+        account.registerSessionKey(
+            sessionKey,
+            address(0),
+            Counter.increment.selector,
+            uint48(1000),
+            uint48(2000)
+        );
+    }
+
+    function test_registerSessionKey_revertsZeroSelector() public {
+        (address sessionKey,) = makeAddrAndKey("sessionKey");
+
+        vm.prank(owner);
+        vm.expectRevert(SmartAccount.InvalidSessionKeyParams.selector);
+        account.registerSessionKey(
+            sessionKey,
+            address(counter),
+            bytes4(0),
+            uint48(1000),
+            uint48(2000)
+        );
+    }
+
     function test_registerSessionKey_revertsZeroValidUntil() public {
         (address sessionKey,) = makeAddrAndKey("sessionKey");
 
@@ -536,6 +564,70 @@ contract SmartAccountTest is Test {
         bytes memory callData = abi.encodeCall(
             SmartAccount.execute,
             (address(counter), 0, abi.encodeCall(Counter.increment, ()))
+        );
+        PackedUserOperation memory userOp = _buildUserOp(callData);
+        userOp.signature = _signUserOp(userOp, sessionPrivKey);
+        bytes32 userOpHash = this.getUserOpHash(userOp);
+
+        vm.prank(address(entryPoint));
+        uint256 validationData = account.validateUserOp(userOp, userOpHash, 0);
+        assertEq(validationData, 1); // SIG_VALIDATION_FAILED
+    }
+
+    function test_validateUserOp_sessionKey_nonCanonicalOffset() public {
+        (address sessionKey, uint256 sessionPrivKey) = makeAddrAndKey("sessionKey");
+
+        vm.prank(owner);
+        account.registerSessionKey(
+            sessionKey,
+            address(counter),
+            Counter.increment.selector,
+            uint48(100),
+            uint48(5000)
+        );
+
+        // Craft calldata with non-canonical ABI offset.
+        // Normal execute(address,uint256,bytes) has offset 0x60 at [68:100].
+        // We set offset to 0xA0, place the allowed selector at [132:136] to
+        // fool a naive fixed-offset check, and put the real (malicious) data
+        // where Solidity's abi.decode would actually read it.
+        bytes memory malicious = abi.encodePacked(
+            SmartAccount.execute.selector,     // [0:4]   outer selector
+            bytes32(uint256(uint160(address(counter)))), // [4:36]  target
+            bytes32(uint256(0)),                // [36:68] value
+            bytes32(uint256(0xA0)),             // [68:100] non-canonical offset
+            bytes32(0),                         // [100:132] padding
+            Counter.increment.selector,         // [132:136] decoy selector
+            bytes28(0),                         // [136:164] padding
+            bytes32(uint256(4)),                // [164:196] length of inner data
+            Counter.setNumber.selector,         // [196:200] actual malicious selector
+            bytes28(0)                          // [200:228] padding
+        );
+
+        PackedUserOperation memory userOp = _buildUserOp(malicious);
+        userOp.signature = _signUserOp(userOp, sessionPrivKey);
+        bytes32 userOpHash = this.getUserOpHash(userOp);
+
+        vm.prank(address(entryPoint));
+        uint256 validationData = account.validateUserOp(userOp, userOpHash, 0);
+        assertEq(validationData, 1); // SIG_VALIDATION_FAILED
+    }
+
+    function test_validateUserOp_sessionKey_nonZeroValue() public {
+        (address sessionKey, uint256 sessionPrivKey) = makeAddrAndKey("sessionKey");
+
+        vm.prank(owner);
+        account.registerSessionKey(
+            sessionKey,
+            address(counter),
+            Counter.increment.selector,
+            uint48(100),
+            uint48(5000)
+        );
+
+        bytes memory callData = abi.encodeCall(
+            SmartAccount.execute,
+            (address(counter), 1 ether, abi.encodeCall(Counter.increment, ()))
         );
         PackedUserOperation memory userOp = _buildUserOp(callData);
         userOp.signature = _signUserOp(userOp, sessionPrivKey);


### PR DESCRIPTION
## What

Add session key registration, revocation, and validation to SmartAccount. Session keys are scoped, time-bounded signing keys that can execute a single target+selector pair on behalf of the account.

## Why

Session keys are a core exam requirement — they allow delegated, least-privilege execution without exposing the owner's private key.

## Scope

- [x] Contracts
- [ ] Backend
- [ ] Frontend
- [ ] Tooling / CI
- [ ] Documentation
- [x] Test

## How to verify

```sh
cd contracts && forge test -vvv
```

All 33 tests pass, including 16 new session key tests covering:
- Registration (event, storage, input validation, duplicates, access control)
- Revocation (event, deletion, not-registered, access control)
- Validation (valid op, wrong target, wrong selector, executeBatch rejected, revoked key)
- Full EntryPoint flow (session key signs and submits a UserOp via handleOps)

## Related issues

Closes #2