### PR TITLE
SmartAccountFactory: CREATE2 deployment

### DIFF
--- a/contracts/src/SmartAccount.sol
+++ b/contracts/src/SmartAccount.sol
@@ -4,7 +4,11 @@ pragma solidity ^0.8.28;
 import {BaseAccount} from "@account-abstraction/contracts/core/BaseAccount.sol";
 import {IEntryPoint} from "@account-abstraction/contracts/interfaces/IEntryPoint.sol";
 import {PackedUserOperation} from "@account-abstraction/contracts/interfaces/PackedUserOperation.sol";
-import {SIG_VALIDATION_FAILED, SIG_VALIDATION_SUCCESS, _packValidationData} from "@account-abstraction/contracts/core/Helpers.sol";
+import {
+    SIG_VALIDATION_FAILED,
+    SIG_VALIDATION_SUCCESS,
+    _packValidationData
+} from "@account-abstraction/contracts/core/Helpers.sol";
 import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 import {MessageHashUtils} from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
 import {Initializable} from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
@@ -38,10 +42,7 @@ contract SmartAccount is BaseAccount, Initializable {
 
     // ───────────────────────────── Events ──────────────────────────────
 
-    event SmartAccountInitialized(
-        IEntryPoint indexed entryPoint,
-        address indexed owner
-    );
+    event SmartAccountInitialized(IEntryPoint indexed entryPoint, address indexed owner);
 
     /// @notice Emitted when the owner registers a new session key (exam spec name).
     event SessionKeyAdded(address indexed key, uint256 expiry);
@@ -106,14 +107,15 @@ contract SmartAccount is BaseAccount, Initializable {
     ///         is signed — it cannot be tampered with between validation and execution.
     ///
     /// @inheritdoc BaseAccount
-    function _validateSignature(
-        PackedUserOperation calldata userOp,
-        bytes32 userOpHash
-    ) internal view override returns (uint256 validationData) {
+    function _validateSignature(PackedUserOperation calldata userOp, bytes32 userOpHash)
+        internal
+        view
+        override
+        returns (uint256 validationData)
+    {
         bytes32 ethSignedHash = userOpHash.toEthSignedMessageHash();
 
-        (address recovered, ECDSA.RecoverError err, ) = ethSignedHash
-            .tryRecover(userOp.signature);
+        (address recovered, ECDSA.RecoverError err,) = ethSignedHash.tryRecover(userOp.signature);
         if (err != ECDSA.RecoverError.NoError) {
             return SIG_VALIDATION_FAILED;
         }
@@ -145,11 +147,8 @@ contract SmartAccount is BaseAccount, Initializable {
         uint48 validUntil
     ) external onlyOwnerOrEntryPoint {
         if (
-            key == address(0) ||
-            allowedTarget == address(0) ||
-            allowedSelector == bytes4(0) ||
-            validUntil == 0 ||
-            validUntil <= validAfter
+            key == address(0) || allowedTarget == address(0) || allowedSelector == bytes4(0) || validUntil == 0
+                || validUntil <= validAfter
         ) {
             revert InvalidSessionKeyParams();
         }
@@ -188,14 +187,8 @@ contract SmartAccount is BaseAccount, Initializable {
     /// @param target  The contract (or EOA) to call.
     /// @param value   The ETH value to send.
     /// @param data    The calldata (function selector + arguments).
-    function execute(
-        address target,
-        uint256 value,
-        bytes calldata data
-    ) external onlyOwnerOrEntryPoint {
-        (bool success, bytes memory returnData) = target.call{value: value}(
-            data
-        );
+    function execute(address target, uint256 value, bytes calldata data) external onlyOwnerOrEntryPoint {
+        (bool success, bytes memory returnData) = target.call{value: value}(data);
         if (!success) {
             revert CallFailed(returnData);
         }
@@ -206,20 +199,13 @@ contract SmartAccount is BaseAccount, Initializable {
     /// @param targets  Array of addresses to call.
     /// @param values   Array of ETH values to send.
     /// @param calldatas Array of calldata payloads.
-    function executeBatch(
-        address[] calldata targets,
-        uint256[] calldata values,
-        bytes[] calldata calldatas
-    ) external onlyOwnerOrEntryPoint {
-        require(
-            targets.length == values.length &&
-                values.length == calldatas.length,
-            "length mismatch"
-        );
+    function executeBatch(address[] calldata targets, uint256[] calldata values, bytes[] calldata calldatas)
+        external
+        onlyOwnerOrEntryPoint
+    {
+        require(targets.length == values.length && values.length == calldatas.length, "length mismatch");
         for (uint256 i = 0; i < targets.length; i++) {
-            (bool success, bytes memory returnData) = targets[i].call{
-                value: values[i]
-            }(calldatas[i]);
+            (bool success, bytes memory returnData) = targets[i].call{value: values[i]}(calldatas[i]);
             if (!success) {
                 revert CallFailed(returnData);
             }
@@ -256,10 +242,7 @@ contract SmartAccount is BaseAccount, Initializable {
     /// @param signer  The recovered session key address.
     /// @param callData The full userOp.callData.
     /// @return validationData Packed (sigFailed, validUntil, validAfter) or SIG_VALIDATION_FAILED.
-    function _validateSessionKey(
-        address signer,
-        bytes calldata callData
-    ) internal view returns (uint256) {
+    function _validateSessionKey(address signer, bytes calldata callData) internal view returns (uint256) {
         SessionKeyData storage sk = sessionKeys[signer];
 
         if (sk.validUntil == 0) {
@@ -269,10 +252,7 @@ contract SmartAccount is BaseAccount, Initializable {
         // Min 136 bytes: 4 (selector) + 3×32 (head) + 32 (data length) + 4 (inner selector).
         // Shorter calldata would cause OOB reads, reverting instead of returning
         // SIG_VALIDATION_FAILED (violating ERC-4337).
-        if (
-            callData.length < 136 ||
-            bytes4(callData[:4]) != this.execute.selector
-        ) {
+        if (callData.length < 136 || bytes4(callData[:4]) != this.execute.selector) {
             return SIG_VALIDATION_FAILED;
         }
 

--- a/contracts/src/SmartAccount.sol
+++ b/contracts/src/SmartAccount.sol
@@ -52,6 +52,7 @@ contract SmartAccount is BaseAccount, Initializable {
 
     // ───────────────────────────── Errors ──────────────────────────────
 
+    error InvalidEntryPoint();
     error OnlyOwnerOrEntryPoint();
     error CallFailed(bytes returnData);
     error SessionKeyAlreadyRegistered(address key);
@@ -73,6 +74,7 @@ contract SmartAccount is BaseAccount, Initializable {
     ///         on the implementation itself — only proxies can be initialized.
     /// @param entryPoint_ The EntryPoint v0.7 address (same on all EVM chains).
     constructor(IEntryPoint entryPoint_) {
+        if (address(entryPoint_) == address(0)) revert InvalidEntryPoint();
         _ENTRY_POINT = entryPoint_;
         _disableInitializers();
     }

--- a/contracts/src/SmartAccountFactory.sol
+++ b/contracts/src/SmartAccountFactory.sol
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.28;
+
+import {Create2} from "@openzeppelin/contracts/utils/Create2.sol";
+import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import {IEntryPoint} from "@account-abstraction/contracts/interfaces/IEntryPoint.sol";
+import {SmartAccount} from "./SmartAccount.sol";
+
+/// @title SmartAccountFactory
+/// @notice Deploys SmartAccount proxies via CREATE2 for deterministic, counterfactual addresses.
+///         Follows the eth-infinitism SimpleAccountFactory pattern: each proxy is an ERC-1967
+///         proxy pointing to a shared SmartAccount implementation deployed in the constructor.
+///         The EntryPoint calls `createAccount` through the UserOperation's `initCode` field
+///         on the first transaction from a new account.
+contract SmartAccountFactory {
+    /// @notice The shared SmartAccount implementation behind all proxies.
+    SmartAccount public immutable accountImplementation;
+
+    /// @notice Emitted when a new account proxy is deployed.
+    event AccountCreated(address indexed account, address indexed owner);
+
+    /// @notice Deploys the SmartAccount implementation contract.
+    /// @param entryPoint_ The EntryPoint v0.7 address passed to the implementation constructor.
+    constructor(IEntryPoint entryPoint_) {
+        accountImplementation = new SmartAccount(entryPoint_);
+    }
+
+    /// @notice Deploy a new SmartAccount proxy, or return the existing one if already deployed.
+    ///         Called by the EntryPoint via `initCode` on the account's first UserOperation,
+    ///         or directly by anyone who wants to pre-deploy an account.
+    /// @param owner The EOA that will own the smart account.
+    /// @param salt  A user-chosen salt for CREATE2 address derivation.
+    /// @return ret The SmartAccount proxy (new or existing).
+    function createAccount(address owner, uint256 salt) external returns (SmartAccount ret) {
+        address addr = getAddress(owner, salt);
+        if (addr.code.length > 0) {
+            return SmartAccount(payable(addr));
+        }
+        ret = SmartAccount(
+            payable(new ERC1967Proxy{salt: bytes32(salt)}(
+                    address(accountImplementation), abi.encodeCall(SmartAccount.initialize, (owner))
+                ))
+        );
+        emit AccountCreated(address(ret), owner);
+    }
+
+    /// @notice Compute the counterfactual address for an account that would be deployed
+    ///         with the given owner and salt, without actually deploying it.
+    /// @param owner The EOA that would own the smart account.
+    /// @param salt  The CREATE2 salt.
+    /// @return The deterministic address.
+    function getAddress(address owner, uint256 salt) public view returns (address) {
+        return Create2.computeAddress(
+            bytes32(salt),
+            keccak256(
+                abi.encodePacked(
+                    type(ERC1967Proxy).creationCode,
+                    abi.encode(address(accountImplementation), abi.encodeCall(SmartAccount.initialize, (owner)))
+                )
+            )
+        );
+    }
+}

--- a/contracts/src/SmartAccountFactory.sol
+++ b/contracts/src/SmartAccountFactory.sol
@@ -19,6 +19,9 @@ contract SmartAccountFactory {
     /// @notice Emitted when a new account proxy is deployed.
     event AccountCreated(address indexed account, address indexed owner);
 
+    /// @notice Thrown when owner is the zero address.
+    error InvalidOwner();
+
     /// @notice Deploys the SmartAccount implementation contract.
     /// @param entryPoint_ The EntryPoint v0.7 address passed to the implementation constructor.
     constructor(IEntryPoint entryPoint_) {
@@ -32,6 +35,7 @@ contract SmartAccountFactory {
     /// @param salt  A user-chosen salt for CREATE2 address derivation.
     /// @return ret The SmartAccount proxy (new or existing).
     function createAccount(address owner, uint256 salt) external returns (SmartAccount ret) {
+        if (owner == address(0)) revert InvalidOwner();
         address addr = getAddress(owner, salt);
         if (addr.code.length > 0) {
             return SmartAccount(payable(addr));
@@ -50,6 +54,7 @@ contract SmartAccountFactory {
     /// @param salt  The CREATE2 salt.
     /// @return The deterministic address.
     function getAddress(address owner, uint256 salt) public view returns (address) {
+        if (owner == address(0)) revert InvalidOwner();
         return Create2.computeAddress(
             bytes32(salt),
             keccak256(

--- a/contracts/test/SmartAccount.t.sol
+++ b/contracts/test/SmartAccount.t.sol
@@ -77,10 +77,7 @@ contract SmartAccountTest is Test {
     }
 
     /// @notice Signs a UserOp: compute hash → EIP-191 prefix → vm.sign → pack (r, s, v).
-    function _signUserOp(
-        PackedUserOperation memory userOp,
-        uint256 privateKey
-    ) internal view returns (bytes memory) {
+    function _signUserOp(PackedUserOperation memory userOp, uint256 privateKey) internal view returns (bytes memory) {
         bytes32 userOpHash = this.getUserOpHash(userOp);
         bytes32 ethSignedHash = userOpHash.toEthSignedMessageHash();
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, ethSignedHash);
@@ -159,10 +156,8 @@ contract SmartAccountTest is Test {
 
     function test_execute_fromEntryPoint() public {
         // Full ERC-4337 flow: handleOps → validateUserOp → execute → counter.increment
-        bytes memory callData = abi.encodeCall(
-            SmartAccount.execute,
-            (address(counter), 0, abi.encodeCall(Counter.increment, ()))
-        );
+        bytes memory callData =
+            abi.encodeCall(SmartAccount.execute, (address(counter), 0, abi.encodeCall(Counter.increment, ())));
         PackedUserOperation memory userOp = _buildUserOp(callData);
         userOp.signature = _signUserOp(userOp, ownerKey);
 
@@ -233,26 +228,14 @@ contract SmartAccountTest is Test {
         emit SmartAccount.SessionKeyAdded(sessionKey, 2000);
 
         vm.prank(owner);
-        account.registerSessionKey(
-            sessionKey,
-            address(counter),
-            Counter.increment.selector,
-            uint48(1000),
-            uint48(2000)
-        );
+        account.registerSessionKey(sessionKey, address(counter), Counter.increment.selector, uint48(1000), uint48(2000));
     }
 
     function test_registerSessionKey_storesData() public {
         (address sessionKey,) = makeAddrAndKey("sessionKey");
 
         vm.prank(owner);
-        account.registerSessionKey(
-            sessionKey,
-            address(counter),
-            Counter.increment.selector,
-            uint48(1000),
-            uint48(2000)
-        );
+        account.registerSessionKey(sessionKey, address(counter), Counter.increment.selector, uint48(1000), uint48(2000));
 
         (address target, bytes4 selector, uint48 validAfter, uint48 validUntil) = account.sessionKeys(sessionKey);
         assertEq(target, address(counter));
@@ -264,13 +247,7 @@ contract SmartAccountTest is Test {
     function test_registerSessionKey_revertsZeroAddress() public {
         vm.prank(owner);
         vm.expectRevert(SmartAccount.InvalidSessionKeyParams.selector);
-        account.registerSessionKey(
-            address(0),
-            address(counter),
-            Counter.increment.selector,
-            uint48(1000),
-            uint48(2000)
-        );
+        account.registerSessionKey(address(0), address(counter), Counter.increment.selector, uint48(1000), uint48(2000));
     }
 
     function test_registerSessionKey_revertsZeroTarget() public {
@@ -278,13 +255,7 @@ contract SmartAccountTest is Test {
 
         vm.prank(owner);
         vm.expectRevert(SmartAccount.InvalidSessionKeyParams.selector);
-        account.registerSessionKey(
-            sessionKey,
-            address(0),
-            Counter.increment.selector,
-            uint48(1000),
-            uint48(2000)
-        );
+        account.registerSessionKey(sessionKey, address(0), Counter.increment.selector, uint48(1000), uint48(2000));
     }
 
     function test_registerSessionKey_revertsZeroSelector() public {
@@ -292,13 +263,7 @@ contract SmartAccountTest is Test {
 
         vm.prank(owner);
         vm.expectRevert(SmartAccount.InvalidSessionKeyParams.selector);
-        account.registerSessionKey(
-            sessionKey,
-            address(counter),
-            bytes4(0),
-            uint48(1000),
-            uint48(2000)
-        );
+        account.registerSessionKey(sessionKey, address(counter), bytes4(0), uint48(1000), uint48(2000));
     }
 
     function test_registerSessionKey_revertsZeroValidUntil() public {
@@ -306,13 +271,7 @@ contract SmartAccountTest is Test {
 
         vm.prank(owner);
         vm.expectRevert(SmartAccount.InvalidSessionKeyParams.selector);
-        account.registerSessionKey(
-            sessionKey,
-            address(counter),
-            Counter.increment.selector,
-            uint48(1000),
-            uint48(0)
-        );
+        account.registerSessionKey(sessionKey, address(counter), Counter.increment.selector, uint48(1000), uint48(0));
     }
 
     function test_registerSessionKey_revertsValidUntilLteValidAfter() public {
@@ -333,23 +292,11 @@ contract SmartAccountTest is Test {
         (address sessionKey,) = makeAddrAndKey("sessionKey");
 
         vm.prank(owner);
-        account.registerSessionKey(
-            sessionKey,
-            address(counter),
-            Counter.increment.selector,
-            uint48(1000),
-            uint48(2000)
-        );
+        account.registerSessionKey(sessionKey, address(counter), Counter.increment.selector, uint48(1000), uint48(2000));
 
         vm.prank(owner);
         vm.expectRevert(abi.encodeWithSelector(SmartAccount.SessionKeyAlreadyRegistered.selector, sessionKey));
-        account.registerSessionKey(
-            sessionKey,
-            address(counter),
-            Counter.increment.selector,
-            uint48(1000),
-            uint48(2000)
-        );
+        account.registerSessionKey(sessionKey, address(counter), Counter.increment.selector, uint48(1000), uint48(2000));
     }
 
     function test_registerSessionKey_revertsFromStranger() public {
@@ -357,13 +304,7 @@ contract SmartAccountTest is Test {
 
         vm.prank(stranger);
         vm.expectRevert(SmartAccount.OnlyOwnerOrEntryPoint.selector);
-        account.registerSessionKey(
-            sessionKey,
-            address(counter),
-            Counter.increment.selector,
-            uint48(1000),
-            uint48(2000)
-        );
+        account.registerSessionKey(sessionKey, address(counter), Counter.increment.selector, uint48(1000), uint48(2000));
     }
 
     function test_registerSessionKey_viaEntryPoint() public {
@@ -380,7 +321,7 @@ contract SmartAccountTest is Test {
         ops[0] = userOp;
         entryPoint.handleOps(ops, beneficiary);
 
-        (, , , uint48 validUntil) = account.sessionKeys(sessionKey);
+        (,,, uint48 validUntil) = account.sessionKeys(sessionKey);
         assertEq(validUntil, 2000);
     }
 
@@ -390,13 +331,7 @@ contract SmartAccountTest is Test {
         (address sessionKey,) = makeAddrAndKey("sessionKey");
 
         vm.prank(owner);
-        account.registerSessionKey(
-            sessionKey,
-            address(counter),
-            Counter.increment.selector,
-            uint48(1000),
-            uint48(2000)
-        );
+        account.registerSessionKey(sessionKey, address(counter), Counter.increment.selector, uint48(1000), uint48(2000));
 
         vm.expectEmit(true, false, false, false);
         emit SmartAccount.SessionKeyRevoked(sessionKey);
@@ -409,18 +344,12 @@ contract SmartAccountTest is Test {
         (address sessionKey,) = makeAddrAndKey("sessionKey");
 
         vm.prank(owner);
-        account.registerSessionKey(
-            sessionKey,
-            address(counter),
-            Counter.increment.selector,
-            uint48(1000),
-            uint48(2000)
-        );
+        account.registerSessionKey(sessionKey, address(counter), Counter.increment.selector, uint48(1000), uint48(2000));
 
         vm.prank(owner);
         account.revokeSessionKey(sessionKey);
 
-        (, , , uint48 validUntil) = account.sessionKeys(sessionKey);
+        (,,, uint48 validUntil) = account.sessionKeys(sessionKey);
         assertEq(validUntil, 0);
     }
 
@@ -434,13 +363,7 @@ contract SmartAccountTest is Test {
         (address sessionKey,) = makeAddrAndKey("sessionKey");
 
         vm.prank(owner);
-        account.registerSessionKey(
-            sessionKey,
-            address(counter),
-            Counter.increment.selector,
-            uint48(1000),
-            uint48(2000)
-        );
+        account.registerSessionKey(sessionKey, address(counter), Counter.increment.selector, uint48(1000), uint48(2000));
 
         vm.prank(stranger);
         vm.expectRevert(SmartAccount.OnlyOwnerOrEntryPoint.selector);
@@ -451,18 +374,9 @@ contract SmartAccountTest is Test {
         (address sessionKey,) = makeAddrAndKey("sessionKey");
 
         vm.prank(owner);
-        account.registerSessionKey(
-            sessionKey,
-            address(counter),
-            Counter.increment.selector,
-            uint48(1000),
-            uint48(2000)
-        );
+        account.registerSessionKey(sessionKey, address(counter), Counter.increment.selector, uint48(1000), uint48(2000));
 
-        bytes memory callData = abi.encodeCall(
-            SmartAccount.revokeSessionKey,
-            (sessionKey)
-        );
+        bytes memory callData = abi.encodeCall(SmartAccount.revokeSessionKey, (sessionKey));
         PackedUserOperation memory userOp = _buildUserOp(callData);
         userOp.signature = _signUserOp(userOp, ownerKey);
 
@@ -470,7 +384,7 @@ contract SmartAccountTest is Test {
         ops[0] = userOp;
         entryPoint.handleOps(ops, beneficiary);
 
-        (, , , uint48 validUntil) = account.sessionKeys(sessionKey);
+        (,,, uint48 validUntil) = account.sessionKeys(sessionKey);
         assertEq(validUntil, 0);
     }
 
@@ -480,18 +394,10 @@ contract SmartAccountTest is Test {
         (address sessionKey, uint256 sessionPrivKey) = makeAddrAndKey("sessionKey");
 
         vm.prank(owner);
-        account.registerSessionKey(
-            sessionKey,
-            address(counter),
-            Counter.increment.selector,
-            uint48(100),
-            uint48(5000)
-        );
+        account.registerSessionKey(sessionKey, address(counter), Counter.increment.selector, uint48(100), uint48(5000));
 
-        bytes memory callData = abi.encodeCall(
-            SmartAccount.execute,
-            (address(counter), 0, abi.encodeCall(Counter.increment, ()))
-        );
+        bytes memory callData =
+            abi.encodeCall(SmartAccount.execute, (address(counter), 0, abi.encodeCall(Counter.increment, ())));
         PackedUserOperation memory userOp = _buildUserOp(callData);
         userOp.signature = _signUserOp(userOp, sessionPrivKey);
         bytes32 userOpHash = this.getUserOpHash(userOp);
@@ -514,18 +420,10 @@ contract SmartAccountTest is Test {
         address wrongTarget = makeAddr("wrongTarget");
 
         vm.prank(owner);
-        account.registerSessionKey(
-            sessionKey,
-            address(counter),
-            Counter.increment.selector,
-            uint48(100),
-            uint48(5000)
-        );
+        account.registerSessionKey(sessionKey, address(counter), Counter.increment.selector, uint48(100), uint48(5000));
 
-        bytes memory callData = abi.encodeCall(
-            SmartAccount.execute,
-            (wrongTarget, 0, abi.encodeCall(Counter.increment, ()))
-        );
+        bytes memory callData =
+            abi.encodeCall(SmartAccount.execute, (wrongTarget, 0, abi.encodeCall(Counter.increment, ())));
         PackedUserOperation memory userOp = _buildUserOp(callData);
         userOp.signature = _signUserOp(userOp, sessionPrivKey);
         bytes32 userOpHash = this.getUserOpHash(userOp);
@@ -547,10 +445,8 @@ contract SmartAccountTest is Test {
             uint48(5000)
         );
 
-        bytes memory callData = abi.encodeCall(
-            SmartAccount.execute,
-            (address(counter), 0, abi.encodeCall(Counter.setNumber, (42)))
-        );
+        bytes memory callData =
+            abi.encodeCall(SmartAccount.execute, (address(counter), 0, abi.encodeCall(Counter.setNumber, (42))));
         PackedUserOperation memory userOp = _buildUserOp(callData);
         userOp.signature = _signUserOp(userOp, sessionPrivKey);
         bytes32 userOpHash = this.getUserOpHash(userOp);
@@ -564,13 +460,7 @@ contract SmartAccountTest is Test {
         (address sessionKey, uint256 sessionPrivKey) = makeAddrAndKey("sessionKey");
 
         vm.prank(owner);
-        account.registerSessionKey(
-            sessionKey,
-            address(counter),
-            Counter.increment.selector,
-            uint48(100),
-            uint48(5000)
-        );
+        account.registerSessionKey(sessionKey, address(counter), Counter.increment.selector, uint48(100), uint48(5000));
 
         address[] memory targets = new address[](1);
         targets[0] = address(counter);
@@ -578,10 +468,7 @@ contract SmartAccountTest is Test {
         bytes[] memory calldatas = new bytes[](1);
         calldatas[0] = abi.encodeCall(Counter.increment, ());
 
-        bytes memory callData = abi.encodeCall(
-            SmartAccount.executeBatch,
-            (targets, values, calldatas)
-        );
+        bytes memory callData = abi.encodeCall(SmartAccount.executeBatch, (targets, values, calldatas));
         PackedUserOperation memory userOp = _buildUserOp(callData);
         userOp.signature = _signUserOp(userOp, sessionPrivKey);
         bytes32 userOpHash = this.getUserOpHash(userOp);
@@ -595,21 +482,13 @@ contract SmartAccountTest is Test {
         (address sessionKey, uint256 sessionPrivKey) = makeAddrAndKey("sessionKey");
 
         vm.prank(owner);
-        account.registerSessionKey(
-            sessionKey,
-            address(counter),
-            Counter.increment.selector,
-            uint48(100),
-            uint48(5000)
-        );
+        account.registerSessionKey(sessionKey, address(counter), Counter.increment.selector, uint48(100), uint48(5000));
 
         vm.prank(owner);
         account.revokeSessionKey(sessionKey);
 
-        bytes memory callData = abi.encodeCall(
-            SmartAccount.execute,
-            (address(counter), 0, abi.encodeCall(Counter.increment, ()))
-        );
+        bytes memory callData =
+            abi.encodeCall(SmartAccount.execute, (address(counter), 0, abi.encodeCall(Counter.increment, ())));
         PackedUserOperation memory userOp = _buildUserOp(callData);
         userOp.signature = _signUserOp(userOp, sessionPrivKey);
         bytes32 userOpHash = this.getUserOpHash(userOp);
@@ -623,13 +502,7 @@ contract SmartAccountTest is Test {
         (address sessionKey, uint256 sessionPrivKey) = makeAddrAndKey("sessionKey");
 
         vm.prank(owner);
-        account.registerSessionKey(
-            sessionKey,
-            address(counter),
-            Counter.increment.selector,
-            uint48(100),
-            uint48(5000)
-        );
+        account.registerSessionKey(sessionKey, address(counter), Counter.increment.selector, uint48(100), uint48(5000));
 
         // Craft calldata with non-canonical ABI offset.
         // Normal execute(address,uint256,bytes) has offset 0x60 at [68:100].
@@ -637,16 +510,16 @@ contract SmartAccountTest is Test {
         // fool a naive fixed-offset check, and put the real (malicious) data
         // where Solidity's abi.decode would actually read it.
         bytes memory malicious = abi.encodePacked(
-            SmartAccount.execute.selector,     // [0:4]   outer selector
+            SmartAccount.execute.selector, // [0:4]   outer selector
             bytes32(uint256(uint160(address(counter)))), // [4:36]  target
-            bytes32(uint256(0)),                // [36:68] value
-            bytes32(uint256(0xA0)),             // [68:100] non-canonical offset
-            bytes32(0),                         // [100:132] padding
-            Counter.increment.selector,         // [132:136] decoy selector
-            bytes28(0),                         // [136:164] padding
-            bytes32(uint256(4)),                // [164:196] length of inner data
-            Counter.setNumber.selector,         // [196:200] actual malicious selector
-            bytes28(0)                          // [200:228] padding
+            bytes32(uint256(0)), // [36:68] value
+            bytes32(uint256(0xA0)), // [68:100] non-canonical offset
+            bytes32(0), // [100:132] padding
+            Counter.increment.selector, // [132:136] decoy selector
+            bytes28(0), // [136:164] padding
+            bytes32(uint256(4)), // [164:196] length of inner data
+            Counter.setNumber.selector, // [196:200] actual malicious selector
+            bytes28(0) // [200:228] padding
         );
 
         PackedUserOperation memory userOp = _buildUserOp(malicious);
@@ -662,18 +535,10 @@ contract SmartAccountTest is Test {
         (address sessionKey, uint256 sessionPrivKey) = makeAddrAndKey("sessionKey");
 
         vm.prank(owner);
-        account.registerSessionKey(
-            sessionKey,
-            address(counter),
-            Counter.increment.selector,
-            uint48(100),
-            uint48(5000)
-        );
+        account.registerSessionKey(sessionKey, address(counter), Counter.increment.selector, uint48(100), uint48(5000));
 
-        bytes memory callData = abi.encodeCall(
-            SmartAccount.execute,
-            (address(counter), 1 ether, abi.encodeCall(Counter.increment, ()))
-        );
+        bytes memory callData =
+            abi.encodeCall(SmartAccount.execute, (address(counter), 1 ether, abi.encodeCall(Counter.increment, ())));
         PackedUserOperation memory userOp = _buildUserOp(callData);
         userOp.signature = _signUserOp(userOp, sessionPrivKey);
         bytes32 userOpHash = this.getUserOpHash(userOp);
@@ -687,26 +552,20 @@ contract SmartAccountTest is Test {
         (address sessionKey, uint256 sessionPrivKey) = makeAddrAndKey("sessionKey");
 
         vm.prank(owner);
-        account.registerSessionKey(
-            sessionKey,
-            address(counter),
-            Counter.increment.selector,
-            uint48(100),
-            uint48(5000)
-        );
+        account.registerSessionKey(sessionKey, address(counter), Counter.increment.selector, uint48(100), uint48(5000));
 
         // Craft calldata where data.length is 0 but trailing bytes contain the
         // allowed selector at [132:136]. Without the dataLen check, our validation
         // would read the trailing bytes and pass, while execute would forward empty
         // calldata (hitting the target's fallback instead of increment).
         bytes memory malicious = abi.encodePacked(
-            SmartAccount.execute.selector,               // [0:4]   outer selector
-            bytes32(uint256(uint160(address(counter)))),  // [4:36]  target
-            bytes32(uint256(0)),                          // [36:68] value
-            bytes32(uint256(0x60)),                       // [68:100] canonical offset
-            bytes32(uint256(0)),                          // [100:132] data.length = 0
-            Counter.increment.selector,                   // [132:136] trailing decoy
-            bytes28(0)                                    // [136:164] padding
+            SmartAccount.execute.selector, // [0:4]   outer selector
+            bytes32(uint256(uint160(address(counter)))), // [4:36]  target
+            bytes32(uint256(0)), // [36:68] value
+            bytes32(uint256(0x60)), // [68:100] canonical offset
+            bytes32(uint256(0)), // [100:132] data.length = 0
+            Counter.increment.selector, // [132:136] trailing decoy
+            bytes28(0) // [136:164] padding
         );
 
         PackedUserOperation memory userOp = _buildUserOp(malicious);
@@ -722,22 +581,16 @@ contract SmartAccountTest is Test {
         (address sessionKey, uint256 sessionPrivKey) = makeAddrAndKey("sessionKey");
 
         vm.prank(owner);
-        account.registerSessionKey(
-            sessionKey,
-            address(counter),
-            Counter.increment.selector,
-            uint48(100),
-            uint48(5000)
-        );
+        account.registerSessionKey(sessionKey, address(counter), Counter.increment.selector, uint48(100), uint48(5000));
 
         // Craft calldata that is 100 bytes — long enough to pass a naive >= 100
         // check but too short for the [100:132] slice. Must return
         // SIG_VALIDATION_FAILED, not revert.
         bytes memory truncated = abi.encodePacked(
-            SmartAccount.execute.selector,               // [0:4]   outer selector
-            bytes32(uint256(uint160(address(counter)))),  // [4:36]  target
-            bytes32(uint256(0)),                          // [36:68] value
-            bytes32(uint256(0x60))                        // [68:100] canonical offset
+            SmartAccount.execute.selector, // [0:4]   outer selector
+            bytes32(uint256(uint160(address(counter)))), // [4:36]  target
+            bytes32(uint256(0)), // [36:68] value
+            bytes32(uint256(0x60)) // [68:100] canonical offset
             // nothing beyond 100 — triggers OOB without the length fix
         );
 
@@ -754,24 +607,18 @@ contract SmartAccountTest is Test {
         (address sessionKey, uint256 sessionPrivKey) = makeAddrAndKey("sessionKey");
 
         vm.prank(owner);
-        account.registerSessionKey(
-            sessionKey,
-            address(counter),
-            Counter.increment.selector,
-            uint48(100),
-            uint48(5000)
-        );
+        account.registerSessionKey(sessionKey, address(counter), Counter.increment.selector, uint48(100), uint48(5000));
 
         // Craft calldata with a huge data.length that would overflow 132 + dataLen.
         // Must return SIG_VALIDATION_FAILED, not revert with arithmetic overflow.
         bytes memory malicious = abi.encodePacked(
-            SmartAccount.execute.selector,               // [0:4]   outer selector
-            bytes32(uint256(uint160(address(counter)))),  // [4:36]  target
-            bytes32(uint256(0)),                          // [36:68] value
-            bytes32(uint256(0x60)),                       // [68:100] canonical offset
-            bytes32(type(uint256).max),                   // [100:132] huge dataLen
-            Counter.increment.selector,                   // [132:136] inner selector
-            bytes28(0)                                    // [136:164] padding
+            SmartAccount.execute.selector, // [0:4]   outer selector
+            bytes32(uint256(uint160(address(counter)))), // [4:36]  target
+            bytes32(uint256(0)), // [36:68] value
+            bytes32(uint256(0x60)), // [68:100] canonical offset
+            bytes32(type(uint256).max), // [100:132] huge dataLen
+            Counter.increment.selector, // [132:136] inner selector
+            bytes28(0) // [136:164] padding
         );
 
         PackedUserOperation memory userOp = _buildUserOp(malicious);
@@ -792,18 +639,10 @@ contract SmartAccountTest is Test {
         uint48 validUntil = uint48(block.timestamp + 1 hours);
 
         vm.prank(owner);
-        account.registerSessionKey(
-            sessionKey,
-            address(counter),
-            Counter.increment.selector,
-            validAfter,
-            validUntil
-        );
+        account.registerSessionKey(sessionKey, address(counter), Counter.increment.selector, validAfter, validUntil);
 
-        bytes memory callData = abi.encodeCall(
-            SmartAccount.execute,
-            (address(counter), 0, abi.encodeCall(Counter.increment, ()))
-        );
+        bytes memory callData =
+            abi.encodeCall(SmartAccount.execute, (address(counter), 0, abi.encodeCall(Counter.increment, ())));
         PackedUserOperation memory userOp = _buildUserOp(callData);
         userOp.signature = _signUserOp(userOp, sessionPrivKey);
 

--- a/contracts/test/SmartAccount.t.sol
+++ b/contracts/test/SmartAccount.t.sol
@@ -107,6 +107,11 @@ contract SmartAccountTest is Test {
         new ERC1967Proxy(address(impl), initData);
     }
 
+    function test_constructor_revertsOnZeroEntryPoint() public {
+        vm.expectRevert(SmartAccount.InvalidEntryPoint.selector);
+        new SmartAccount(IEntryPoint(address(0)));
+    }
+
     // ───────────────── Signature validation tests ─────────────────────
 
     function test_validateUserOp_validOwnerSignature() public {

--- a/contracts/test/SmartAccountFactory.t.sol
+++ b/contracts/test/SmartAccountFactory.t.sol
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.28;
+
+import {Test, Vm} from "forge-std/Test.sol";
+import {VmSafe} from "forge-std/Vm.sol";
+import {EntryPoint} from "@account-abstraction/contracts/core/EntryPoint.sol";
+import {IEntryPoint} from "@account-abstraction/contracts/interfaces/IEntryPoint.sol";
+import {SmartAccount} from "../src/SmartAccount.sol";
+import {SmartAccountFactory} from "../src/SmartAccountFactory.sol";
+
+contract SmartAccountFactoryTest is Test {
+    // ───────────────────────────── State ───────────────────────────────
+
+    EntryPoint public entryPoint;
+    SmartAccountFactory public factory;
+
+    address public owner;
+    address public otherOwner;
+
+    // ───────────────────────────── Setup ───────────────────────────────
+
+    function setUp() public {
+        entryPoint = new EntryPoint();
+        factory = new SmartAccountFactory(IEntryPoint(address(entryPoint)));
+        owner = makeAddr("owner");
+        otherOwner = makeAddr("otherOwner");
+    }
+
+    // ───────────────── accountImplementation tests ────────────────────
+
+    function test_accountImplementation_isNonZero() public view {
+        assertTrue(address(factory.accountImplementation()) != address(0));
+    }
+
+    function test_accountImplementation_hasCode() public view {
+        assertTrue(address(factory.accountImplementation()).code.length > 0);
+    }
+
+    function test_accountImplementation_entryPointIsCorrect() public view {
+        assertEq(address(factory.accountImplementation().entryPoint()), address(entryPoint));
+    }
+
+    // ──────────────────── createAccount tests ─────────────────────────
+
+    function test_createAccount_deploysProxy() public {
+        SmartAccount account = factory.createAccount(owner, 0);
+        assertTrue(address(account).code.length > 0);
+    }
+
+    function test_createAccount_initializesOwner() public {
+        SmartAccount account = factory.createAccount(owner, 0);
+        assertEq(account.owner(), owner);
+    }
+
+    function test_createAccount_entryPointIsCorrect() public {
+        SmartAccount account = factory.createAccount(owner, 0);
+        assertEq(address(account.entryPoint()), address(entryPoint));
+    }
+
+    function test_createAccount_deterministicAddress() public {
+        address predicted = factory.getAddress(owner, 0);
+        SmartAccount account = factory.createAccount(owner, 0);
+        assertEq(address(account), predicted);
+    }
+
+    function test_createAccount_returnsExistingOnSecondCall() public {
+        SmartAccount first = factory.createAccount(owner, 0);
+        SmartAccount second = factory.createAccount(owner, 0);
+        assertEq(address(first), address(second));
+    }
+
+    function test_createAccount_differentSaltDifferentAddress() public {
+        SmartAccount a = factory.createAccount(owner, 0);
+        SmartAccount b = factory.createAccount(owner, 1);
+        assertTrue(address(a) != address(b));
+    }
+
+    function test_createAccount_differentOwnerDifferentAddress() public {
+        SmartAccount a = factory.createAccount(owner, 0);
+        SmartAccount b = factory.createAccount(otherOwner, 0);
+        assertTrue(address(a) != address(b));
+    }
+
+    function test_createAccount_emitsAccountCreated() public {
+        address predicted = factory.getAddress(owner, 0);
+
+        vm.expectEmit(true, true, false, false);
+        emit SmartAccountFactory.AccountCreated(predicted, owner);
+        factory.createAccount(owner, 0);
+    }
+
+    function test_createAccount_noEventOnExistingAccount() public {
+        factory.createAccount(owner, 0);
+
+        // Second call should not emit AccountCreated.
+        vm.recordLogs();
+        factory.createAccount(owner, 0);
+
+        VmSafe.Log[] memory logs = vm.getRecordedLogs();
+        for (uint256 i = 0; i < logs.length; i++) {
+            assertTrue(logs[i].topics[0] != SmartAccountFactory.AccountCreated.selector);
+        }
+    }
+
+    // ────────────────────── getAddress tests ──────────────────────────
+
+    function test_getAddress_consistentBeforeAndAfterDeploy() public {
+        address before = factory.getAddress(owner, 42);
+        factory.createAccount(owner, 42);
+        address after_ = factory.getAddress(owner, 42);
+        assertEq(before, after_);
+    }
+
+    function test_getAddress_differentSaltsDiffer() public view {
+        address a = factory.getAddress(owner, 0);
+        address b = factory.getAddress(owner, 1);
+        assertTrue(a != b);
+    }
+
+    function test_getAddress_differentOwnersDiffer() public view {
+        address a = factory.getAddress(owner, 0);
+        address b = factory.getAddress(otherOwner, 0);
+        assertTrue(a != b);
+    }
+
+    // ──────────────── proxy initialization guard tests ────────────────
+
+    function test_proxy_cannotBeReinitialised() public {
+        SmartAccount account = factory.createAccount(owner, 0);
+        vm.expectRevert();
+        account.initialize(otherOwner);
+    }
+
+    function test_implementation_cannotBeInitialised() public {
+        SmartAccount impl = factory.accountImplementation();
+        vm.expectRevert();
+        impl.initialize(owner);
+    }
+}

--- a/contracts/test/SmartAccountFactory.t.sol
+++ b/contracts/test/SmartAccountFactory.t.sol
@@ -123,6 +123,18 @@ contract SmartAccountFactoryTest is Test {
         assertTrue(a != b);
     }
 
+    // ──────────────────── zero-owner guard tests ───────────────────────
+
+    function test_createAccount_revertsZeroOwner() public {
+        vm.expectRevert(SmartAccountFactory.InvalidOwner.selector);
+        factory.createAccount(address(0), 0);
+    }
+
+    function test_getAddress_revertsZeroOwner() public {
+        vm.expectRevert(SmartAccountFactory.InvalidOwner.selector);
+        factory.getAddress(address(0), 0);
+    }
+
     // ──────────────── proxy initialization guard tests ────────────────
 
     function test_proxy_cannotBeReinitialised() public {

--- a/contracts/test/SmartAccountFactory.t.sol
+++ b/contracts/test/SmartAccountFactory.t.sol
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.28;
 
-import {Test, Vm} from "forge-std/Test.sol";
-import {VmSafe} from "forge-std/Vm.sol";
+import {Test} from "forge-std/Test.sol";
 import {EntryPoint} from "@account-abstraction/contracts/core/EntryPoint.sol";
 import {IEntryPoint} from "@account-abstraction/contracts/interfaces/IEntryPoint.sol";
 import {SmartAccount} from "../src/SmartAccount.sol";
@@ -92,14 +91,11 @@ contract SmartAccountFactoryTest is Test {
     function test_createAccount_noEventOnExistingAccount() public {
         factory.createAccount(owner, 0);
 
-        // Second call should not emit AccountCreated.
+        // Second call returns early — no logs at all.
         vm.recordLogs();
         factory.createAccount(owner, 0);
 
-        VmSafe.Log[] memory logs = vm.getRecordedLogs();
-        for (uint256 i = 0; i < logs.length; i++) {
-            assertTrue(logs[i].topics[0] != SmartAccountFactory.AccountCreated.selector);
-        }
+        assertEq(vm.getRecordedLogs().length, 0);
     }
 
     // ────────────────────── getAddress tests ──────────────────────────


### PR DESCRIPTION
## What

Add `SmartAccountFactory` — deploys `SmartAccount` proxies via CREATE2
for deterministic, counterfactual addresses. Follows the eth-infinitism
`SimpleAccountFactory` reference pattern using OZ's `ERC1967Proxy`.

## Why

The EntryPoint needs a factory to deploy smart accounts on the first
UserOperation (`initCode` field). Deterministic addresses let users
receive funds before their account exists on-chain.

## Scope

- [x] Contracts
- [ ] Backend
- [ ] Frontend
- [ ] Tooling / CI
- [ ] Documentation
- [x] Test

## How to verify

```sh
cd contracts && forge test --match-contract SmartAccountFactory -vvv
```

17 tests covering: proxy deployment, owner initialization, address
determinism, idempotent `createAccount`, event emission, re-initialization
guards, and `getAddress` consistency.

## Related issues

Closes #3