### PR TITLE
Per-account Counter with getCount

### DIFF
--- a/contracts/src/Counter.sol
+++ b/contracts/src/Counter.sol
@@ -1,14 +1,29 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.13;
+pragma solidity ^0.8.28;
 
+/// @title Counter
+/// @notice Demo target contract for SmartAccount interactions.
+///         Each caller (smart account) has its own independent counter.
 contract Counter {
-    uint256 public number;
+    /// @notice Per-account counters. Keyed by msg.sender (the smart account address
+    ///         when called via SmartAccount.execute).
+    mapping(address => uint256) private _counts;
 
-    function setNumber(uint256 newNumber) public {
-        number = newNumber;
+    /// @notice Increment the caller's counter by one.
+    function increment() external {
+        _counts[msg.sender]++;
     }
 
-    function increment() public {
-        number++;
+    /// @notice Set the caller's counter to an arbitrary value.
+    /// @param newNumber The value to set.
+    function setNumber(uint256 newNumber) external {
+        _counts[msg.sender] = newNumber;
+    }
+
+    /// @notice Returns the counter value for a specific account.
+    /// @param account The address to query.
+    /// @return The current count for that account.
+    function getCount(address account) external view returns (uint256) {
+        return _counts[account];
     }
 }

--- a/contracts/test/Counter.t.sol
+++ b/contracts/test/Counter.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.13;
+pragma solidity ^0.8.28;
 
 import {Test} from "forge-std/Test.sol";
 import {Counter} from "../src/Counter.sol";
@@ -7,18 +7,70 @@ import {Counter} from "../src/Counter.sol";
 contract CounterTest is Test {
     Counter public counter;
 
+    address public alice;
+    address public bob;
+
     function setUp() public {
         counter = new Counter();
-        counter.setNumber(0);
+        alice = makeAddr("alice");
+        bob = makeAddr("bob");
     }
 
-    function test_Increment() public {
+    // ──────────────────────── increment tests ─────────────────────────
+
+    function test_increment_updatesCallerCount() public {
+        vm.prank(alice);
         counter.increment();
-        assertEq(counter.number(), 1);
+        assertEq(counter.getCount(alice), 1);
     }
 
-    function testFuzz_SetNumber(uint256 x) public {
+    function test_increment_multipleCallsAccumulate() public {
+        vm.startPrank(alice);
+        counter.increment();
+        counter.increment();
+        counter.increment();
+        vm.stopPrank();
+        assertEq(counter.getCount(alice), 3);
+    }
+
+    function test_increment_independentPerAccount() public {
+        vm.prank(alice);
+        counter.increment();
+
+        vm.prank(bob);
+        counter.increment();
+        vm.prank(bob);
+        counter.increment();
+
+        assertEq(counter.getCount(alice), 1);
+        assertEq(counter.getCount(bob), 2);
+    }
+
+    // ──────────────────────── setNumber tests ─────────────────────────
+
+    function test_setNumber_updatesCallerCount() public {
+        vm.prank(alice);
+        counter.setNumber(42);
+        assertEq(counter.getCount(alice), 42);
+    }
+
+    function test_setNumber_doesNotAffectOtherAccounts() public {
+        vm.prank(alice);
+        counter.setNumber(100);
+
+        assertEq(counter.getCount(alice), 100);
+        assertEq(counter.getCount(bob), 0);
+    }
+
+    function testFuzz_setNumber(uint256 x) public {
+        vm.prank(alice);
         counter.setNumber(x);
-        assertEq(counter.number(), x);
+        assertEq(counter.getCount(alice), x);
+    }
+
+    // ──────────────────────── getCount tests ──────────────────────────
+
+    function test_getCount_returnsZeroForNewAccount() public view {
+        assertEq(counter.getCount(alice), 0);
     }
 }

--- a/contracts/test/SmartAccount.t.sol
+++ b/contracts/test/SmartAccount.t.sol
@@ -170,13 +170,13 @@ contract SmartAccountTest is Test {
         ops[0] = userOp;
         entryPoint.handleOps(ops, beneficiary);
 
-        assertEq(counter.number(), 1);
+        assertEq(counter.getCount(address(account)), 1);
     }
 
     function test_execute_fromOwner() public {
         vm.prank(owner);
         account.execute(address(counter), 0, abi.encodeCall(Counter.increment, ()));
-        assertEq(counter.number(), 1);
+        assertEq(counter.getCount(address(account)), 1);
     }
 
     function test_execute_revertsFromStranger() public {
@@ -198,7 +198,7 @@ contract SmartAccountTest is Test {
 
         vm.prank(owner);
         account.executeBatch(targets, values, calldatas);
-        assertEq(counter.number(), 2);
+        assertEq(counter.getCount(address(account)), 2);
     }
 
     function test_executeBatch_revertsOnLengthMismatch() public {
@@ -811,6 +811,6 @@ contract SmartAccountTest is Test {
         ops[0] = userOp;
         entryPoint.handleOps(ops, beneficiary);
 
-        assertEq(counter.number(), 1);
+        assertEq(counter.getCount(address(account)), 1);
     }
 }


### PR DESCRIPTION
## What

Rewrite the Counter contract with per-account counters keyed by `msg.sender`, add `getCount(address account)`, and update all downstream tests.

## Why

The exam spec (section 1.2) requires a Counter where "each smart account has its own counter" with `increment()` and `getCount(address account)`. The Foundry scaffold default used a single global `number`.

## Scope

- [x] Contracts
- [ ] Backend
- [ ] Frontend
- [ ] Tooling / CI
- [ ] Documentation
- [x] Test

## How to verify

```sh
cd contracts && forge test -vvv
```

All 21 tests pass:
- 7 Counter tests (increment, setNumber, getCount, per-account isolation, fuzz)
- 14 SmartAccount tests (updated `counter.number()` → `counter.getCount(address(account))`)

## Related issues

Closes #4