### PR TITLE
Contract test suite: time bounds, ETH forwarding, revert propagation, multi-key

### DIFF
--- a/contracts/src/SmartAccount.sol
+++ b/contracts/src/SmartAccount.sol
@@ -4,7 +4,11 @@ pragma solidity ^0.8.28;
 import {BaseAccount} from "@account-abstraction/contracts/core/BaseAccount.sol";
 import {IEntryPoint} from "@account-abstraction/contracts/interfaces/IEntryPoint.sol";
 import {PackedUserOperation} from "@account-abstraction/contracts/interfaces/PackedUserOperation.sol";
-import {SIG_VALIDATION_FAILED, SIG_VALIDATION_SUCCESS, _packValidationData} from "@account-abstraction/contracts/core/Helpers.sol";
+import {
+    SIG_VALIDATION_FAILED,
+    SIG_VALIDATION_SUCCESS,
+    _packValidationData
+} from "@account-abstraction/contracts/core/Helpers.sol";
 import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 import {MessageHashUtils} from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
 import {Initializable} from "@openzeppelin/contracts/proxy/utils/Initializable.sol";
@@ -38,10 +42,7 @@ contract SmartAccount is BaseAccount, Initializable {
 
     // ───────────────────────────── Events ──────────────────────────────
 
-    event SmartAccountInitialized(
-        IEntryPoint indexed entryPoint,
-        address indexed owner
-    );
+    event SmartAccountInitialized(IEntryPoint indexed entryPoint, address indexed owner);
 
     /// @notice Emitted when the owner registers a new session key (exam spec name).
     event SessionKeyAdded(address indexed key, uint256 expiry);
@@ -106,14 +107,15 @@ contract SmartAccount is BaseAccount, Initializable {
     ///         is signed — it cannot be tampered with between validation and execution.
     ///
     /// @inheritdoc BaseAccount
-    function _validateSignature(
-        PackedUserOperation calldata userOp,
-        bytes32 userOpHash
-    ) internal view override returns (uint256 validationData) {
+    function _validateSignature(PackedUserOperation calldata userOp, bytes32 userOpHash)
+        internal
+        view
+        override
+        returns (uint256 validationData)
+    {
         bytes32 ethSignedHash = userOpHash.toEthSignedMessageHash();
 
-        (address recovered, ECDSA.RecoverError err, ) = ethSignedHash
-            .tryRecover(userOp.signature);
+        (address recovered, ECDSA.RecoverError err,) = ethSignedHash.tryRecover(userOp.signature);
         if (err != ECDSA.RecoverError.NoError) {
             return SIG_VALIDATION_FAILED;
         }
@@ -145,11 +147,8 @@ contract SmartAccount is BaseAccount, Initializable {
         uint48 validUntil
     ) external onlyOwnerOrEntryPoint {
         if (
-            key == address(0) ||
-            allowedTarget == address(0) ||
-            allowedSelector == bytes4(0) ||
-            validUntil == 0 ||
-            validUntil <= validAfter
+            key == address(0) || allowedTarget == address(0) || allowedSelector == bytes4(0) || validUntil == 0
+                || validUntil <= validAfter
         ) {
             revert InvalidSessionKeyParams();
         }
@@ -188,14 +187,8 @@ contract SmartAccount is BaseAccount, Initializable {
     /// @param target  The contract (or EOA) to call.
     /// @param value   The ETH value to send.
     /// @param data    The calldata (function selector + arguments).
-    function execute(
-        address target,
-        uint256 value,
-        bytes calldata data
-    ) external onlyOwnerOrEntryPoint {
-        (bool success, bytes memory returnData) = target.call{value: value}(
-            data
-        );
+    function execute(address target, uint256 value, bytes calldata data) external onlyOwnerOrEntryPoint {
+        (bool success, bytes memory returnData) = target.call{value: value}(data);
         if (!success) {
             revert CallFailed(returnData);
         }
@@ -206,20 +199,13 @@ contract SmartAccount is BaseAccount, Initializable {
     /// @param targets  Array of addresses to call.
     /// @param values   Array of ETH values to send.
     /// @param calldatas Array of calldata payloads.
-    function executeBatch(
-        address[] calldata targets,
-        uint256[] calldata values,
-        bytes[] calldata calldatas
-    ) external onlyOwnerOrEntryPoint {
-        require(
-            targets.length == values.length &&
-                values.length == calldatas.length,
-            "length mismatch"
-        );
+    function executeBatch(address[] calldata targets, uint256[] calldata values, bytes[] calldata calldatas)
+        external
+        onlyOwnerOrEntryPoint
+    {
+        require(targets.length == values.length && values.length == calldatas.length, "length mismatch");
         for (uint256 i = 0; i < targets.length; i++) {
-            (bool success, bytes memory returnData) = targets[i].call{
-                value: values[i]
-            }(calldatas[i]);
+            (bool success, bytes memory returnData) = targets[i].call{value: values[i]}(calldatas[i]);
             if (!success) {
                 revert CallFailed(returnData);
             }
@@ -256,10 +242,7 @@ contract SmartAccount is BaseAccount, Initializable {
     /// @param signer  The recovered session key address.
     /// @param callData The full userOp.callData.
     /// @return validationData Packed (sigFailed, validUntil, validAfter) or SIG_VALIDATION_FAILED.
-    function _validateSessionKey(
-        address signer,
-        bytes calldata callData
-    ) internal view returns (uint256) {
+    function _validateSessionKey(address signer, bytes calldata callData) internal view returns (uint256) {
         SessionKeyData storage sk = sessionKeys[signer];
 
         if (sk.validUntil == 0) {
@@ -269,10 +252,7 @@ contract SmartAccount is BaseAccount, Initializable {
         // Min 136 bytes: 4 (selector) + 3×32 (head) + 32 (data length) + 4 (inner selector).
         // Shorter calldata would cause OOB reads, reverting instead of returning
         // SIG_VALIDATION_FAILED (violating ERC-4337).
-        if (
-            callData.length < 136 ||
-            bytes4(callData[:4]) != this.execute.selector
-        ) {
+        if (callData.length < 136 || bytes4(callData[:4]) != this.execute.selector) {
             return SIG_VALIDATION_FAILED;
         }
 

--- a/contracts/test/SmartAccount.t.sol
+++ b/contracts/test/SmartAccount.t.sol
@@ -77,10 +77,7 @@ contract SmartAccountTest is Test {
     }
 
     /// @notice Signs a UserOp: compute hash → EIP-191 prefix → vm.sign → pack (r, s, v).
-    function _signUserOp(
-        PackedUserOperation memory userOp,
-        uint256 privateKey
-    ) internal view returns (bytes memory) {
+    function _signUserOp(PackedUserOperation memory userOp, uint256 privateKey) internal view returns (bytes memory) {
         bytes32 userOpHash = this.getUserOpHash(userOp);
         bytes32 ethSignedHash = userOpHash.toEthSignedMessageHash();
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, ethSignedHash);
@@ -159,10 +156,8 @@ contract SmartAccountTest is Test {
 
     function test_execute_fromEntryPoint() public {
         // Full ERC-4337 flow: handleOps → validateUserOp → execute → counter.increment
-        bytes memory callData = abi.encodeCall(
-            SmartAccount.execute,
-            (address(counter), 0, abi.encodeCall(Counter.increment, ()))
-        );
+        bytes memory callData =
+            abi.encodeCall(SmartAccount.execute, (address(counter), 0, abi.encodeCall(Counter.increment, ())));
         PackedUserOperation memory userOp = _buildUserOp(callData);
         userOp.signature = _signUserOp(userOp, ownerKey);
 
@@ -233,26 +228,14 @@ contract SmartAccountTest is Test {
         emit SmartAccount.SessionKeyAdded(sessionKey, 2000);
 
         vm.prank(owner);
-        account.registerSessionKey(
-            sessionKey,
-            address(counter),
-            Counter.increment.selector,
-            uint48(1000),
-            uint48(2000)
-        );
+        account.registerSessionKey(sessionKey, address(counter), Counter.increment.selector, uint48(1000), uint48(2000));
     }
 
     function test_registerSessionKey_storesData() public {
         (address sessionKey,) = makeAddrAndKey("sessionKey");
 
         vm.prank(owner);
-        account.registerSessionKey(
-            sessionKey,
-            address(counter),
-            Counter.increment.selector,
-            uint48(1000),
-            uint48(2000)
-        );
+        account.registerSessionKey(sessionKey, address(counter), Counter.increment.selector, uint48(1000), uint48(2000));
 
         (address target, bytes4 selector, uint48 validAfter, uint48 validUntil) = account.sessionKeys(sessionKey);
         assertEq(target, address(counter));
@@ -264,13 +247,7 @@ contract SmartAccountTest is Test {
     function test_registerSessionKey_revertsZeroAddress() public {
         vm.prank(owner);
         vm.expectRevert(SmartAccount.InvalidSessionKeyParams.selector);
-        account.registerSessionKey(
-            address(0),
-            address(counter),
-            Counter.increment.selector,
-            uint48(1000),
-            uint48(2000)
-        );
+        account.registerSessionKey(address(0), address(counter), Counter.increment.selector, uint48(1000), uint48(2000));
     }
 
     function test_registerSessionKey_revertsZeroTarget() public {
@@ -278,13 +255,7 @@ contract SmartAccountTest is Test {
 
         vm.prank(owner);
         vm.expectRevert(SmartAccount.InvalidSessionKeyParams.selector);
-        account.registerSessionKey(
-            sessionKey,
-            address(0),
-            Counter.increment.selector,
-            uint48(1000),
-            uint48(2000)
-        );
+        account.registerSessionKey(sessionKey, address(0), Counter.increment.selector, uint48(1000), uint48(2000));
     }
 
     function test_registerSessionKey_revertsZeroSelector() public {
@@ -292,13 +263,7 @@ contract SmartAccountTest is Test {
 
         vm.prank(owner);
         vm.expectRevert(SmartAccount.InvalidSessionKeyParams.selector);
-        account.registerSessionKey(
-            sessionKey,
-            address(counter),
-            bytes4(0),
-            uint48(1000),
-            uint48(2000)
-        );
+        account.registerSessionKey(sessionKey, address(counter), bytes4(0), uint48(1000), uint48(2000));
     }
 
     function test_registerSessionKey_revertsZeroValidUntil() public {
@@ -306,13 +271,7 @@ contract SmartAccountTest is Test {
 
         vm.prank(owner);
         vm.expectRevert(SmartAccount.InvalidSessionKeyParams.selector);
-        account.registerSessionKey(
-            sessionKey,
-            address(counter),
-            Counter.increment.selector,
-            uint48(1000),
-            uint48(0)
-        );
+        account.registerSessionKey(sessionKey, address(counter), Counter.increment.selector, uint48(1000), uint48(0));
     }
 
     function test_registerSessionKey_revertsValidUntilLteValidAfter() public {
@@ -333,23 +292,11 @@ contract SmartAccountTest is Test {
         (address sessionKey,) = makeAddrAndKey("sessionKey");
 
         vm.prank(owner);
-        account.registerSessionKey(
-            sessionKey,
-            address(counter),
-            Counter.increment.selector,
-            uint48(1000),
-            uint48(2000)
-        );
+        account.registerSessionKey(sessionKey, address(counter), Counter.increment.selector, uint48(1000), uint48(2000));
 
         vm.prank(owner);
         vm.expectRevert(abi.encodeWithSelector(SmartAccount.SessionKeyAlreadyRegistered.selector, sessionKey));
-        account.registerSessionKey(
-            sessionKey,
-            address(counter),
-            Counter.increment.selector,
-            uint48(1000),
-            uint48(2000)
-        );
+        account.registerSessionKey(sessionKey, address(counter), Counter.increment.selector, uint48(1000), uint48(2000));
     }
 
     function test_registerSessionKey_revertsFromStranger() public {
@@ -357,13 +304,7 @@ contract SmartAccountTest is Test {
 
         vm.prank(stranger);
         vm.expectRevert(SmartAccount.OnlyOwnerOrEntryPoint.selector);
-        account.registerSessionKey(
-            sessionKey,
-            address(counter),
-            Counter.increment.selector,
-            uint48(1000),
-            uint48(2000)
-        );
+        account.registerSessionKey(sessionKey, address(counter), Counter.increment.selector, uint48(1000), uint48(2000));
     }
 
     function test_registerSessionKey_viaEntryPoint() public {
@@ -380,7 +321,7 @@ contract SmartAccountTest is Test {
         ops[0] = userOp;
         entryPoint.handleOps(ops, beneficiary);
 
-        (, , , uint48 validUntil) = account.sessionKeys(sessionKey);
+        (,,, uint48 validUntil) = account.sessionKeys(sessionKey);
         assertEq(validUntil, 2000);
     }
 
@@ -390,13 +331,7 @@ contract SmartAccountTest is Test {
         (address sessionKey,) = makeAddrAndKey("sessionKey");
 
         vm.prank(owner);
-        account.registerSessionKey(
-            sessionKey,
-            address(counter),
-            Counter.increment.selector,
-            uint48(1000),
-            uint48(2000)
-        );
+        account.registerSessionKey(sessionKey, address(counter), Counter.increment.selector, uint48(1000), uint48(2000));
 
         vm.expectEmit(true, false, false, false);
         emit SmartAccount.SessionKeyRevoked(sessionKey);
@@ -409,18 +344,12 @@ contract SmartAccountTest is Test {
         (address sessionKey,) = makeAddrAndKey("sessionKey");
 
         vm.prank(owner);
-        account.registerSessionKey(
-            sessionKey,
-            address(counter),
-            Counter.increment.selector,
-            uint48(1000),
-            uint48(2000)
-        );
+        account.registerSessionKey(sessionKey, address(counter), Counter.increment.selector, uint48(1000), uint48(2000));
 
         vm.prank(owner);
         account.revokeSessionKey(sessionKey);
 
-        (, , , uint48 validUntil) = account.sessionKeys(sessionKey);
+        (,,, uint48 validUntil) = account.sessionKeys(sessionKey);
         assertEq(validUntil, 0);
     }
 
@@ -434,13 +363,7 @@ contract SmartAccountTest is Test {
         (address sessionKey,) = makeAddrAndKey("sessionKey");
 
         vm.prank(owner);
-        account.registerSessionKey(
-            sessionKey,
-            address(counter),
-            Counter.increment.selector,
-            uint48(1000),
-            uint48(2000)
-        );
+        account.registerSessionKey(sessionKey, address(counter), Counter.increment.selector, uint48(1000), uint48(2000));
 
         vm.prank(stranger);
         vm.expectRevert(SmartAccount.OnlyOwnerOrEntryPoint.selector);
@@ -451,18 +374,9 @@ contract SmartAccountTest is Test {
         (address sessionKey,) = makeAddrAndKey("sessionKey");
 
         vm.prank(owner);
-        account.registerSessionKey(
-            sessionKey,
-            address(counter),
-            Counter.increment.selector,
-            uint48(1000),
-            uint48(2000)
-        );
+        account.registerSessionKey(sessionKey, address(counter), Counter.increment.selector, uint48(1000), uint48(2000));
 
-        bytes memory callData = abi.encodeCall(
-            SmartAccount.revokeSessionKey,
-            (sessionKey)
-        );
+        bytes memory callData = abi.encodeCall(SmartAccount.revokeSessionKey, (sessionKey));
         PackedUserOperation memory userOp = _buildUserOp(callData);
         userOp.signature = _signUserOp(userOp, ownerKey);
 
@@ -470,7 +384,7 @@ contract SmartAccountTest is Test {
         ops[0] = userOp;
         entryPoint.handleOps(ops, beneficiary);
 
-        (, , , uint48 validUntil) = account.sessionKeys(sessionKey);
+        (,,, uint48 validUntil) = account.sessionKeys(sessionKey);
         assertEq(validUntil, 0);
     }
 
@@ -480,18 +394,10 @@ contract SmartAccountTest is Test {
         (address sessionKey, uint256 sessionPrivKey) = makeAddrAndKey("sessionKey");
 
         vm.prank(owner);
-        account.registerSessionKey(
-            sessionKey,
-            address(counter),
-            Counter.increment.selector,
-            uint48(100),
-            uint48(5000)
-        );
+        account.registerSessionKey(sessionKey, address(counter), Counter.increment.selector, uint48(100), uint48(5000));
 
-        bytes memory callData = abi.encodeCall(
-            SmartAccount.execute,
-            (address(counter), 0, abi.encodeCall(Counter.increment, ()))
-        );
+        bytes memory callData =
+            abi.encodeCall(SmartAccount.execute, (address(counter), 0, abi.encodeCall(Counter.increment, ())));
         PackedUserOperation memory userOp = _buildUserOp(callData);
         userOp.signature = _signUserOp(userOp, sessionPrivKey);
         bytes32 userOpHash = this.getUserOpHash(userOp);
@@ -514,18 +420,10 @@ contract SmartAccountTest is Test {
         address wrongTarget = makeAddr("wrongTarget");
 
         vm.prank(owner);
-        account.registerSessionKey(
-            sessionKey,
-            address(counter),
-            Counter.increment.selector,
-            uint48(100),
-            uint48(5000)
-        );
+        account.registerSessionKey(sessionKey, address(counter), Counter.increment.selector, uint48(100), uint48(5000));
 
-        bytes memory callData = abi.encodeCall(
-            SmartAccount.execute,
-            (wrongTarget, 0, abi.encodeCall(Counter.increment, ()))
-        );
+        bytes memory callData =
+            abi.encodeCall(SmartAccount.execute, (wrongTarget, 0, abi.encodeCall(Counter.increment, ())));
         PackedUserOperation memory userOp = _buildUserOp(callData);
         userOp.signature = _signUserOp(userOp, sessionPrivKey);
         bytes32 userOpHash = this.getUserOpHash(userOp);
@@ -547,10 +445,8 @@ contract SmartAccountTest is Test {
             uint48(5000)
         );
 
-        bytes memory callData = abi.encodeCall(
-            SmartAccount.execute,
-            (address(counter), 0, abi.encodeCall(Counter.setNumber, (42)))
-        );
+        bytes memory callData =
+            abi.encodeCall(SmartAccount.execute, (address(counter), 0, abi.encodeCall(Counter.setNumber, (42))));
         PackedUserOperation memory userOp = _buildUserOp(callData);
         userOp.signature = _signUserOp(userOp, sessionPrivKey);
         bytes32 userOpHash = this.getUserOpHash(userOp);
@@ -564,13 +460,7 @@ contract SmartAccountTest is Test {
         (address sessionKey, uint256 sessionPrivKey) = makeAddrAndKey("sessionKey");
 
         vm.prank(owner);
-        account.registerSessionKey(
-            sessionKey,
-            address(counter),
-            Counter.increment.selector,
-            uint48(100),
-            uint48(5000)
-        );
+        account.registerSessionKey(sessionKey, address(counter), Counter.increment.selector, uint48(100), uint48(5000));
 
         address[] memory targets = new address[](1);
         targets[0] = address(counter);
@@ -578,10 +468,7 @@ contract SmartAccountTest is Test {
         bytes[] memory calldatas = new bytes[](1);
         calldatas[0] = abi.encodeCall(Counter.increment, ());
 
-        bytes memory callData = abi.encodeCall(
-            SmartAccount.executeBatch,
-            (targets, values, calldatas)
-        );
+        bytes memory callData = abi.encodeCall(SmartAccount.executeBatch, (targets, values, calldatas));
         PackedUserOperation memory userOp = _buildUserOp(callData);
         userOp.signature = _signUserOp(userOp, sessionPrivKey);
         bytes32 userOpHash = this.getUserOpHash(userOp);
@@ -595,21 +482,13 @@ contract SmartAccountTest is Test {
         (address sessionKey, uint256 sessionPrivKey) = makeAddrAndKey("sessionKey");
 
         vm.prank(owner);
-        account.registerSessionKey(
-            sessionKey,
-            address(counter),
-            Counter.increment.selector,
-            uint48(100),
-            uint48(5000)
-        );
+        account.registerSessionKey(sessionKey, address(counter), Counter.increment.selector, uint48(100), uint48(5000));
 
         vm.prank(owner);
         account.revokeSessionKey(sessionKey);
 
-        bytes memory callData = abi.encodeCall(
-            SmartAccount.execute,
-            (address(counter), 0, abi.encodeCall(Counter.increment, ()))
-        );
+        bytes memory callData =
+            abi.encodeCall(SmartAccount.execute, (address(counter), 0, abi.encodeCall(Counter.increment, ())));
         PackedUserOperation memory userOp = _buildUserOp(callData);
         userOp.signature = _signUserOp(userOp, sessionPrivKey);
         bytes32 userOpHash = this.getUserOpHash(userOp);
@@ -623,13 +502,7 @@ contract SmartAccountTest is Test {
         (address sessionKey, uint256 sessionPrivKey) = makeAddrAndKey("sessionKey");
 
         vm.prank(owner);
-        account.registerSessionKey(
-            sessionKey,
-            address(counter),
-            Counter.increment.selector,
-            uint48(100),
-            uint48(5000)
-        );
+        account.registerSessionKey(sessionKey, address(counter), Counter.increment.selector, uint48(100), uint48(5000));
 
         // Craft calldata with non-canonical ABI offset.
         // Normal execute(address,uint256,bytes) has offset 0x60 at [68:100].
@@ -637,16 +510,16 @@ contract SmartAccountTest is Test {
         // fool a naive fixed-offset check, and put the real (malicious) data
         // where Solidity's abi.decode would actually read it.
         bytes memory malicious = abi.encodePacked(
-            SmartAccount.execute.selector,     // [0:4]   outer selector
+            SmartAccount.execute.selector, // [0:4]   outer selector
             bytes32(uint256(uint160(address(counter)))), // [4:36]  target
-            bytes32(uint256(0)),                // [36:68] value
-            bytes32(uint256(0xA0)),             // [68:100] non-canonical offset
-            bytes32(0),                         // [100:132] padding
-            Counter.increment.selector,         // [132:136] decoy selector
-            bytes28(0),                         // [136:164] padding
-            bytes32(uint256(4)),                // [164:196] length of inner data
-            Counter.setNumber.selector,         // [196:200] actual malicious selector
-            bytes28(0)                          // [200:228] padding
+            bytes32(uint256(0)), // [36:68] value
+            bytes32(uint256(0xA0)), // [68:100] non-canonical offset
+            bytes32(0), // [100:132] padding
+            Counter.increment.selector, // [132:136] decoy selector
+            bytes28(0), // [136:164] padding
+            bytes32(uint256(4)), // [164:196] length of inner data
+            Counter.setNumber.selector, // [196:200] actual malicious selector
+            bytes28(0) // [200:228] padding
         );
 
         PackedUserOperation memory userOp = _buildUserOp(malicious);
@@ -662,18 +535,10 @@ contract SmartAccountTest is Test {
         (address sessionKey, uint256 sessionPrivKey) = makeAddrAndKey("sessionKey");
 
         vm.prank(owner);
-        account.registerSessionKey(
-            sessionKey,
-            address(counter),
-            Counter.increment.selector,
-            uint48(100),
-            uint48(5000)
-        );
+        account.registerSessionKey(sessionKey, address(counter), Counter.increment.selector, uint48(100), uint48(5000));
 
-        bytes memory callData = abi.encodeCall(
-            SmartAccount.execute,
-            (address(counter), 1 ether, abi.encodeCall(Counter.increment, ()))
-        );
+        bytes memory callData =
+            abi.encodeCall(SmartAccount.execute, (address(counter), 1 ether, abi.encodeCall(Counter.increment, ())));
         PackedUserOperation memory userOp = _buildUserOp(callData);
         userOp.signature = _signUserOp(userOp, sessionPrivKey);
         bytes32 userOpHash = this.getUserOpHash(userOp);
@@ -687,26 +552,20 @@ contract SmartAccountTest is Test {
         (address sessionKey, uint256 sessionPrivKey) = makeAddrAndKey("sessionKey");
 
         vm.prank(owner);
-        account.registerSessionKey(
-            sessionKey,
-            address(counter),
-            Counter.increment.selector,
-            uint48(100),
-            uint48(5000)
-        );
+        account.registerSessionKey(sessionKey, address(counter), Counter.increment.selector, uint48(100), uint48(5000));
 
         // Craft calldata where data.length is 0 but trailing bytes contain the
         // allowed selector at [132:136]. Without the dataLen check, our validation
         // would read the trailing bytes and pass, while execute would forward empty
         // calldata (hitting the target's fallback instead of increment).
         bytes memory malicious = abi.encodePacked(
-            SmartAccount.execute.selector,               // [0:4]   outer selector
-            bytes32(uint256(uint160(address(counter)))),  // [4:36]  target
-            bytes32(uint256(0)),                          // [36:68] value
-            bytes32(uint256(0x60)),                       // [68:100] canonical offset
-            bytes32(uint256(0)),                          // [100:132] data.length = 0
-            Counter.increment.selector,                   // [132:136] trailing decoy
-            bytes28(0)                                    // [136:164] padding
+            SmartAccount.execute.selector, // [0:4]   outer selector
+            bytes32(uint256(uint160(address(counter)))), // [4:36]  target
+            bytes32(uint256(0)), // [36:68] value
+            bytes32(uint256(0x60)), // [68:100] canonical offset
+            bytes32(uint256(0)), // [100:132] data.length = 0
+            Counter.increment.selector, // [132:136] trailing decoy
+            bytes28(0) // [136:164] padding
         );
 
         PackedUserOperation memory userOp = _buildUserOp(malicious);
@@ -722,22 +581,16 @@ contract SmartAccountTest is Test {
         (address sessionKey, uint256 sessionPrivKey) = makeAddrAndKey("sessionKey");
 
         vm.prank(owner);
-        account.registerSessionKey(
-            sessionKey,
-            address(counter),
-            Counter.increment.selector,
-            uint48(100),
-            uint48(5000)
-        );
+        account.registerSessionKey(sessionKey, address(counter), Counter.increment.selector, uint48(100), uint48(5000));
 
         // Craft calldata that is 100 bytes — long enough to pass a naive >= 100
         // check but too short for the [100:132] slice. Must return
         // SIG_VALIDATION_FAILED, not revert.
         bytes memory truncated = abi.encodePacked(
-            SmartAccount.execute.selector,               // [0:4]   outer selector
-            bytes32(uint256(uint160(address(counter)))),  // [4:36]  target
-            bytes32(uint256(0)),                          // [36:68] value
-            bytes32(uint256(0x60))                        // [68:100] canonical offset
+            SmartAccount.execute.selector, // [0:4]   outer selector
+            bytes32(uint256(uint160(address(counter)))), // [4:36]  target
+            bytes32(uint256(0)), // [36:68] value
+            bytes32(uint256(0x60)) // [68:100] canonical offset
             // nothing beyond 100 — triggers OOB without the length fix
         );
 
@@ -754,24 +607,18 @@ contract SmartAccountTest is Test {
         (address sessionKey, uint256 sessionPrivKey) = makeAddrAndKey("sessionKey");
 
         vm.prank(owner);
-        account.registerSessionKey(
-            sessionKey,
-            address(counter),
-            Counter.increment.selector,
-            uint48(100),
-            uint48(5000)
-        );
+        account.registerSessionKey(sessionKey, address(counter), Counter.increment.selector, uint48(100), uint48(5000));
 
         // Craft calldata with a huge data.length that would overflow 132 + dataLen.
         // Must return SIG_VALIDATION_FAILED, not revert with arithmetic overflow.
         bytes memory malicious = abi.encodePacked(
-            SmartAccount.execute.selector,               // [0:4]   outer selector
-            bytes32(uint256(uint160(address(counter)))),  // [4:36]  target
-            bytes32(uint256(0)),                          // [36:68] value
-            bytes32(uint256(0x60)),                       // [68:100] canonical offset
-            bytes32(type(uint256).max),                   // [100:132] huge dataLen
-            Counter.increment.selector,                   // [132:136] inner selector
-            bytes28(0)                                    // [136:164] padding
+            SmartAccount.execute.selector, // [0:4]   outer selector
+            bytes32(uint256(uint160(address(counter)))), // [4:36]  target
+            bytes32(uint256(0)), // [36:68] value
+            bytes32(uint256(0x60)), // [68:100] canonical offset
+            bytes32(type(uint256).max), // [100:132] huge dataLen
+            Counter.increment.selector, // [132:136] inner selector
+            bytes28(0) // [136:164] padding
         );
 
         PackedUserOperation memory userOp = _buildUserOp(malicious);
@@ -783,7 +630,7 @@ contract SmartAccountTest is Test {
         assertEq(validationData, 1); // SIG_VALIDATION_FAILED, no revert
     }
 
-    // ──────────── Session key full EntryPoint flow test ───────────────
+    // ──────────── Session key full EntryPoint flow tests ──────────────
 
     function test_execute_sessionKey_fullFlow() public {
         (address sessionKey, uint256 sessionPrivKey) = makeAddrAndKey("sessionKey");
@@ -792,18 +639,10 @@ contract SmartAccountTest is Test {
         uint48 validUntil = uint48(block.timestamp + 1 hours);
 
         vm.prank(owner);
-        account.registerSessionKey(
-            sessionKey,
-            address(counter),
-            Counter.increment.selector,
-            validAfter,
-            validUntil
-        );
+        account.registerSessionKey(sessionKey, address(counter), Counter.increment.selector, validAfter, validUntil);
 
-        bytes memory callData = abi.encodeCall(
-            SmartAccount.execute,
-            (address(counter), 0, abi.encodeCall(Counter.increment, ()))
-        );
+        bytes memory callData =
+            abi.encodeCall(SmartAccount.execute, (address(counter), 0, abi.encodeCall(Counter.increment, ())));
         PackedUserOperation memory userOp = _buildUserOp(callData);
         userOp.signature = _signUserOp(userOp, sessionPrivKey);
 
@@ -812,5 +651,225 @@ contract SmartAccountTest is Test {
         entryPoint.handleOps(ops, beneficiary);
 
         assertEq(counter.getCount(address(account)), 1);
+    }
+
+    function test_execute_sessionKey_expiredKeyRejected() public {
+        (address sessionKey, uint256 sessionPrivKey) = makeAddrAndKey("sessionKey");
+
+        uint48 validAfter = uint48(100);
+        uint48 validUntil = uint48(200);
+
+        vm.warp(150); // within valid window for registration
+        vm.prank(owner);
+        account.registerSessionKey(sessionKey, address(counter), Counter.increment.selector, validAfter, validUntil);
+
+        // Move past expiry
+        vm.warp(300);
+
+        bytes memory callData =
+            abi.encodeCall(SmartAccount.execute, (address(counter), 0, abi.encodeCall(Counter.increment, ())));
+        PackedUserOperation memory userOp = _buildUserOp(callData);
+        userOp.signature = _signUserOp(userOp, sessionPrivKey);
+
+        PackedUserOperation[] memory ops = new PackedUserOperation[](1);
+        ops[0] = userOp;
+
+        vm.expectRevert(abi.encodeWithSelector(IEntryPoint.FailedOp.selector, 0, "AA22 expired or not due"));
+        entryPoint.handleOps(ops, beneficiary);
+    }
+
+    function test_execute_sessionKey_notYetValidRejected() public {
+        (address sessionKey, uint256 sessionPrivKey) = makeAddrAndKey("sessionKey");
+
+        uint48 validAfter = uint48(1000);
+        uint48 validUntil = uint48(2000);
+
+        vm.prank(owner);
+        account.registerSessionKey(sessionKey, address(counter), Counter.increment.selector, validAfter, validUntil);
+
+        // Stay before validAfter
+        vm.warp(500);
+
+        bytes memory callData =
+            abi.encodeCall(SmartAccount.execute, (address(counter), 0, abi.encodeCall(Counter.increment, ())));
+        PackedUserOperation memory userOp = _buildUserOp(callData);
+        userOp.signature = _signUserOp(userOp, sessionPrivKey);
+
+        PackedUserOperation[] memory ops = new PackedUserOperation[](1);
+        ops[0] = userOp;
+
+        vm.expectRevert(abi.encodeWithSelector(IEntryPoint.FailedOp.selector, 0, "AA22 expired or not due"));
+        entryPoint.handleOps(ops, beneficiary);
+    }
+
+    function test_execute_sessionKey_multipleKeysIndependent() public {
+        (address keyA, uint256 privA) = makeAddrAndKey("keyA");
+        (address keyB, uint256 privB) = makeAddrAndKey("keyB");
+
+        uint48 validAfter = uint48(block.timestamp);
+        uint48 validUntil = uint48(block.timestamp + 1 hours);
+
+        // keyA: only counter.increment
+        vm.prank(owner);
+        account.registerSessionKey(keyA, address(counter), Counter.increment.selector, validAfter, validUntil);
+
+        // keyB: only counter.setNumber
+        vm.prank(owner);
+        account.registerSessionKey(keyB, address(counter), Counter.setNumber.selector, validAfter, validUntil);
+
+        // keyA can increment
+        bytes memory callDataA =
+            abi.encodeCall(SmartAccount.execute, (address(counter), 0, abi.encodeCall(Counter.increment, ())));
+        PackedUserOperation memory opA = _buildUserOp(callDataA);
+        opA.signature = _signUserOp(opA, privA);
+
+        PackedUserOperation[] memory ops = new PackedUserOperation[](1);
+        ops[0] = opA;
+        entryPoint.handleOps(ops, beneficiary);
+        assertEq(counter.getCount(address(account)), 1);
+
+        // keyB can setNumber
+        bytes memory callDataB =
+            abi.encodeCall(SmartAccount.execute, (address(counter), 0, abi.encodeCall(Counter.setNumber, (42))));
+        PackedUserOperation memory opB = _buildUserOp(callDataB);
+        opB.signature = _signUserOp(opB, privB);
+
+        ops[0] = opB;
+        entryPoint.handleOps(ops, beneficiary);
+        assertEq(counter.getCount(address(account)), 42);
+
+        // keyA cannot setNumber (wrong selector for keyA)
+        bytes memory callDataBad =
+            abi.encodeCall(SmartAccount.execute, (address(counter), 0, abi.encodeCall(Counter.setNumber, (99))));
+        PackedUserOperation memory opBad = _buildUserOp(callDataBad);
+        opBad.signature = _signUserOp(opBad, privA);
+        bytes32 opBadHash = this.getUserOpHash(opBad);
+
+        vm.prank(address(entryPoint));
+        uint256 validationData = account.validateUserOp(opBad, opBadHash, 0);
+        assertEq(validationData, 1); // SIG_VALIDATION_FAILED
+    }
+
+    function test_validateUserOp_sessionKey_selfCallRejected() public {
+        (address sessionKey, uint256 sessionPrivKey) = makeAddrAndKey("sessionKey");
+
+        vm.prank(owner);
+        account.registerSessionKey(sessionKey, address(counter), Counter.increment.selector, uint48(100), uint48(5000));
+
+        // Session key tries to call registerSessionKey on the account itself.
+        // Target is address(account) instead of address(counter) → target mismatch.
+        bytes memory innerData = abi.encodeCall(
+            SmartAccount.registerSessionKey,
+            (makeAddr("evil"), address(counter), Counter.increment.selector, uint48(0), uint48(9999))
+        );
+        bytes memory callData = abi.encodeCall(SmartAccount.execute, (address(account), 0, innerData));
+        PackedUserOperation memory userOp = _buildUserOp(callData);
+        userOp.signature = _signUserOp(userOp, sessionPrivKey);
+        bytes32 userOpHash = this.getUserOpHash(userOp);
+
+        vm.prank(address(entryPoint));
+        uint256 validationData = account.validateUserOp(userOp, userOpHash, 0);
+        assertEq(validationData, 1); // SIG_VALIDATION_FAILED — target mismatch
+    }
+
+    // ─────────────── Execution: ETH forwarding & reverts ──────────────
+
+    function test_execute_forwardsEthValue() public {
+        address payable recipient = payable(makeAddr("recipient"));
+        uint256 sendAmount = 0.5 ether;
+        uint256 recipientBefore = recipient.balance;
+
+        vm.prank(owner);
+        account.execute(recipient, sendAmount, "");
+
+        assertEq(recipient.balance, recipientBefore + sendAmount);
+    }
+
+    function test_execute_revertsOnFailedCall() public {
+        Reverter reverter = new Reverter();
+
+        vm.prank(owner);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                SmartAccount.CallFailed.selector, abi.encodeWithSelector(Reverter.AlwaysReverts.selector)
+            )
+        );
+        account.execute(address(reverter), 0, abi.encodeCall(Reverter.fail, ()));
+    }
+
+    function test_executeBatch_forwardsEthValues() public {
+        address payable recipientA = payable(makeAddr("recipientA"));
+        address payable recipientB = payable(makeAddr("recipientB"));
+
+        address[] memory targets = new address[](2);
+        targets[0] = recipientA;
+        targets[1] = recipientB;
+
+        uint256[] memory values = new uint256[](2);
+        values[0] = 0.3 ether;
+        values[1] = 0.2 ether;
+
+        bytes[] memory calldatas = new bytes[](2);
+        calldatas[0] = "";
+        calldatas[1] = "";
+
+        vm.prank(owner);
+        account.executeBatch(targets, values, calldatas);
+
+        assertEq(recipientA.balance, 0.3 ether);
+        assertEq(recipientB.balance, 0.2 ether);
+    }
+
+    function test_executeBatch_revertsOnFailedCall() public {
+        Reverter reverter = new Reverter();
+
+        address[] memory targets = new address[](2);
+        targets[0] = address(counter);
+        targets[1] = address(reverter);
+
+        uint256[] memory values = new uint256[](2);
+
+        bytes[] memory calldatas = new bytes[](2);
+        calldatas[0] = abi.encodeCall(Counter.increment, ());
+        calldatas[1] = abi.encodeCall(Reverter.fail, ());
+
+        vm.prank(owner);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                SmartAccount.CallFailed.selector, abi.encodeWithSelector(Reverter.AlwaysReverts.selector)
+            )
+        );
+        account.executeBatch(targets, values, calldatas);
+    }
+
+    function test_executeBatch_viaEntryPoint() public {
+        address[] memory targets = new address[](2);
+        targets[0] = address(counter);
+        targets[1] = address(counter);
+
+        uint256[] memory values = new uint256[](2);
+
+        bytes[] memory calldatas = new bytes[](2);
+        calldatas[0] = abi.encodeCall(Counter.increment, ());
+        calldatas[1] = abi.encodeCall(Counter.increment, ());
+
+        bytes memory callData = abi.encodeCall(SmartAccount.executeBatch, (targets, values, calldatas));
+        PackedUserOperation memory userOp = _buildUserOp(callData);
+        userOp.signature = _signUserOp(userOp, ownerKey);
+
+        PackedUserOperation[] memory ops = new PackedUserOperation[](1);
+        ops[0] = userOp;
+        entryPoint.handleOps(ops, beneficiary);
+
+        assertEq(counter.getCount(address(account)), 2);
+    }
+}
+
+/// @notice Helper that always reverts — used to test execute/executeBatch error propagation.
+contract Reverter {
+    error AlwaysReverts();
+
+    function fail() external pure {
+        revert AlwaysReverts();
     }
 }

--- a/contracts/test/SmartAccount.t.sol
+++ b/contracts/test/SmartAccount.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.28;
 
-import {Test} from "forge-std/Test.sol";
+import {Test, Vm} from "forge-std/Test.sol";
 import {EntryPoint} from "@account-abstraction/contracts/core/EntryPoint.sol";
 import {IEntryPoint} from "@account-abstraction/contracts/interfaces/IEntryPoint.sol";
 import {PackedUserOperation} from "@account-abstraction/contracts/interfaces/PackedUserOperation.sol";
@@ -659,7 +659,6 @@ contract SmartAccountTest is Test {
         uint48 validAfter = uint48(100);
         uint48 validUntil = uint48(200);
 
-        vm.warp(150); // within valid window for registration
         vm.prank(owner);
         account.registerSessionKey(sessionKey, address(counter), Counter.increment.selector, validAfter, validUntil);
 
@@ -674,8 +673,14 @@ contract SmartAccountTest is Test {
         PackedUserOperation[] memory ops = new PackedUserOperation[](1);
         ops[0] = userOp;
 
-        vm.expectRevert(abi.encodeWithSelector(IEntryPoint.FailedOp.selector, 0, "AA22 expired or not due"));
-        entryPoint.handleOps(ops, beneficiary);
+        // Match on the selector only — the reason string is upstream-specific and may
+        // change across account-abstraction versions. The important assertion is that
+        // the EntryPoint rejects the operation via FailedOp.
+        try entryPoint.handleOps(ops, beneficiary) {
+            fail("handleOps should have reverted");
+        } catch (bytes memory reason) {
+            assertEq(bytes4(reason), IEntryPoint.FailedOp.selector);
+        }
     }
 
     function test_execute_sessionKey_notYetValidRejected() public {
@@ -698,8 +703,11 @@ contract SmartAccountTest is Test {
         PackedUserOperation[] memory ops = new PackedUserOperation[](1);
         ops[0] = userOp;
 
-        vm.expectRevert(abi.encodeWithSelector(IEntryPoint.FailedOp.selector, 0, "AA22 expired or not due"));
-        entryPoint.handleOps(ops, beneficiary);
+        try entryPoint.handleOps(ops, beneficiary) {
+            fail("handleOps should have reverted");
+        } catch (bytes memory reason) {
+            assertEq(bytes4(reason), IEntryPoint.FailedOp.selector);
+        }
     }
 
     function test_execute_sessionKey_multipleKeysIndependent() public {
@@ -750,17 +758,28 @@ contract SmartAccountTest is Test {
         assertEq(validationData, 1); // SIG_VALIDATION_FAILED
     }
 
-    function test_validateUserOp_sessionKey_selfCallRejected() public {
+    function test_execute_sessionKey_cannotEscalateViaSelfCall() public {
         (address sessionKey, uint256 sessionPrivKey) = makeAddrAndKey("sessionKey");
 
+        // Deliberately scope the session key to target the account itself with
+        // registerSessionKey's selector. _validateSessionKey passes (target, selector,
+        // and time bounds all match), but the self-call during execution hits
+        // onlyOwnerOrEntryPoint because msg.sender is address(account), not the
+        // EntryPoint or owner. Defense-in-depth: validation alone doesn't prevent
+        // this; the modifier does.
         vm.prank(owner);
-        account.registerSessionKey(sessionKey, address(counter), Counter.increment.selector, uint48(100), uint48(5000));
+        account.registerSessionKey(
+            sessionKey,
+            address(account),
+            SmartAccount.registerSessionKey.selector,
+            uint48(block.timestamp),
+            uint48(block.timestamp + 1 hours)
+        );
 
-        // Session key tries to call registerSessionKey on the account itself.
-        // Target is address(account) instead of address(counter) → target mismatch.
+        // Validation should pass — target and selector match the session key scope.
         bytes memory innerData = abi.encodeCall(
             SmartAccount.registerSessionKey,
-            (makeAddr("evil"), address(counter), Counter.increment.selector, uint48(0), uint48(9999))
+            (makeAddr("evil"), address(counter), Counter.increment.selector, uint48(100), uint48(9999))
         );
         bytes memory callData = abi.encodeCall(SmartAccount.execute, (address(account), 0, innerData));
         PackedUserOperation memory userOp = _buildUserOp(callData);
@@ -769,7 +788,37 @@ contract SmartAccountTest is Test {
 
         vm.prank(address(entryPoint));
         uint256 validationData = account.validateUserOp(userOp, userOpHash, 0);
-        assertEq(validationData, 1); // SIG_VALIDATION_FAILED — target mismatch
+        // Validation succeeds (not 0 = owner success, not 1 = failed) — returns packed time bounds.
+        assertNotEq(validationData, 1, "validation should pass for scoped self-call");
+
+        // But the full flow through handleOps records success=false: the inner
+        // self-call reverts with OnlyOwnerOrEntryPoint because msg.sender is
+        // address(account) during the delegated call.
+        PackedUserOperation[] memory ops = new PackedUserOperation[](1);
+        ops[0] = userOp;
+
+        vm.recordLogs();
+        entryPoint.handleOps(ops, beneficiary);
+
+        // The UserOperationEvent's success field (4th non-indexed param) should be false.
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        bool foundEvent = false;
+        for (uint256 i = 0; i < logs.length; i++) {
+            if (
+                logs[i].topics[0]
+                    == keccak256("UserOperationEvent(bytes32,address,address,uint256,bool,uint256,uint256)")
+            ) {
+                (, bool success,,) = abi.decode(logs[i].data, (uint256, bool, uint256, uint256));
+                assertFalse(success, "self-call should fail at execution time");
+                foundEvent = true;
+                break;
+            }
+        }
+        assertTrue(foundEvent, "UserOperationEvent not emitted");
+
+        // Confirm the escalation had no effect: "evil" key was not registered.
+        (,,, uint48 evilValidUntil) = account.sessionKeys(makeAddr("evil"));
+        assertEq(evilValidUntil, 0, "evil session key must not be registered");
     }
 
     // ─────────────── Execution: ETH forwarding & reverts ──────────────

--- a/contracts/test/SmartAccount.t.sol
+++ b/contracts/test/SmartAccount.t.sol
@@ -800,7 +800,7 @@ contract SmartAccountTest is Test {
         vm.recordLogs();
         entryPoint.handleOps(ops, beneficiary);
 
-        // The UserOperationEvent's success field (4th non-indexed param) should be false.
+        // The UserOperationEvent's success field (2nd non-indexed param) should be false.
         Vm.Log[] memory logs = vm.getRecordedLogs();
         bool foundEvent = false;
         for (uint256 i = 0; i < logs.length; i++) {


### PR DESCRIPTION
## What

Add 9 new SmartAccount tests covering critical paths that were missing from the existing suite. Total SmartAccount tests: 40 → 49 (56 across all suites). Also applies `forge fmt` to SmartAccount.sol (formatting only, no logic changes).

## Why

Issue #6 targets full critical-path coverage ahead of oral defense. The existing tests covered initialization, ECDSA validation, session key CRUD, and calldata attack vectors — but missed time-bound enforcement, ETH forwarding, revert propagation, batch-via-EntryPoint, multi-key independence, and privilege-escalation prevention.

## Scope

- [ ] Contracts
- [ ] Backend
- [ ] Frontend
- [ ] Tooling / CI
- [ ] Documentation
- [x] Test

## How to verify

```sh
cd contracts && forge test -vvv
```

All 56 tests pass (49 SmartAccount + 7 Counter). New tests:

| Test | Covers |
|------|--------|
| `test_execute_sessionKey_expiredKeyRejected` | EP rejects expired session key (`vm.warp` past `validUntil`) |
| `test_execute_sessionKey_notYetValidRejected` | EP rejects not-yet-valid key (`vm.warp` before `validAfter`) |
| `test_execute_sessionKey_multipleKeysIndependent` | Two keys with different selector scopes; cross-scope rejected |
| `test_execute_sessionKey_cannotEscalateViaSelfCall` | Session key scoped to `account.registerSessionKey` passes validation but fails at execution (`onlyOwnerOrEntryPoint` blocks the self-call) — defense-in-depth |
| `test_execute_forwardsEthValue` | `execute` forwards ETH to recipient |
| `test_execute_revertsOnFailedCall` | `execute` propagates `CallFailed` on inner revert |
| `test_executeBatch_forwardsEthValues` | Batch with ETH value forwarding |
| `test_executeBatch_revertsOnFailedCall` | Batch reverts on inner call failure |
| `test_executeBatch_viaEntryPoint` | Full `handleOps` flow with batch execution |

**Note:** SmartAccountFactory tests (19 tests) are on #31. An initCode-deploy-via-EntryPoint integration test should be added once the factory merges.

## Related issues

Closes #6