### PR TITLE
feat(indexer): index UserOperationEvent with polling, cursor resume, and calldata decoding

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,5 +41,11 @@ RPC_URL=https://eth-sepolia.g.alchemy.com/v2/YOUR_KEY
 # Optional: timeout per JSON-RPC request (default: 15s)
 # INDEXER_REQUEST_TIMEOUT=15s
 
+# Optional: concurrent JSON-RPC calls for tx/block enrichment (default: 8)
+# INDEXER_RPC_CONCURRENCY=8
+
+# Optional: disable tx input decoding/enrichment to reduce RPC load (default: true)
+# INDEXER_ENABLE_TX_ENRICHMENT=true
+
 # HTTP port for the indexer API (default: 3001)
 # PORT=3001

--- a/.env.example
+++ b/.env.example
@@ -47,5 +47,8 @@ RPC_URL=https://eth-sepolia.g.alchemy.com/v2/YOUR_KEY
 # Optional: disable tx input decoding/enrichment to reduce RPC load (default: true)
 # INDEXER_ENABLE_TX_ENRICHMENT=true
 
+# Optional: allow destructive trim if cursor is ahead of safe head (default: false)
+# INDEXER_ALLOW_CURSOR_TRIM=false
+
 # HTTP port for the indexer API (default: 3001)
 # PORT=3001

--- a/.env.example
+++ b/.env.example
@@ -19,5 +19,27 @@ DATABASE_URL=postgres://bastion:bastion@localhost:5432/bastion?sslmode=disable
 # JSON-RPC endpoint for the chain to index
 RPC_URL=https://eth-sepolia.g.alchemy.com/v2/YOUR_KEY
 
+# Optional: override EntryPoint address (defaults to canonical v0.7)
+# ENTRYPOINT=0x0000000071727De22E5E9d8BAf0edAc6f37da032
+
+# Optional: first block to begin indexing from.
+# If omitted and no cursor exists, the indexer starts at current safe head.
+# INDEXER_START_BLOCK=0
+
+# Optional: max blocks per eth_getLogs request (default: 500)
+# INDEXER_BATCH_SIZE=500
+
+# Optional: confirmation depth before indexing blocks (default: 3)
+# INDEXER_CONFIRMATIONS=3
+
+# Optional: rewind window from cursor on each loop (default: confirmations)
+# INDEXER_REORG_WINDOW=3
+
+# Optional: polling interval for new ranges (default: 4s)
+# INDEXER_POLL_INTERVAL=4s
+
+# Optional: timeout per JSON-RPC request (default: 15s)
+# INDEXER_REQUEST_TIMEOUT=15s
+
 # HTTP port for the indexer API (default: 3001)
 # PORT=3001

--- a/.env.example
+++ b/.env.example
@@ -44,6 +44,9 @@ RPC_URL=https://eth-sepolia.g.alchemy.com/v2/YOUR_KEY
 # Optional: concurrent JSON-RPC calls for tx/block enrichment (default: 8)
 # INDEXER_RPC_CONCURRENCY=8
 
+# Optional: max JSON-RPC response bytes before adaptive range splitting (default: 8388608)
+# INDEXER_RPC_RESPONSE_MAX_BYTES=8388608
+
 # Optional: disable tx input decoding/enrichment to reduce RPC load (default: true)
 # INDEXER_ENABLE_TX_ENRICHMENT=true
 

--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ Optional indexer env vars:
 - `INDEXER_REORG_WINDOW` — rewind window from cursor each loop (default = confirmations)
 - `INDEXER_POLL_INTERVAL` — polling interval (default `4s`)
 - `INDEXER_REQUEST_TIMEOUT` — per-RPC request timeout (default `15s`)
+- `INDEXER_RPC_CONCURRENCY` — max concurrent RPC calls for tx/block enrichment (default `8`)
+- `INDEXER_ENABLE_TX_ENRICHMENT` — toggle tx input decoding for `target`/`calldata` enrichment (default `true`)
 
 ### Makefile (all components)
 

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Optional indexer env vars:
 - `INDEXER_REQUEST_TIMEOUT` — per-RPC request timeout (default `15s`)
 - `INDEXER_RPC_CONCURRENCY` — max concurrent RPC calls for tx/block enrichment (default `8`)
 - `INDEXER_ENABLE_TX_ENRICHMENT` — toggle tx input decoding for `target`/`calldata` enrichment (default `true`)
+- `INDEXER_ALLOW_CURSOR_TRIM` — allow destructive trim when cursor is ahead of safe head (default `false`)
 
 ### Makefile (all components)
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,21 @@ go build ./cmd/indexer
 go run ./cmd/indexer   # Starts on http://localhost:3001
 ```
 
+Required env vars:
+
+- `DATABASE_URL` — PostgreSQL DSN
+- `RPC_URL` — chain JSON-RPC endpoint
+
+Optional indexer env vars:
+
+- `ENTRYPOINT` — override EntryPoint address (default: canonical v0.7)
+- `INDEXER_START_BLOCK` — initial block when no cursor exists
+- `INDEXER_BATCH_SIZE` — max block span per `eth_getLogs` batch (default `500`)
+- `INDEXER_CONFIRMATIONS` — confirmation lag before indexing (default `3`)
+- `INDEXER_REORG_WINDOW` — rewind window from cursor each loop (default = confirmations)
+- `INDEXER_POLL_INTERVAL` — polling interval (default `4s`)
+- `INDEXER_REQUEST_TIMEOUT` — per-RPC request timeout (default `15s`)
+
 ### Makefile (all components)
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Optional indexer env vars:
 - `INDEXER_POLL_INTERVAL` — polling interval (default `4s`)
 - `INDEXER_REQUEST_TIMEOUT` — per-RPC request timeout (default `15s`)
 - `INDEXER_RPC_CONCURRENCY` — max concurrent RPC calls for tx/block enrichment (default `8`)
+- `INDEXER_RPC_RESPONSE_MAX_BYTES` — max RPC response size before adaptive range splitting (default `8388608`)
 - `INDEXER_ENABLE_TX_ENRICHMENT` — toggle tx input decoding for `target`/`calldata` enrichment (default `true`)
 - `INDEXER_ALLOW_CURSOR_TRIM` — allow destructive trim when cursor is ahead of safe head (default `false`)
 

--- a/indexer/cmd/indexer/main.go
+++ b/indexer/cmd/indexer/main.go
@@ -60,12 +60,13 @@ func run() error {
 		return fmt.Errorf("init indexer service: %w", err)
 	}
 
-	workerErrCh := make(chan error, 1)
+	workerResultCh := make(chan error, 1)
 	go func() {
-		if runErr := svc.Run(ctx); runErr != nil {
-			workerErrCh <- runErr
+		runErr := svc.Run(ctx)
+		if runErr != nil {
 			cancel()
 		}
+		workerResultCh <- runErr
 	}()
 
 	mux := http.NewServeMux()
@@ -105,16 +106,22 @@ func run() error {
 	}()
 
 	slog.Info("indexer API listening", "port", port)
-	if err := srv.ListenAndServe(); err != http.ErrServerClosed {
-		return fmt.Errorf("server: %w", err)
+	listenErr := srv.ListenAndServe()
+	if listenErr != nil && listenErr != http.ErrServerClosed {
+		cancel()
 	}
 
-	select {
-	case workerErr := <-workerErrCh:
+	workerErr := <-workerResultCh
+
+	if listenErr != nil && listenErr != http.ErrServerClosed {
 		if workerErr != nil {
-			return fmt.Errorf("indexer worker: %w", workerErr)
+			return fmt.Errorf("server: %w (indexer worker: %v)", listenErr, workerErr)
 		}
-	default:
+		return fmt.Errorf("server: %w", listenErr)
+	}
+
+	if workerErr != nil {
+		return fmt.Errorf("indexer worker: %w", workerErr)
 	}
 
 	return nil

--- a/indexer/cmd/indexer/main.go
+++ b/indexer/cmd/indexer/main.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/flwrenn/bastion/indexer/internal/db"
+	"github.com/flwrenn/bastion/indexer/internal/indexer"
 )
 
 func main() {
@@ -34,6 +35,11 @@ func run() error {
 		return fmt.Errorf("DATABASE_URL is not set")
 	}
 
+	indexerConfig, err := indexer.LoadConfigFromEnv()
+	if err != nil {
+		return fmt.Errorf("load indexer config: %w", err)
+	}
+
 	// Connect to PostgreSQL and run pending migrations.
 	// Bounded so the process fails fast if the DB is unreachable.
 	startupCtx, startupCancel := context.WithTimeout(ctx, 15*time.Second)
@@ -48,6 +54,19 @@ func run() error {
 	if err := db.Migrate(startupCtx, pool); err != nil {
 		return fmt.Errorf("run migrations: %w", err)
 	}
+
+	svc, err := indexer.New(indexerConfig, pool)
+	if err != nil {
+		return fmt.Errorf("init indexer service: %w", err)
+	}
+
+	workerErrCh := make(chan error, 1)
+	go func() {
+		if runErr := svc.Run(ctx); runErr != nil {
+			workerErrCh <- runErr
+			cancel()
+		}
+	}()
 
 	mux := http.NewServeMux()
 
@@ -89,5 +108,14 @@ func run() error {
 	if err := srv.ListenAndServe(); err != http.ErrServerClosed {
 		return fmt.Errorf("server: %w", err)
 	}
+
+	select {
+	case workerErr := <-workerErrCh:
+		if workerErr != nil {
+			return fmt.Errorf("indexer worker: %w", workerErr)
+		}
+	default:
+	}
+
 	return nil
 }

--- a/indexer/internal/db/state.go
+++ b/indexer/internal/db/state.go
@@ -12,6 +12,10 @@ import (
 )
 
 func GetState(ctx context.Context, pool *pgxpool.Pool, key string) (string, bool, error) {
+	if pool == nil {
+		return "", false, fmt.Errorf("pool is required")
+	}
+
 	var value string
 	err := pool.QueryRow(ctx, "SELECT value FROM indexer_state WHERE key = $1", key).Scan(&value)
 	if err != nil {
@@ -60,6 +64,10 @@ func TrimOperationsAboveBlockAndSetCursor(
 	stateKey string,
 	safeHead uint64,
 ) error {
+	if pool == nil {
+		return fmt.Errorf("pool is required")
+	}
+
 	if safeHead > math.MaxInt64 {
 		return fmt.Errorf("safe head %d overflows int64", safeHead)
 	}

--- a/indexer/internal/db/state.go
+++ b/indexer/internal/db/state.go
@@ -1,0 +1,54 @@
+package db
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+func GetState(ctx context.Context, pool *pgxpool.Pool, key string) (string, bool, error) {
+	var value string
+	err := pool.QueryRow(ctx, "SELECT value FROM indexer_state WHERE key = $1", key).Scan(&value)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return "", false, nil
+		}
+		return "", false, fmt.Errorf("query state %q: %w", key, err)
+	}
+	return value, true, nil
+}
+
+func GetStateUint64(ctx context.Context, pool *pgxpool.Pool, key string) (uint64, bool, error) {
+	value, ok, err := GetState(ctx, pool, key)
+	if err != nil {
+		return 0, false, err
+	}
+	if !ok {
+		return 0, false, nil
+	}
+
+	parsed, err := strconv.ParseUint(value, 10, 64)
+	if err != nil {
+		return 0, false, fmt.Errorf("parse state %q value %q as uint64: %w", key, value, err)
+	}
+
+	return parsed, true, nil
+}
+
+func setStateTx(ctx context.Context, tx pgx.Tx, key, value string) error {
+	_, err := tx.Exec(ctx, `
+		INSERT INTO indexer_state (key, value)
+		VALUES ($1, $2)
+		ON CONFLICT (key)
+		DO UPDATE SET value = EXCLUDED.value
+	`, key, value)
+	if err != nil {
+		return fmt.Errorf("upsert state %q: %w", key, err)
+	}
+
+	return nil
+}

--- a/indexer/internal/db/state.go
+++ b/indexer/internal/db/state.go
@@ -45,6 +45,10 @@ func GetStateUint64(ctx context.Context, pool *pgxpool.Pool, key string) (uint64
 }
 
 func setStateTx(ctx context.Context, tx pgx.Tx, key, value string) error {
+	if key == "" {
+		return fmt.Errorf("state key is required")
+	}
+
 	_, err := tx.Exec(ctx, `
 		INSERT INTO indexer_state (key, value)
 		VALUES ($1, $2)
@@ -64,6 +68,9 @@ func TrimOperationsAboveBlockAndSetCursor(
 	stateKey string,
 	safeHead uint64,
 ) error {
+	if stateKey == "" {
+		return fmt.Errorf("state key is required")
+	}
 	if pool == nil {
 		return fmt.Errorf("pool is required")
 	}

--- a/indexer/internal/db/state.go
+++ b/indexer/internal/db/state.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"strconv"
 
 	"github.com/jackc/pgx/v5"
@@ -48,6 +49,40 @@ func setStateTx(ctx context.Context, tx pgx.Tx, key, value string) error {
 	`, key, value)
 	if err != nil {
 		return fmt.Errorf("upsert state %q: %w", key, err)
+	}
+
+	return nil
+}
+
+func TrimOperationsAboveBlockAndSetCursor(
+	ctx context.Context,
+	pool *pgxpool.Pool,
+	stateKey string,
+	safeHead uint64,
+) error {
+	if safeHead > math.MaxInt64 {
+		return fmt.Errorf("safe head %d overflows int64", safeHead)
+	}
+
+	tx, err := pool.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback(ctx)
+
+	if _, err := tx.Exec(ctx,
+		"DELETE FROM user_operations WHERE block_number > $1",
+		int64(safeHead),
+	); err != nil {
+		return fmt.Errorf("delete operations above safe head %d: %w", safeHead, err)
+	}
+
+	if err := setStateTx(ctx, tx, stateKey, strconv.FormatUint(safeHead, 10)); err != nil {
+		return err
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("commit tx: %w", err)
 	}
 
 	return nil

--- a/indexer/internal/db/state_test.go
+++ b/indexer/internal/db/state_test.go
@@ -2,21 +2,49 @@ package db
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 )
+
+func TestGetStateRejectsNilPool(t *testing.T) {
+	t.Parallel()
+
+	_, _, err := GetState(context.Background(), nil, "cursor")
+	if err == nil {
+		t.Fatal("expected nil-pool error")
+	}
+	if !strings.Contains(err.Error(), "pool is required") {
+		t.Fatalf("expected pool error, got %v", err)
+	}
+}
+
+func TestTrimOperationsAboveBlockAndSetCursorRejectsNilPool(t *testing.T) {
+	t.Parallel()
+
+	err := TrimOperationsAboveBlockAndSetCursor(context.Background(), nil, "cursor", 1)
+	if err == nil {
+		t.Fatal("expected nil-pool error")
+	}
+	if !strings.Contains(err.Error(), "pool is required") {
+		t.Fatalf("expected pool error, got %v", err)
+	}
+}
 
 func TestTrimOperationsAboveBlockAndSetCursorRejectsOverflow(t *testing.T) {
 	t.Parallel()
 
 	err := TrimOperationsAboveBlockAndSetCursor(
 		context.Background(),
-		(*pgxpool.Pool)(nil),
+		&pgxpool.Pool{},
 		"cursor",
 		^uint64(0),
 	)
 	if err == nil {
 		t.Fatal("expected overflow error")
+	}
+	if !strings.Contains(err.Error(), "overflows int64") {
+		t.Fatalf("expected overflow error, got %v", err)
 	}
 }

--- a/indexer/internal/db/state_test.go
+++ b/indexer/internal/db/state_test.go
@@ -32,6 +32,18 @@ func TestTrimOperationsAboveBlockAndSetCursorRejectsNilPool(t *testing.T) {
 	}
 }
 
+func TestTrimOperationsAboveBlockAndSetCursorRejectsEmptyStateKey(t *testing.T) {
+	t.Parallel()
+
+	err := TrimOperationsAboveBlockAndSetCursor(context.Background(), nil, "", 1)
+	if err == nil {
+		t.Fatal("expected state key error")
+	}
+	if !strings.Contains(err.Error(), "state key is required") {
+		t.Fatalf("expected state key error, got %v", err)
+	}
+}
+
 func TestTrimOperationsAboveBlockAndSetCursorRejectsOverflow(t *testing.T) {
 	t.Parallel()
 

--- a/indexer/internal/db/state_test.go
+++ b/indexer/internal/db/state_test.go
@@ -1,0 +1,22 @@
+package db
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+func TestTrimOperationsAboveBlockAndSetCursorRejectsOverflow(t *testing.T) {
+	t.Parallel()
+
+	err := TrimOperationsAboveBlockAndSetCursor(
+		context.Background(),
+		(*pgxpool.Pool)(nil),
+		"cursor",
+		^uint64(0),
+	)
+	if err == nil {
+		t.Fatal("expected overflow error")
+	}
+}

--- a/indexer/internal/db/user_operations.go
+++ b/indexer/internal/db/user_operations.go
@@ -1,0 +1,106 @@
+package db
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"strconv"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+func ReplaceOperationsAndSetCursor(
+	ctx context.Context,
+	pool *pgxpool.Pool,
+	stateKey string,
+	fromBlock uint64,
+	toBlock uint64,
+	cursor uint64,
+	operations []UserOperation,
+) error {
+	if fromBlock > toBlock {
+		return fmt.Errorf("invalid block range: from %d > to %d", fromBlock, toBlock)
+	}
+
+	from, err := toInt64(fromBlock)
+	if err != nil {
+		return fmt.Errorf("convert from block: %w", err)
+	}
+	to, err := toInt64(toBlock)
+	if err != nil {
+		return fmt.Errorf("convert to block: %w", err)
+	}
+
+	tx, err := pool.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback(ctx)
+
+	if _, err := tx.Exec(ctx,
+		"DELETE FROM user_operations WHERE block_number BETWEEN $1 AND $2",
+		from,
+		to,
+	); err != nil {
+		return fmt.Errorf("delete operations in range [%d,%d]: %w", fromBlock, toBlock, err)
+	}
+
+	for i := range operations {
+		op := operations[i]
+		if _, err := tx.Exec(ctx, `
+			INSERT INTO user_operations (
+				user_op_hash,
+				sender,
+				paymaster,
+				target,
+				calldata,
+				nonce,
+				success,
+				actual_gas_cost,
+				actual_gas_used,
+				tx_hash,
+				block_number,
+				block_timestamp,
+				log_index
+			)
+			VALUES (
+				$1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13
+			)
+			ON CONFLICT (tx_hash, log_index) DO NOTHING
+		`,
+			op.UserOpHash,
+			op.Sender,
+			op.Paymaster,
+			op.Target,
+			op.Calldata,
+			op.Nonce,
+			op.Success,
+			op.ActualGasCost,
+			op.ActualGasUsed,
+			op.TxHash,
+			op.BlockNumber,
+			op.BlockTimestamp,
+			op.LogIndex,
+		); err != nil {
+			return fmt.Errorf("insert operation at index %d: %w", i, err)
+		}
+	}
+
+	if err := setStateTx(ctx, tx, stateKey, strconv.FormatUint(cursor, 10)); err != nil {
+		return err
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("commit tx: %w", err)
+	}
+
+	return nil
+}
+
+func toInt64(v uint64) (int64, error) {
+	if v > math.MaxInt64 {
+		return 0, fmt.Errorf("value %d overflows int64", v)
+	}
+	return int64(v), nil
+}

--- a/indexer/internal/db/user_operations.go
+++ b/indexer/internal/db/user_operations.go
@@ -10,6 +10,39 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
+const upsertUserOperationSQL = `
+	INSERT INTO user_operations (
+		user_op_hash,
+		sender,
+		paymaster,
+		target,
+		calldata,
+		nonce,
+		success,
+		actual_gas_cost,
+		actual_gas_used,
+		tx_hash,
+		block_number,
+		block_timestamp,
+		log_index
+	)
+	VALUES (
+		$1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13
+	)
+	ON CONFLICT (tx_hash, log_index) DO UPDATE SET
+		user_op_hash = EXCLUDED.user_op_hash,
+		sender = EXCLUDED.sender,
+		paymaster = EXCLUDED.paymaster,
+		target = EXCLUDED.target,
+		calldata = EXCLUDED.calldata,
+		nonce = EXCLUDED.nonce,
+		success = EXCLUDED.success,
+		actual_gas_cost = EXCLUDED.actual_gas_cost,
+		actual_gas_used = EXCLUDED.actual_gas_used,
+		block_number = EXCLUDED.block_number,
+		block_timestamp = EXCLUDED.block_timestamp
+`
+
 func ReplaceOperationsAndSetCursor(
 	ctx context.Context,
 	pool *pgxpool.Pool,
@@ -46,55 +79,37 @@ func ReplaceOperationsAndSetCursor(
 		return fmt.Errorf("delete operations in range [%d,%d]: %w", fromBlock, toBlock, err)
 	}
 
-	for i := range operations {
-		op := operations[i]
-		if _, err := tx.Exec(ctx, `
-			INSERT INTO user_operations (
-				user_op_hash,
-				sender,
-				paymaster,
-				target,
-				calldata,
-				nonce,
-				success,
-				actual_gas_cost,
-				actual_gas_used,
-				tx_hash,
-				block_number,
-				block_timestamp,
-				log_index
+	if len(operations) > 0 {
+		batch := &pgx.Batch{}
+		for i := range operations {
+			op := operations[i]
+			batch.Queue(
+				upsertUserOperationSQL,
+				op.UserOpHash,
+				op.Sender,
+				op.Paymaster,
+				op.Target,
+				op.Calldata,
+				op.Nonce,
+				op.Success,
+				op.ActualGasCost,
+				op.ActualGasUsed,
+				op.TxHash,
+				op.BlockNumber,
+				op.BlockTimestamp,
+				op.LogIndex,
 			)
-			VALUES (
-				$1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13
-			)
-			ON CONFLICT (tx_hash, log_index) DO UPDATE SET
-				user_op_hash = EXCLUDED.user_op_hash,
-				sender = EXCLUDED.sender,
-				paymaster = EXCLUDED.paymaster,
-				target = EXCLUDED.target,
-				calldata = EXCLUDED.calldata,
-				nonce = EXCLUDED.nonce,
-				success = EXCLUDED.success,
-				actual_gas_cost = EXCLUDED.actual_gas_cost,
-				actual_gas_used = EXCLUDED.actual_gas_used,
-				block_number = EXCLUDED.block_number,
-				block_timestamp = EXCLUDED.block_timestamp
-		`,
-			op.UserOpHash,
-			op.Sender,
-			op.Paymaster,
-			op.Target,
-			op.Calldata,
-			op.Nonce,
-			op.Success,
-			op.ActualGasCost,
-			op.ActualGasUsed,
-			op.TxHash,
-			op.BlockNumber,
-			op.BlockTimestamp,
-			op.LogIndex,
-		); err != nil {
-			return fmt.Errorf("insert operation at index %d: %w", i, err)
+		}
+
+		results := tx.SendBatch(ctx, batch)
+		for i := range operations {
+			if _, err := results.Exec(); err != nil {
+				_ = results.Close()
+				return fmt.Errorf("insert operation at index %d: %w", i, err)
+			}
+		}
+		if err := results.Close(); err != nil {
+			return fmt.Errorf("close operation batch: %w", err)
 		}
 	}
 

--- a/indexer/internal/db/user_operations.go
+++ b/indexer/internal/db/user_operations.go
@@ -67,7 +67,18 @@ func ReplaceOperationsAndSetCursor(
 			VALUES (
 				$1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13
 			)
-			ON CONFLICT (tx_hash, log_index) DO NOTHING
+			ON CONFLICT (tx_hash, log_index) DO UPDATE SET
+				user_op_hash = EXCLUDED.user_op_hash,
+				sender = EXCLUDED.sender,
+				paymaster = EXCLUDED.paymaster,
+				target = EXCLUDED.target,
+				calldata = EXCLUDED.calldata,
+				nonce = EXCLUDED.nonce,
+				success = EXCLUDED.success,
+				actual_gas_cost = EXCLUDED.actual_gas_cost,
+				actual_gas_used = EXCLUDED.actual_gas_used,
+				block_number = EXCLUDED.block_number,
+				block_timestamp = EXCLUDED.block_timestamp
 		`,
 			op.UserOpHash,
 			op.Sender,

--- a/indexer/internal/db/user_operations.go
+++ b/indexer/internal/db/user_operations.go
@@ -52,6 +52,13 @@ func ReplaceOperationsAndSetCursor(
 	cursor uint64,
 	operations []UserOperation,
 ) error {
+	if stateKey == "" {
+		return fmt.Errorf("state key is required")
+	}
+	if pool == nil {
+		return fmt.Errorf("pool is required")
+	}
+
 	if fromBlock > toBlock {
 		return fmt.Errorf("invalid block range: from %d > to %d", fromBlock, toBlock)
 	}

--- a/indexer/internal/db/user_operations.go
+++ b/indexer/internal/db/user_operations.go
@@ -3,9 +3,9 @@ package db
 import (
 	"context"
 	"fmt"
-	"math"
 	"strconv"
 
+	"github.com/flwrenn/bastion/indexer/internal/numconv"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
@@ -125,8 +125,5 @@ func ReplaceOperationsAndSetCursor(
 }
 
 func toInt64(v uint64) (int64, error) {
-	if v > math.MaxInt64 {
-		return 0, fmt.Errorf("value %d overflows int64", v)
-	}
-	return int64(v), nil
+	return numconv.Uint64ToInt64(v)
 }

--- a/indexer/internal/db/user_operations_test.go
+++ b/indexer/internal/db/user_operations_test.go
@@ -1,0 +1,47 @@
+package db
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestReplaceOperationsAndSetCursorRejectsNilPool(t *testing.T) {
+	t.Parallel()
+
+	err := ReplaceOperationsAndSetCursor(
+		context.Background(),
+		nil,
+		"user_operations.last_indexed_block",
+		0,
+		0,
+		0,
+		nil,
+	)
+	if err == nil {
+		t.Fatal("expected nil-pool error")
+	}
+	if !strings.Contains(err.Error(), "pool is required") {
+		t.Fatalf("expected pool error, got %v", err)
+	}
+}
+
+func TestReplaceOperationsAndSetCursorRejectsEmptyStateKey(t *testing.T) {
+	t.Parallel()
+
+	err := ReplaceOperationsAndSetCursor(
+		context.Background(),
+		nil,
+		"",
+		0,
+		0,
+		0,
+		nil,
+	)
+	if err == nil {
+		t.Fatal("expected state key error")
+	}
+	if !strings.Contains(err.Error(), "state key is required") {
+		t.Fatalf("expected state key error, got %v", err)
+	}
+}

--- a/indexer/internal/indexer/config.go
+++ b/indexer/internal/indexer/config.go
@@ -31,6 +31,7 @@ type Config struct {
 	RequestTimeout     time.Duration
 	RPCConcurrency     int
 	EnableTxEnrichment bool
+	AllowCursorTrim    bool
 	StateKey           string
 }
 
@@ -136,6 +137,14 @@ func LoadConfigFromEnv() (Config, error) {
 			return Config{}, fmt.Errorf("parse INDEXER_ENABLE_TX_ENRICHMENT: %w", err)
 		}
 		cfg.EnableTxEnrichment = enabled
+	}
+
+	if value := strings.TrimSpace(os.Getenv("INDEXER_ALLOW_CURSOR_TRIM")); value != "" {
+		enabled, err := strconv.ParseBool(value)
+		if err != nil {
+			return Config{}, fmt.Errorf("parse INDEXER_ALLOW_CURSOR_TRIM: %w", err)
+		}
+		cfg.AllowCursorTrim = enabled
 	}
 
 	return cfg, nil

--- a/indexer/internal/indexer/config.go
+++ b/indexer/internal/indexer/config.go
@@ -14,32 +14,37 @@ const (
 	defaultConfirmations  = uint64(3)
 	defaultPollInterval   = 4 * time.Second
 	defaultRequestTimeout = 15 * time.Second
+	defaultRPCConcurrency = 8
 
 	stateKeyLastIndexedBlock = "user_operations.last_indexed_block"
 )
 
 type Config struct {
-	RPCURL         string
-	EntryPoint     string
-	StartBlock     uint64
-	HasStartBlock  bool
-	BatchSize      uint64
-	Confirmations  uint64
-	ReorgWindow    uint64
-	PollInterval   time.Duration
-	RequestTimeout time.Duration
-	StateKey       string
+	RPCURL             string
+	EntryPoint         string
+	StartBlock         uint64
+	HasStartBlock      bool
+	BatchSize          uint64
+	Confirmations      uint64
+	ReorgWindow        uint64
+	PollInterval       time.Duration
+	RequestTimeout     time.Duration
+	RPCConcurrency     int
+	EnableTxEnrichment bool
+	StateKey           string
 }
 
 func LoadConfigFromEnv() (Config, error) {
 	cfg := Config{
-		RPCURL:         strings.TrimSpace(os.Getenv("RPC_URL")),
-		EntryPoint:     defaultEntryPoint,
-		BatchSize:      defaultBatchSize,
-		Confirmations:  defaultConfirmations,
-		PollInterval:   defaultPollInterval,
-		RequestTimeout: defaultRequestTimeout,
-		StateKey:       stateKeyLastIndexedBlock,
+		RPCURL:             strings.TrimSpace(os.Getenv("RPC_URL")),
+		EntryPoint:         defaultEntryPoint,
+		BatchSize:          defaultBatchSize,
+		Confirmations:      defaultConfirmations,
+		PollInterval:       defaultPollInterval,
+		RequestTimeout:     defaultRequestTimeout,
+		RPCConcurrency:     defaultRPCConcurrency,
+		EnableTxEnrichment: true,
+		StateKey:           stateKeyLastIndexedBlock,
 	}
 
 	if cfg.RPCURL == "" {
@@ -112,6 +117,25 @@ func LoadConfigFromEnv() (Config, error) {
 			return Config{}, fmt.Errorf("INDEXER_REQUEST_TIMEOUT must be greater than 0")
 		}
 		cfg.RequestTimeout = timeout
+	}
+
+	if value := strings.TrimSpace(os.Getenv("INDEXER_RPC_CONCURRENCY")); value != "" {
+		concurrency, err := strconv.Atoi(value)
+		if err != nil {
+			return Config{}, fmt.Errorf("parse INDEXER_RPC_CONCURRENCY: %w", err)
+		}
+		if concurrency <= 0 {
+			return Config{}, fmt.Errorf("INDEXER_RPC_CONCURRENCY must be greater than 0")
+		}
+		cfg.RPCConcurrency = concurrency
+	}
+
+	if value := strings.TrimSpace(os.Getenv("INDEXER_ENABLE_TX_ENRICHMENT")); value != "" {
+		enabled, err := strconv.ParseBool(value)
+		if err != nil {
+			return Config{}, fmt.Errorf("parse INDEXER_ENABLE_TX_ENRICHMENT: %w", err)
+		}
+		cfg.EnableTxEnrichment = enabled
 	}
 
 	return cfg, nil

--- a/indexer/internal/indexer/config.go
+++ b/indexer/internal/indexer/config.go
@@ -1,0 +1,118 @@
+package indexer
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	defaultEntryPoint     = "0x0000000071727de22e5e9d8baf0edac6f37da032"
+	defaultBatchSize      = uint64(500)
+	defaultConfirmations  = uint64(3)
+	defaultPollInterval   = 4 * time.Second
+	defaultRequestTimeout = 15 * time.Second
+
+	stateKeyLastIndexedBlock = "user_operations.last_indexed_block"
+)
+
+type Config struct {
+	RPCURL         string
+	EntryPoint     string
+	StartBlock     uint64
+	HasStartBlock  bool
+	BatchSize      uint64
+	Confirmations  uint64
+	ReorgWindow    uint64
+	PollInterval   time.Duration
+	RequestTimeout time.Duration
+	StateKey       string
+}
+
+func LoadConfigFromEnv() (Config, error) {
+	cfg := Config{
+		RPCURL:         strings.TrimSpace(os.Getenv("RPC_URL")),
+		EntryPoint:     defaultEntryPoint,
+		BatchSize:      defaultBatchSize,
+		Confirmations:  defaultConfirmations,
+		PollInterval:   defaultPollInterval,
+		RequestTimeout: defaultRequestTimeout,
+		StateKey:       stateKeyLastIndexedBlock,
+	}
+
+	if cfg.RPCURL == "" {
+		return Config{}, fmt.Errorf("RPC_URL is not set")
+	}
+
+	if value := strings.TrimSpace(os.Getenv("ENTRYPOINT")); value != "" {
+		normalized, err := normalizeAddress(value)
+		if err != nil {
+			return Config{}, fmt.Errorf("parse ENTRYPOINT: %w", err)
+		}
+		cfg.EntryPoint = normalized
+	}
+
+	if value := strings.TrimSpace(os.Getenv("INDEXER_START_BLOCK")); value != "" {
+		start, err := strconv.ParseUint(value, 10, 64)
+		if err != nil {
+			return Config{}, fmt.Errorf("parse INDEXER_START_BLOCK: %w", err)
+		}
+		cfg.StartBlock = start
+		cfg.HasStartBlock = true
+	}
+
+	if value := strings.TrimSpace(os.Getenv("INDEXER_BATCH_SIZE")); value != "" {
+		batchSize, err := strconv.ParseUint(value, 10, 64)
+		if err != nil {
+			return Config{}, fmt.Errorf("parse INDEXER_BATCH_SIZE: %w", err)
+		}
+		if batchSize == 0 {
+			return Config{}, fmt.Errorf("INDEXER_BATCH_SIZE must be greater than 0")
+		}
+		cfg.BatchSize = batchSize
+	}
+
+	if value := strings.TrimSpace(os.Getenv("INDEXER_CONFIRMATIONS")); value != "" {
+		confirmations, err := strconv.ParseUint(value, 10, 64)
+		if err != nil {
+			return Config{}, fmt.Errorf("parse INDEXER_CONFIRMATIONS: %w", err)
+		}
+		cfg.Confirmations = confirmations
+	}
+
+	if value := strings.TrimSpace(os.Getenv("INDEXER_REORG_WINDOW")); value != "" {
+		reorgWindow, err := strconv.ParseUint(value, 10, 64)
+		if err != nil {
+			return Config{}, fmt.Errorf("parse INDEXER_REORG_WINDOW: %w", err)
+		}
+		cfg.ReorgWindow = reorgWindow
+	} else {
+		cfg.ReorgWindow = cfg.Confirmations
+	}
+
+	if value := strings.TrimSpace(os.Getenv("INDEXER_POLL_INTERVAL")); value != "" {
+		pollInterval, err := time.ParseDuration(value)
+		if err != nil {
+			return Config{}, fmt.Errorf("parse INDEXER_POLL_INTERVAL: %w", err)
+		}
+		if pollInterval <= 0 {
+			return Config{}, fmt.Errorf("INDEXER_POLL_INTERVAL must be greater than 0")
+		}
+		cfg.PollInterval = pollInterval
+	}
+
+	if value := strings.TrimSpace(os.Getenv("INDEXER_REQUEST_TIMEOUT")); value != "" {
+		timeout, err := time.ParseDuration(value)
+		if err != nil {
+			return Config{}, fmt.Errorf("parse INDEXER_REQUEST_TIMEOUT: %w", err)
+		}
+		if timeout <= 0 {
+			return Config{}, fmt.Errorf("INDEXER_REQUEST_TIMEOUT must be greater than 0")
+		}
+		cfg.RequestTimeout = timeout
+	}
+
+	return cfg, nil
+}

--- a/indexer/internal/indexer/config.go
+++ b/indexer/internal/indexer/config.go
@@ -15,37 +15,40 @@ const (
 	defaultPollInterval   = 4 * time.Second
 	defaultRequestTimeout = 15 * time.Second
 	defaultRPCConcurrency = 8
+	defaultRPCResponseMax = 8 * 1024 * 1024
 
 	stateKeyLastIndexedBlock = "user_operations.last_indexed_block"
 )
 
 type Config struct {
-	RPCURL             string
-	EntryPoint         string
-	StartBlock         uint64
-	HasStartBlock      bool
-	BatchSize          uint64
-	Confirmations      uint64
-	ReorgWindow        uint64
-	PollInterval       time.Duration
-	RequestTimeout     time.Duration
-	RPCConcurrency     int
-	EnableTxEnrichment bool
-	AllowCursorTrim    bool
-	StateKey           string
+	RPCURL              string
+	EntryPoint          string
+	StartBlock          uint64
+	HasStartBlock       bool
+	BatchSize           uint64
+	Confirmations       uint64
+	ReorgWindow         uint64
+	PollInterval        time.Duration
+	RequestTimeout      time.Duration
+	RPCConcurrency      int
+	RPCResponseMaxBytes int64
+	EnableTxEnrichment  bool
+	AllowCursorTrim     bool
+	StateKey            string
 }
 
 func LoadConfigFromEnv() (Config, error) {
 	cfg := Config{
-		RPCURL:             strings.TrimSpace(os.Getenv("RPC_URL")),
-		EntryPoint:         defaultEntryPoint,
-		BatchSize:          defaultBatchSize,
-		Confirmations:      defaultConfirmations,
-		PollInterval:       defaultPollInterval,
-		RequestTimeout:     defaultRequestTimeout,
-		RPCConcurrency:     defaultRPCConcurrency,
-		EnableTxEnrichment: true,
-		StateKey:           stateKeyLastIndexedBlock,
+		RPCURL:              strings.TrimSpace(os.Getenv("RPC_URL")),
+		EntryPoint:          defaultEntryPoint,
+		BatchSize:           defaultBatchSize,
+		Confirmations:       defaultConfirmations,
+		PollInterval:        defaultPollInterval,
+		RequestTimeout:      defaultRequestTimeout,
+		RPCConcurrency:      defaultRPCConcurrency,
+		RPCResponseMaxBytes: defaultRPCResponseMax,
+		EnableTxEnrichment:  true,
+		StateKey:            stateKeyLastIndexedBlock,
 	}
 
 	if cfg.RPCURL == "" {
@@ -129,6 +132,17 @@ func LoadConfigFromEnv() (Config, error) {
 			return Config{}, fmt.Errorf("INDEXER_RPC_CONCURRENCY must be greater than 0")
 		}
 		cfg.RPCConcurrency = concurrency
+	}
+
+	if value := strings.TrimSpace(os.Getenv("INDEXER_RPC_RESPONSE_MAX_BYTES")); value != "" {
+		limit, err := strconv.ParseInt(value, 10, 64)
+		if err != nil {
+			return Config{}, fmt.Errorf("parse INDEXER_RPC_RESPONSE_MAX_BYTES: %w", err)
+		}
+		if limit <= 0 {
+			return Config{}, fmt.Errorf("INDEXER_RPC_RESPONSE_MAX_BYTES must be greater than 0")
+		}
+		cfg.RPCResponseMaxBytes = limit
 	}
 
 	if value := strings.TrimSpace(os.Getenv("INDEXER_ENABLE_TX_ENRICHMENT")); value != "" {

--- a/indexer/internal/indexer/config.go
+++ b/indexer/internal/indexer/config.go
@@ -2,6 +2,7 @@ package indexer
 
 import (
 	"fmt"
+	"math"
 	"os"
 	"strconv"
 	"strings"
@@ -141,6 +142,9 @@ func LoadConfigFromEnv() (Config, error) {
 		}
 		if limit <= 0 {
 			return Config{}, fmt.Errorf("INDEXER_RPC_RESPONSE_MAX_BYTES must be greater than 0")
+		}
+		if limit >= math.MaxInt64 {
+			return Config{}, fmt.Errorf("INDEXER_RPC_RESPONSE_MAX_BYTES must be less than %d", math.MaxInt64)
 		}
 		cfg.RPCResponseMaxBytes = limit
 	}

--- a/indexer/internal/indexer/config_test.go
+++ b/indexer/internal/indexer/config_test.go
@@ -182,6 +182,11 @@ func TestLoadConfigFromEnv_InvalidNumericValues(t *testing.T) {
 	if _, err := LoadConfigFromEnv(); err == nil {
 		t.Fatal("expected rpc response max parse error")
 	}
+
+	t.Setenv("INDEXER_RPC_RESPONSE_MAX_BYTES", "9223372036854775807")
+	if _, err := LoadConfigFromEnv(); err == nil {
+		t.Fatal("expected rpc response max overflow-prone validation error")
+	}
 }
 
 func TestLoadConfigFromEnv_InvalidDurationsAndBools(t *testing.T) {

--- a/indexer/internal/indexer/config_test.go
+++ b/indexer/internal/indexer/config_test.go
@@ -1,0 +1,25 @@
+package indexer
+
+import "testing"
+
+func TestNormalizeAddress(t *testing.T) {
+	t.Parallel()
+
+	value, err := normalizeAddress("0x0000000071727De22E5E9d8BAf0edAc6f37da032")
+	if err != nil {
+		t.Fatalf("normalizeAddress returned error: %v", err)
+	}
+
+	const expected = "0x0000000071727de22e5e9d8baf0edac6f37da032"
+	if value != expected {
+		t.Fatalf("expected %q, got %q", expected, value)
+	}
+}
+
+func TestNormalizeAddressRejectsInvalidLength(t *testing.T) {
+	t.Parallel()
+
+	if _, err := normalizeAddress("0x1234"); err == nil {
+		t.Fatal("expected error for invalid address length")
+	}
+}

--- a/indexer/internal/indexer/config_test.go
+++ b/indexer/internal/indexer/config_test.go
@@ -1,6 +1,10 @@
 package indexer
 
-import "testing"
+import (
+	"strings"
+	"testing"
+	"time"
+)
 
 func TestNormalizeAddress(t *testing.T) {
 	t.Parallel()
@@ -36,4 +40,155 @@ func TestNormalizeAddressAcceptsUppercasePrefix(t *testing.T) {
 	if value != expected {
 		t.Fatalf("expected %q, got %q", expected, value)
 	}
+}
+
+func TestLoadConfigFromEnv_Defaults(t *testing.T) {
+	t.Setenv("RPC_URL", "https://rpc.example")
+	clearOptionalIndexerEnv(t)
+
+	cfg, err := LoadConfigFromEnv()
+	if err != nil {
+		t.Fatalf("LoadConfigFromEnv returned error: %v", err)
+	}
+
+	if cfg.RPCURL != "https://rpc.example" {
+		t.Fatalf("expected RPC_URL to be preserved, got %q", cfg.RPCURL)
+	}
+	if cfg.EntryPoint != defaultEntryPoint {
+		t.Fatalf("expected default entrypoint %q, got %q", defaultEntryPoint, cfg.EntryPoint)
+	}
+	if cfg.BatchSize != defaultBatchSize {
+		t.Fatalf("expected default batch size %d, got %d", defaultBatchSize, cfg.BatchSize)
+	}
+	if cfg.Confirmations != defaultConfirmations {
+		t.Fatalf("expected default confirmations %d, got %d", defaultConfirmations, cfg.Confirmations)
+	}
+	if cfg.ReorgWindow != defaultConfirmations {
+		t.Fatalf("expected default reorg window %d, got %d", defaultConfirmations, cfg.ReorgWindow)
+	}
+	if cfg.PollInterval != defaultPollInterval {
+		t.Fatalf("expected default poll interval %s, got %s", defaultPollInterval, cfg.PollInterval)
+	}
+	if cfg.RequestTimeout != defaultRequestTimeout {
+		t.Fatalf("expected default request timeout %s, got %s", defaultRequestTimeout, cfg.RequestTimeout)
+	}
+	if cfg.RPCConcurrency != defaultRPCConcurrency {
+		t.Fatalf("expected default rpc concurrency %d, got %d", defaultRPCConcurrency, cfg.RPCConcurrency)
+	}
+	if !cfg.EnableTxEnrichment {
+		t.Fatal("expected tx enrichment to be enabled by default")
+	}
+	if cfg.StateKey != stateKeyLastIndexedBlock {
+		t.Fatalf("expected state key %q, got %q", stateKeyLastIndexedBlock, cfg.StateKey)
+	}
+}
+
+func TestLoadConfigFromEnv_ParsesOptionals(t *testing.T) {
+	t.Setenv("RPC_URL", "https://rpc.example")
+	t.Setenv("ENTRYPOINT", "0X0000000071727De22E5E9d8BAf0edAc6f37da032")
+	t.Setenv("INDEXER_START_BLOCK", "123")
+	t.Setenv("INDEXER_BATCH_SIZE", "777")
+	t.Setenv("INDEXER_CONFIRMATIONS", "9")
+	t.Setenv("INDEXER_REORG_WINDOW", "4")
+	t.Setenv("INDEXER_POLL_INTERVAL", "750ms")
+	t.Setenv("INDEXER_REQUEST_TIMEOUT", "9s")
+	t.Setenv("INDEXER_RPC_CONCURRENCY", "12")
+	t.Setenv("INDEXER_ENABLE_TX_ENRICHMENT", "false")
+
+	cfg, err := LoadConfigFromEnv()
+	if err != nil {
+		t.Fatalf("LoadConfigFromEnv returned error: %v", err)
+	}
+
+	if !cfg.HasStartBlock || cfg.StartBlock != 123 {
+		t.Fatalf("expected start block 123, got has=%v block=%d", cfg.HasStartBlock, cfg.StartBlock)
+	}
+	if cfg.BatchSize != 777 {
+		t.Fatalf("expected batch size 777, got %d", cfg.BatchSize)
+	}
+	if cfg.Confirmations != 9 {
+		t.Fatalf("expected confirmations 9, got %d", cfg.Confirmations)
+	}
+	if cfg.ReorgWindow != 4 {
+		t.Fatalf("expected reorg window 4, got %d", cfg.ReorgWindow)
+	}
+	if cfg.PollInterval != 750*time.Millisecond {
+		t.Fatalf("expected poll interval 750ms, got %s", cfg.PollInterval)
+	}
+	if cfg.RequestTimeout != 9*time.Second {
+		t.Fatalf("expected request timeout 9s, got %s", cfg.RequestTimeout)
+	}
+	if cfg.RPCConcurrency != 12 {
+		t.Fatalf("expected rpc concurrency 12, got %d", cfg.RPCConcurrency)
+	}
+	if cfg.EnableTxEnrichment {
+		t.Fatal("expected tx enrichment to be disabled")
+	}
+}
+
+func TestLoadConfigFromEnv_RequiresRPCURL(t *testing.T) {
+	clearOptionalIndexerEnv(t)
+	t.Setenv("RPC_URL", "")
+
+	_, err := LoadConfigFromEnv()
+	if err == nil {
+		t.Fatal("expected error when RPC_URL is missing")
+	}
+	if !strings.Contains(err.Error(), "RPC_URL") {
+		t.Fatalf("expected RPC_URL error, got %v", err)
+	}
+}
+
+func TestLoadConfigFromEnv_InvalidNumericValues(t *testing.T) {
+	t.Setenv("RPC_URL", "https://rpc.example")
+
+	t.Setenv("INDEXER_BATCH_SIZE", "0")
+	if _, err := LoadConfigFromEnv(); err == nil {
+		t.Fatal("expected batch size validation error")
+	}
+
+	t.Setenv("INDEXER_BATCH_SIZE", "500")
+	t.Setenv("INDEXER_RPC_CONCURRENCY", "0")
+	if _, err := LoadConfigFromEnv(); err == nil {
+		t.Fatal("expected rpc concurrency validation error")
+	}
+
+	t.Setenv("INDEXER_RPC_CONCURRENCY", "abc")
+	if _, err := LoadConfigFromEnv(); err == nil {
+		t.Fatal("expected rpc concurrency parse error")
+	}
+}
+
+func TestLoadConfigFromEnv_InvalidDurationsAndBools(t *testing.T) {
+	t.Setenv("RPC_URL", "https://rpc.example")
+
+	t.Setenv("INDEXER_POLL_INTERVAL", "0s")
+	if _, err := LoadConfigFromEnv(); err == nil {
+		t.Fatal("expected poll interval validation error")
+	}
+
+	t.Setenv("INDEXER_POLL_INTERVAL", "1s")
+	t.Setenv("INDEXER_REQUEST_TIMEOUT", "0s")
+	if _, err := LoadConfigFromEnv(); err == nil {
+		t.Fatal("expected request timeout validation error")
+	}
+
+	t.Setenv("INDEXER_REQUEST_TIMEOUT", "1s")
+	t.Setenv("INDEXER_ENABLE_TX_ENRICHMENT", "maybe")
+	if _, err := LoadConfigFromEnv(); err == nil {
+		t.Fatal("expected tx enrichment parse error")
+	}
+}
+
+func clearOptionalIndexerEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("ENTRYPOINT", "")
+	t.Setenv("INDEXER_START_BLOCK", "")
+	t.Setenv("INDEXER_BATCH_SIZE", "")
+	t.Setenv("INDEXER_CONFIRMATIONS", "")
+	t.Setenv("INDEXER_REORG_WINDOW", "")
+	t.Setenv("INDEXER_POLL_INTERVAL", "")
+	t.Setenv("INDEXER_REQUEST_TIMEOUT", "")
+	t.Setenv("INDEXER_RPC_CONCURRENCY", "")
+	t.Setenv("INDEXER_ENABLE_TX_ENRICHMENT", "")
 }

--- a/indexer/internal/indexer/config_test.go
+++ b/indexer/internal/indexer/config_test.go
@@ -78,6 +78,9 @@ func TestLoadConfigFromEnv_Defaults(t *testing.T) {
 	if !cfg.EnableTxEnrichment {
 		t.Fatal("expected tx enrichment to be enabled by default")
 	}
+	if cfg.AllowCursorTrim {
+		t.Fatal("expected cursor trim to be disabled by default")
+	}
 	if cfg.StateKey != stateKeyLastIndexedBlock {
 		t.Fatalf("expected state key %q, got %q", stateKeyLastIndexedBlock, cfg.StateKey)
 	}
@@ -94,6 +97,7 @@ func TestLoadConfigFromEnv_ParsesOptionals(t *testing.T) {
 	t.Setenv("INDEXER_REQUEST_TIMEOUT", "9s")
 	t.Setenv("INDEXER_RPC_CONCURRENCY", "12")
 	t.Setenv("INDEXER_ENABLE_TX_ENRICHMENT", "false")
+	t.Setenv("INDEXER_ALLOW_CURSOR_TRIM", "true")
 
 	cfg, err := LoadConfigFromEnv()
 	if err != nil {
@@ -123,6 +127,9 @@ func TestLoadConfigFromEnv_ParsesOptionals(t *testing.T) {
 	}
 	if cfg.EnableTxEnrichment {
 		t.Fatal("expected tx enrichment to be disabled")
+	}
+	if !cfg.AllowCursorTrim {
+		t.Fatal("expected cursor trim to be enabled")
 	}
 }
 
@@ -178,6 +185,12 @@ func TestLoadConfigFromEnv_InvalidDurationsAndBools(t *testing.T) {
 	if _, err := LoadConfigFromEnv(); err == nil {
 		t.Fatal("expected tx enrichment parse error")
 	}
+
+	t.Setenv("INDEXER_ENABLE_TX_ENRICHMENT", "true")
+	t.Setenv("INDEXER_ALLOW_CURSOR_TRIM", "maybe")
+	if _, err := LoadConfigFromEnv(); err == nil {
+		t.Fatal("expected cursor trim parse error")
+	}
 }
 
 func clearOptionalIndexerEnv(t *testing.T) {
@@ -191,4 +204,5 @@ func clearOptionalIndexerEnv(t *testing.T) {
 	t.Setenv("INDEXER_REQUEST_TIMEOUT", "")
 	t.Setenv("INDEXER_RPC_CONCURRENCY", "")
 	t.Setenv("INDEXER_ENABLE_TX_ENRICHMENT", "")
+	t.Setenv("INDEXER_ALLOW_CURSOR_TRIM", "")
 }

--- a/indexer/internal/indexer/config_test.go
+++ b/indexer/internal/indexer/config_test.go
@@ -75,6 +75,9 @@ func TestLoadConfigFromEnv_Defaults(t *testing.T) {
 	if cfg.RPCConcurrency != defaultRPCConcurrency {
 		t.Fatalf("expected default rpc concurrency %d, got %d", defaultRPCConcurrency, cfg.RPCConcurrency)
 	}
+	if cfg.RPCResponseMaxBytes != defaultRPCResponseMax {
+		t.Fatalf("expected default rpc response max %d, got %d", defaultRPCResponseMax, cfg.RPCResponseMaxBytes)
+	}
 	if !cfg.EnableTxEnrichment {
 		t.Fatal("expected tx enrichment to be enabled by default")
 	}
@@ -96,6 +99,7 @@ func TestLoadConfigFromEnv_ParsesOptionals(t *testing.T) {
 	t.Setenv("INDEXER_POLL_INTERVAL", "750ms")
 	t.Setenv("INDEXER_REQUEST_TIMEOUT", "9s")
 	t.Setenv("INDEXER_RPC_CONCURRENCY", "12")
+	t.Setenv("INDEXER_RPC_RESPONSE_MAX_BYTES", "1048576")
 	t.Setenv("INDEXER_ENABLE_TX_ENRICHMENT", "false")
 	t.Setenv("INDEXER_ALLOW_CURSOR_TRIM", "true")
 
@@ -124,6 +128,9 @@ func TestLoadConfigFromEnv_ParsesOptionals(t *testing.T) {
 	}
 	if cfg.RPCConcurrency != 12 {
 		t.Fatalf("expected rpc concurrency 12, got %d", cfg.RPCConcurrency)
+	}
+	if cfg.RPCResponseMaxBytes != 1048576 {
+		t.Fatalf("expected rpc response max 1048576, got %d", cfg.RPCResponseMaxBytes)
 	}
 	if cfg.EnableTxEnrichment {
 		t.Fatal("expected tx enrichment to be disabled")
@@ -164,6 +171,17 @@ func TestLoadConfigFromEnv_InvalidNumericValues(t *testing.T) {
 	if _, err := LoadConfigFromEnv(); err == nil {
 		t.Fatal("expected rpc concurrency parse error")
 	}
+
+	t.Setenv("INDEXER_RPC_CONCURRENCY", "8")
+	t.Setenv("INDEXER_RPC_RESPONSE_MAX_BYTES", "0")
+	if _, err := LoadConfigFromEnv(); err == nil {
+		t.Fatal("expected rpc response max validation error")
+	}
+
+	t.Setenv("INDEXER_RPC_RESPONSE_MAX_BYTES", "abc")
+	if _, err := LoadConfigFromEnv(); err == nil {
+		t.Fatal("expected rpc response max parse error")
+	}
 }
 
 func TestLoadConfigFromEnv_InvalidDurationsAndBools(t *testing.T) {
@@ -203,6 +221,7 @@ func clearOptionalIndexerEnv(t *testing.T) {
 	t.Setenv("INDEXER_POLL_INTERVAL", "")
 	t.Setenv("INDEXER_REQUEST_TIMEOUT", "")
 	t.Setenv("INDEXER_RPC_CONCURRENCY", "")
+	t.Setenv("INDEXER_RPC_RESPONSE_MAX_BYTES", "")
 	t.Setenv("INDEXER_ENABLE_TX_ENRICHMENT", "")
 	t.Setenv("INDEXER_ALLOW_CURSOR_TRIM", "")
 }

--- a/indexer/internal/indexer/config_test.go
+++ b/indexer/internal/indexer/config_test.go
@@ -23,3 +23,17 @@ func TestNormalizeAddressRejectsInvalidLength(t *testing.T) {
 		t.Fatal("expected error for invalid address length")
 	}
 }
+
+func TestNormalizeAddressAcceptsUppercasePrefix(t *testing.T) {
+	t.Parallel()
+
+	value, err := normalizeAddress("0X0000000071727De22E5E9d8BAf0edAc6f37da032")
+	if err != nil {
+		t.Fatalf("normalizeAddress returned error: %v", err)
+	}
+
+	const expected = "0x0000000071727de22e5e9d8baf0edac6f37da032"
+	if value != expected {
+		t.Fatalf("expected %q, got %q", expected, value)
+	}
+}

--- a/indexer/internal/indexer/decode.go
+++ b/indexer/internal/indexer/decode.go
@@ -128,7 +128,7 @@ func decodeHandleOpsInput(input []byte) ([]operationCall, error) {
 	if err != nil {
 		return nil, fmt.Errorf("parse ops offset: %w", err)
 	}
-	if opsOffset+32 > len(args) {
+	if opsOffset > len(args)-32 {
 		return nil, fmt.Errorf("ops offset %d out of bounds", opsOffset)
 	}
 
@@ -143,8 +143,8 @@ func decodeHandleOpsInput(input []byte) ([]operationCall, error) {
 	}
 
 	offsetsBase := arrayStart + 32
-	requiredOffsetsEnd := offsetsBase + arrayLen*32
-	if requiredOffsetsEnd > len(args) {
+	maxOffsets := (len(args) - offsetsBase) / 32
+	if arrayLen > maxOffsets {
 		return nil, fmt.Errorf("ops offsets exceed calldata length")
 	}
 
@@ -157,6 +157,9 @@ func decodeHandleOpsInput(input []byte) ([]operationCall, error) {
 		relOffset, err := wordToOffset(offsetWord)
 		if err != nil {
 			return nil, fmt.Errorf("parse op[%d] offset: %w", i, err)
+		}
+		if relOffset > len(args)-offsetsBase {
+			return nil, fmt.Errorf("op[%d] tuple offset %d out of bounds", i, relOffset)
 		}
 
 		tupleStart := offsetsBase + relOffset

--- a/indexer/internal/indexer/decode.go
+++ b/indexer/internal/indexer/decode.go
@@ -1,0 +1,369 @@
+package indexer
+
+import (
+	"encoding/hex"
+	"fmt"
+	"math"
+	"math/big"
+	"strings"
+)
+
+var (
+	userOperationEventTopic = "0x49628fd1471006c1482da88028e9ce4dbb080b815c9b0344d39e5a8e6ec1419f"
+	handleOpsSelector       = []byte{0x76, 0x5e, 0x82, 0x7f}
+	executeSelector         = []byte{0xb6, 0x1d, 0x27, 0xf6}
+)
+
+type decodedEvent struct {
+	UserOpHash    []byte
+	Sender        []byte
+	Paymaster     []byte
+	Nonce         string
+	Success       bool
+	ActualGasCost string
+	ActualGasUsed string
+	TxHash        []byte
+	TxHashHex     string
+	BlockNumber   uint64
+	LogIndex      int32
+}
+
+type operationCall struct {
+	Sender   []byte
+	Nonce    string
+	Target   []byte
+	Calldata []byte
+}
+
+type operationMeta struct {
+	Target   []byte
+	Calldata []byte
+}
+
+func decodeUserOperationEventLog(log rpcLog) (decodedEvent, error) {
+	if len(log.Topics) != 4 {
+		return decodedEvent{}, fmt.Errorf("expected 4 topics, got %d", len(log.Topics))
+	}
+
+	if !strings.EqualFold(log.Topics[0], userOperationEventTopic) {
+		return decodedEvent{}, fmt.Errorf("unexpected topic0 %q", log.Topics[0])
+	}
+
+	userOpHash, err := decodeHexFixed(log.Topics[1], 32)
+	if err != nil {
+		return decodedEvent{}, fmt.Errorf("decode userOpHash topic: %w", err)
+	}
+
+	sender, err := decodeIndexedAddress(log.Topics[2])
+	if err != nil {
+		return decodedEvent{}, fmt.Errorf("decode sender topic: %w", err)
+	}
+
+	paymaster, err := decodeIndexedAddress(log.Topics[3])
+	if err != nil {
+		return decodedEvent{}, fmt.Errorf("decode paymaster topic: %w", err)
+	}
+
+	data, err := decodeHex(log.Data)
+	if err != nil {
+		return decodedEvent{}, fmt.Errorf("decode log data: %w", err)
+	}
+	if len(data) != 32*4 {
+		return decodedEvent{}, fmt.Errorf("expected 128 bytes of log data, got %d", len(data))
+	}
+
+	nonce := uint256ToDecimal(data[0:32])
+	success := !isZeroWord(data[32:64])
+	actualGasCost := uint256ToDecimal(data[64:96])
+	actualGasUsed := uint256ToDecimal(data[96:128])
+
+	txHash, err := decodeHexFixed(log.TransactionHash, 32)
+	if err != nil {
+		return decodedEvent{}, fmt.Errorf("decode transaction hash: %w", err)
+	}
+
+	blockNumber, err := parseHexUint64(log.BlockNumber)
+	if err != nil {
+		return decodedEvent{}, fmt.Errorf("parse block number: %w", err)
+	}
+
+	logIndexValue, err := parseHexUint64(log.LogIndex)
+	if err != nil {
+		return decodedEvent{}, fmt.Errorf("parse log index: %w", err)
+	}
+	if logIndexValue > math.MaxInt32 {
+		return decodedEvent{}, fmt.Errorf("log index %d overflows int32", logIndexValue)
+	}
+
+	return decodedEvent{
+		UserOpHash:    userOpHash,
+		Sender:        sender,
+		Paymaster:     paymaster,
+		Nonce:         nonce,
+		Success:       success,
+		ActualGasCost: actualGasCost,
+		ActualGasUsed: actualGasUsed,
+		TxHash:        txHash,
+		TxHashHex:     "0x" + hex.EncodeToString(txHash),
+		BlockNumber:   blockNumber,
+		LogIndex:      int32(logIndexValue),
+	}, nil
+}
+
+func decodeHandleOpsInput(input []byte) ([]operationCall, error) {
+	if len(input) < 4+64 {
+		return nil, fmt.Errorf("input too short: %d", len(input))
+	}
+	if !bytesEqual(input[:4], handleOpsSelector) {
+		return nil, fmt.Errorf("unexpected selector 0x%s", hex.EncodeToString(input[:4]))
+	}
+
+	args := input[4:]
+
+	opsOffsetWord, err := wordAt(args, 0)
+	if err != nil {
+		return nil, fmt.Errorf("read ops offset: %w", err)
+	}
+	opsOffset, err := wordToOffset(opsOffsetWord)
+	if err != nil {
+		return nil, fmt.Errorf("parse ops offset: %w", err)
+	}
+	if opsOffset+32 > len(args) {
+		return nil, fmt.Errorf("ops offset %d out of bounds", opsOffset)
+	}
+
+	arrayStart := opsOffset
+	arrayLenWord, err := wordAt(args, arrayStart)
+	if err != nil {
+		return nil, fmt.Errorf("read ops length: %w", err)
+	}
+	arrayLen, err := wordToOffset(arrayLenWord)
+	if err != nil {
+		return nil, fmt.Errorf("parse ops length: %w", err)
+	}
+
+	offsetsBase := arrayStart + 32
+	requiredOffsetsEnd := offsetsBase + arrayLen*32
+	if requiredOffsetsEnd > len(args) {
+		return nil, fmt.Errorf("ops offsets exceed calldata length")
+	}
+
+	result := make([]operationCall, 0, arrayLen)
+	for i := 0; i < arrayLen; i++ {
+		offsetWord, err := wordAt(args, offsetsBase+i*32)
+		if err != nil {
+			return nil, fmt.Errorf("read op[%d] offset: %w", i, err)
+		}
+		relOffset, err := wordToOffset(offsetWord)
+		if err != nil {
+			return nil, fmt.Errorf("parse op[%d] offset: %w", i, err)
+		}
+
+		tupleStart := offsetsBase + relOffset
+		tuple, err := parsePackedUserOperation(args, tupleStart)
+		if err != nil {
+			return nil, fmt.Errorf("decode op[%d]: %w", i, err)
+		}
+
+		target, calldata, ok := extractExecuteTargetAndCalldata(tuple.Calldata)
+		if !ok {
+			continue
+		}
+
+		result = append(result, operationCall{
+			Sender:   tuple.Sender,
+			Nonce:    tuple.Nonce,
+			Target:   target,
+			Calldata: calldata,
+		})
+	}
+
+	return result, nil
+}
+
+type packedUserOperation struct {
+	Sender   []byte
+	Nonce    string
+	Calldata []byte
+}
+
+func parsePackedUserOperation(args []byte, tupleStart int) (packedUserOperation, error) {
+	const tupleHeadSize = 9 * 32
+	if tupleStart < 0 || tupleStart+tupleHeadSize > len(args) {
+		return packedUserOperation{}, fmt.Errorf("tuple head out of bounds")
+	}
+
+	senderWord, err := wordAt(args, tupleStart)
+	if err != nil {
+		return packedUserOperation{}, err
+	}
+	nonceWord, err := wordAt(args, tupleStart+32)
+	if err != nil {
+		return packedUserOperation{}, err
+	}
+	callDataOffsetWord, err := wordAt(args, tupleStart+3*32)
+	if err != nil {
+		return packedUserOperation{}, err
+	}
+
+	callDataOffset, err := wordToOffset(callDataOffsetWord)
+	if err != nil {
+		return packedUserOperation{}, fmt.Errorf("parse callData offset: %w", err)
+	}
+	callData, err := readDynamicBytes(args, tupleStart, callDataOffset)
+	if err != nil {
+		return packedUserOperation{}, fmt.Errorf("read callData: %w", err)
+	}
+
+	return packedUserOperation{
+		Sender:   append([]byte(nil), senderWord[12:32]...),
+		Nonce:    uint256ToDecimal(nonceWord),
+		Calldata: callData,
+	}, nil
+}
+
+func extractExecuteTargetAndCalldata(callData []byte) ([]byte, []byte, bool) {
+	const (
+		selectorSize   = 4
+		minCallDataLen = selectorSize + 4*32
+	)
+
+	if len(callData) < minCallDataLen {
+		return nil, nil, false
+	}
+	if !bytesEqual(callData[:selectorSize], executeSelector) {
+		return nil, nil, false
+	}
+
+	valueWord := callData[selectorSize+32 : selectorSize+64]
+	if !isZeroWord(valueWord) {
+		return nil, nil, false
+	}
+
+	target := append([]byte(nil), callData[selectorSize+12:selectorSize+32]...)
+	offsetWord := callData[selectorSize+2*32 : selectorSize+3*32]
+	offset, err := wordToOffset(offsetWord)
+	if err != nil {
+		return nil, nil, false
+	}
+
+	bytesHead := selectorSize + offset
+	if bytesHead+32 > len(callData) {
+		return nil, nil, false
+	}
+
+	lenWord := callData[bytesHead : bytesHead+32]
+	lenValue, err := wordToOffset(lenWord)
+	if err != nil {
+		return nil, nil, false
+	}
+
+	dataStart := bytesHead + 32
+	dataEnd := dataStart + lenValue
+	if dataEnd > len(callData) {
+		return nil, nil, false
+	}
+
+	inner := append([]byte(nil), callData[dataStart:dataEnd]...)
+	return target, inner, true
+}
+
+func toOperationMetaQueue(calls []operationCall) map[string][]operationMeta {
+	queue := make(map[string][]operationMeta)
+	for i := range calls {
+		call := calls[i]
+		key := operationKey(call.Sender, call.Nonce)
+		queue[key] = append(queue[key], operationMeta{
+			Target:   call.Target,
+			Calldata: call.Calldata,
+		})
+	}
+	return queue
+}
+
+func decodeIndexedAddress(topic string) ([]byte, error) {
+	decoded, err := decodeHexFixed(topic, 32)
+	if err != nil {
+		return nil, err
+	}
+	return append([]byte(nil), decoded[12:32]...), nil
+}
+
+func readDynamicBytes(data []byte, base int, offset int) ([]byte, error) {
+	if offset < 0 {
+		return nil, fmt.Errorf("negative offset")
+	}
+	start := base + offset
+	if start+32 > len(data) {
+		return nil, fmt.Errorf("offset %d out of bounds", offset)
+	}
+
+	lenWord, err := wordAt(data, start)
+	if err != nil {
+		return nil, err
+	}
+	lenValue, err := wordToOffset(lenWord)
+	if err != nil {
+		return nil, fmt.Errorf("parse bytes length: %w", err)
+	}
+
+	bytesStart := start + 32
+	bytesEnd := bytesStart + lenValue
+	if bytesEnd > len(data) {
+		return nil, fmt.Errorf("bytes end %d out of bounds", bytesEnd)
+	}
+
+	return append([]byte(nil), data[bytesStart:bytesEnd]...), nil
+}
+
+func wordAt(data []byte, offset int) ([]byte, error) {
+	if offset < 0 || offset+32 > len(data) {
+		return nil, fmt.Errorf("word offset %d out of bounds", offset)
+	}
+	return data[offset : offset+32], nil
+}
+
+func wordToOffset(word []byte) (int, error) {
+	v := new(big.Int).SetBytes(word)
+	if v.Sign() < 0 {
+		return 0, fmt.Errorf("negative value")
+	}
+	if !v.IsUint64() {
+		return 0, fmt.Errorf("value overflows uint64")
+	}
+	u := v.Uint64()
+	if u > uint64(math.MaxInt) {
+		return 0, fmt.Errorf("value overflows int")
+	}
+	return int(u), nil
+}
+
+func uint256ToDecimal(word []byte) string {
+	v := new(big.Int).SetBytes(word)
+	return v.String()
+}
+
+func operationKey(sender []byte, nonce string) string {
+	return hex.EncodeToString(sender) + ":" + nonce
+}
+
+func isZeroWord(word []byte) bool {
+	for _, b := range word {
+		if b != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func bytesEqual(a []byte, b []byte) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/indexer/internal/indexer/decode_test.go
+++ b/indexer/internal/indexer/decode_test.go
@@ -1,0 +1,221 @@
+package indexer
+
+import (
+	"bytes"
+	"encoding/hex"
+	"fmt"
+	"testing"
+)
+
+func TestDecodeUserOperationEventLog(t *testing.T) {
+	t.Parallel()
+
+	log := rpcLog{
+		Topics: []string{
+			userOperationEventTopic,
+			"0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			"0x0000000000000000000000001111111111111111111111111111111111111111",
+			"0x0000000000000000000000002222222222222222222222222222222222222222",
+		},
+		Data:            "0x" + hexWord(5) + hexWord(1) + hexWord(123) + hexWord(456),
+		TransactionHash: "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+		BlockNumber:     "0x10",
+		LogIndex:        "0x2",
+	}
+
+	decoded, err := decodeUserOperationEventLog(log)
+	if err != nil {
+		t.Fatalf("decodeUserOperationEventLog returned error: %v", err)
+	}
+
+	if decoded.Nonce != "5" {
+		t.Fatalf("expected nonce 5, got %s", decoded.Nonce)
+	}
+	if !decoded.Success {
+		t.Fatal("expected success true")
+	}
+	if decoded.ActualGasCost != "123" {
+		t.Fatalf("expected gas cost 123, got %s", decoded.ActualGasCost)
+	}
+	if decoded.ActualGasUsed != "456" {
+		t.Fatalf("expected gas used 456, got %s", decoded.ActualGasUsed)
+	}
+	if decoded.BlockNumber != 16 {
+		t.Fatalf("expected block number 16, got %d", decoded.BlockNumber)
+	}
+	if decoded.LogIndex != 2 {
+		t.Fatalf("expected log index 2, got %d", decoded.LogIndex)
+	}
+	if hex.EncodeToString(decoded.Sender) != "1111111111111111111111111111111111111111" {
+		t.Fatalf("unexpected sender: %x", decoded.Sender)
+	}
+	if hex.EncodeToString(decoded.Paymaster) != "2222222222222222222222222222222222222222" {
+		t.Fatalf("unexpected paymaster: %x", decoded.Paymaster)
+	}
+}
+
+func TestDecodeHandleOpsInputWithExecute(t *testing.T) {
+	t.Parallel()
+
+	innerData := []byte{0xde, 0xad, 0xbe, 0xef}
+	target := mustAddressBytes("00000000000000000000000000000000000000aa")
+	sender := mustAddressBytes("0000000000000000000000000000000000000001")
+
+	executeCallData := buildExecuteCallData(target, innerData)
+	handleOpsInput := buildHandleOpsInput(sender, 1, executeCallData)
+
+	calls, err := decodeHandleOpsInput(handleOpsInput)
+	if err != nil {
+		t.Fatalf("decodeHandleOpsInput returned error: %v", err)
+	}
+
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 call, got %d", len(calls))
+	}
+
+	call := calls[0]
+	if hex.EncodeToString(call.Sender) != "0000000000000000000000000000000000000001" {
+		t.Fatalf("unexpected sender: %x", call.Sender)
+	}
+	if call.Nonce != "1" {
+		t.Fatalf("expected nonce 1, got %s", call.Nonce)
+	}
+	if !bytes.Equal(call.Target, target) {
+		t.Fatalf("unexpected target: %x", call.Target)
+	}
+	if !bytes.Equal(call.Calldata, innerData) {
+		t.Fatalf("unexpected calldata: %x", call.Calldata)
+	}
+}
+
+func TestDecodeHandleOpsInputSkipsExecuteWithNonZeroValue(t *testing.T) {
+	t.Parallel()
+
+	innerData := []byte{0xde, 0xad, 0xbe, 0xef}
+	target := mustAddressBytes("00000000000000000000000000000000000000aa")
+	sender := mustAddressBytes("0000000000000000000000000000000000000001")
+
+	executeCallData := buildExecuteCallDataWithValue(target, 1, innerData)
+	handleOpsInput := buildHandleOpsInput(sender, 1, executeCallData)
+
+	calls, err := decodeHandleOpsInput(handleOpsInput)
+	if err != nil {
+		t.Fatalf("decodeHandleOpsInput returned error: %v", err)
+	}
+
+	if len(calls) != 0 {
+		t.Fatalf("expected 0 calls, got %d", len(calls))
+	}
+}
+
+func hexWord(value uint64) string {
+	return fmt.Sprintf("%064x", value)
+}
+
+func mustAddressBytes(hexAddress string) []byte {
+	b, err := hex.DecodeString(hexAddress)
+	if err != nil {
+		panic(err)
+	}
+	if len(b) != 20 {
+		panic("address must be 20 bytes")
+	}
+	return b
+}
+
+func buildExecuteCallData(target []byte, inner []byte) []byte {
+	return buildExecuteCallDataWithValue(target, 0, inner)
+}
+
+func buildExecuteCallDataWithValue(target []byte, value uint64, inner []byte) []byte {
+	selector := []byte{0xb6, 0x1d, 0x27, 0xf6}
+
+	head := make([]byte, 0, 96)
+	head = append(head, addressWord(target)...)
+	head = append(head, uintWord(value)...)
+	head = append(head, uintWord(96)...)
+
+	tail := encodeBytes(inner)
+
+	out := make([]byte, 0, len(selector)+len(head)+len(tail))
+	out = append(out, selector...)
+	out = append(out, head...)
+	out = append(out, tail...)
+	return out
+}
+
+func buildHandleOpsInput(sender []byte, nonce uint64, callData []byte) []byte {
+	selector := []byte{0x76, 0x5e, 0x82, 0x7f}
+
+	initCode := encodeBytes(nil)
+	encodedCallData := encodeBytes(callData)
+	paymasterAndData := encodeBytes(nil)
+	signature := encodeBytes(nil)
+
+	tupleHeadSize := 9 * 32
+	initCodeOffset := tupleHeadSize
+	callDataOffset := initCodeOffset + len(initCode)
+	paymasterOffset := callDataOffset + len(encodedCallData)
+	signatureOffset := paymasterOffset + len(paymasterAndData)
+
+	tupleHead := make([]byte, 0, tupleHeadSize)
+	tupleHead = append(tupleHead, addressWord(sender)...)
+	tupleHead = append(tupleHead, uintWord(nonce)...)
+	tupleHead = append(tupleHead, uintWord(uint64(initCodeOffset))...)
+	tupleHead = append(tupleHead, uintWord(uint64(callDataOffset))...)
+	tupleHead = append(tupleHead, uintWord(0)...)
+	tupleHead = append(tupleHead, uintWord(0)...)
+	tupleHead = append(tupleHead, uintWord(0)...)
+	tupleHead = append(tupleHead, uintWord(uint64(paymasterOffset))...)
+	tupleHead = append(tupleHead, uintWord(uint64(signatureOffset))...)
+
+	tuple := make([]byte, 0, len(tupleHead)+len(initCode)+len(encodedCallData)+len(paymasterAndData)+len(signature))
+	tuple = append(tuple, tupleHead...)
+	tuple = append(tuple, initCode...)
+	tuple = append(tuple, encodedCallData...)
+	tuple = append(tuple, paymasterAndData...)
+	tuple = append(tuple, signature...)
+
+	opsData := make([]byte, 0, 64+len(tuple))
+	opsData = append(opsData, uintWord(1)...)  // array length
+	opsData = append(opsData, uintWord(32)...) // first tuple offset (relative to offsets base)
+	opsData = append(opsData, tuple...)
+
+	argsHead := make([]byte, 0, 64)
+	argsHead = append(argsHead, uintWord(64)...) // ops starts after two head words
+	argsHead = append(argsHead, addressWord(mustAddressBytes("0000000000000000000000000000000000000002"))...)
+
+	out := make([]byte, 0, len(selector)+len(argsHead)+len(opsData))
+	out = append(out, selector...)
+	out = append(out, argsHead...)
+	out = append(out, opsData...)
+
+	return out
+}
+
+func addressWord(address []byte) []byte {
+	if len(address) != 20 {
+		panic("address must be 20 bytes")
+	}
+	word := make([]byte, 32)
+	copy(word[12:], address)
+	return word
+}
+
+func uintWord(value uint64) []byte {
+	word := make([]byte, 32)
+	for i := 0; i < 8; i++ {
+		word[31-i] = byte(value >> (8 * i))
+	}
+	return word
+}
+
+func encodeBytes(value []byte) []byte {
+	lengthWord := uintWord(uint64(len(value)))
+	padded := make([]byte, len(value))
+	copy(padded, value)
+	for len(padded)%32 != 0 {
+		padded = append(padded, 0)
+	}
+	return append(lengthWord, padded...)
+}

--- a/indexer/internal/indexer/decode_test.go
+++ b/indexer/internal/indexer/decode_test.go
@@ -108,6 +108,37 @@ func TestDecodeHandleOpsInputSkipsExecuteWithNonZeroValue(t *testing.T) {
 	}
 }
 
+func TestDecodeHandleOpsInputRejectsOversizedArrayLen(t *testing.T) {
+	t.Parallel()
+
+	selector := []byte{0x76, 0x5e, 0x82, 0x7f}
+	args := make([]byte, 64)
+	copy(args[0:32], uintWord(32))
+	copy(args[32:64], uintWord(2))
+
+	input := append(selector, args...)
+	_, err := decodeHandleOpsInput(input)
+	if err == nil {
+		t.Fatal("expected error for oversized ops array length")
+	}
+}
+
+func TestDecodeHandleOpsInputRejectsTupleOffsetOutOfBounds(t *testing.T) {
+	t.Parallel()
+
+	selector := []byte{0x76, 0x5e, 0x82, 0x7f}
+	args := make([]byte, 32*4)
+	copy(args[0:32], uintWord(64))
+	copy(args[64:96], uintWord(1))
+	copy(args[96:128], uintWord(1000))
+
+	input := append(selector, args...)
+	_, err := decodeHandleOpsInput(input)
+	if err == nil {
+		t.Fatal("expected error for tuple offset out of bounds")
+	}
+}
+
 func hexWord(value uint64) string {
 	return fmt.Sprintf("%064x", value)
 }

--- a/indexer/internal/indexer/hex.go
+++ b/indexer/internal/indexer/hex.go
@@ -10,7 +10,7 @@ import (
 
 func normalizeAddress(input string) (string, error) {
 	trimmed := strings.TrimSpace(input)
-	if !strings.HasPrefix(trimmed, "0x") {
+	if !hasHexPrefix(trimmed) {
 		return "", fmt.Errorf("address must start with 0x")
 	}
 
@@ -28,7 +28,7 @@ func normalizeAddress(input string) (string, error) {
 
 func decodeHex(input string) ([]byte, error) {
 	trimmed := strings.TrimSpace(input)
-	if !strings.HasPrefix(trimmed, "0x") {
+	if !hasHexPrefix(trimmed) {
 		return nil, fmt.Errorf("hex value must start with 0x")
 	}
 
@@ -60,7 +60,7 @@ func decodeHexFixed(input string, length int) ([]byte, error) {
 
 func parseHexUint64(input string) (uint64, error) {
 	trimmed := strings.TrimSpace(input)
-	if !strings.HasPrefix(trimmed, "0x") {
+	if !hasHexPrefix(trimmed) {
 		return 0, fmt.Errorf("hex uint64 must start with 0x")
 	}
 
@@ -70,6 +70,10 @@ func parseHexUint64(input string) (uint64, error) {
 	}
 
 	return value, nil
+}
+
+func hasHexPrefix(value string) bool {
+	return len(value) >= 2 && value[0] == '0' && (value[1] == 'x' || value[1] == 'X')
 }
 
 func toInt64(value uint64) (int64, error) {

--- a/indexer/internal/indexer/hex.go
+++ b/indexer/internal/indexer/hex.go
@@ -3,9 +3,10 @@ package indexer
 import (
 	"encoding/hex"
 	"fmt"
-	"math"
 	"strconv"
 	"strings"
+
+	"github.com/flwrenn/bastion/indexer/internal/numconv"
 )
 
 func normalizeAddress(input string) (string, error) {
@@ -77,9 +78,5 @@ func hasHexPrefix(value string) bool {
 }
 
 func toInt64(value uint64) (int64, error) {
-	if value > math.MaxInt64 {
-		return 0, fmt.Errorf("value %d overflows int64", value)
-	}
-
-	return int64(value), nil
+	return numconv.Uint64ToInt64(value)
 }

--- a/indexer/internal/indexer/hex.go
+++ b/indexer/internal/indexer/hex.go
@@ -1,0 +1,81 @@
+package indexer
+
+import (
+	"encoding/hex"
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+)
+
+func normalizeAddress(input string) (string, error) {
+	trimmed := strings.TrimSpace(input)
+	if !strings.HasPrefix(trimmed, "0x") {
+		return "", fmt.Errorf("address must start with 0x")
+	}
+
+	hexPart := trimmed[2:]
+	if len(hexPart) != 40 {
+		return "", fmt.Errorf("address must be 20 bytes, got %d hex chars", len(hexPart))
+	}
+
+	if _, err := hex.DecodeString(hexPart); err != nil {
+		return "", fmt.Errorf("invalid address hex: %w", err)
+	}
+
+	return "0x" + strings.ToLower(hexPart), nil
+}
+
+func decodeHex(input string) ([]byte, error) {
+	trimmed := strings.TrimSpace(input)
+	if !strings.HasPrefix(trimmed, "0x") {
+		return nil, fmt.Errorf("hex value must start with 0x")
+	}
+
+	hexPart := trimmed[2:]
+	if len(hexPart)%2 != 0 {
+		return nil, fmt.Errorf("hex value has odd length")
+	}
+
+	decoded, err := hex.DecodeString(hexPart)
+	if err != nil {
+		return nil, fmt.Errorf("decode hex: %w", err)
+	}
+
+	return decoded, nil
+}
+
+func decodeHexFixed(input string, length int) ([]byte, error) {
+	decoded, err := decodeHex(input)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(decoded) != length {
+		return nil, fmt.Errorf("expected %d bytes, got %d", length, len(decoded))
+	}
+
+	return decoded, nil
+}
+
+func parseHexUint64(input string) (uint64, error) {
+	trimmed := strings.TrimSpace(input)
+	if !strings.HasPrefix(trimmed, "0x") {
+		return 0, fmt.Errorf("hex uint64 must start with 0x")
+	}
+
+	value, err := strconv.ParseUint(trimmed[2:], 16, 64)
+	if err != nil {
+		return 0, fmt.Errorf("parse hex uint64: %w", err)
+	}
+
+	return value, nil
+}
+
+func toInt64(value uint64) (int64, error) {
+	if value > math.MaxInt64 {
+		return 0, fmt.Errorf("value %d overflows int64", value)
+	}
+
+	return int64(value), nil
+}

--- a/indexer/internal/indexer/indexer.go
+++ b/indexer/internal/indexer/indexer.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/flwrenn/bastion/indexer/internal/db"
@@ -12,11 +14,15 @@ import (
 )
 
 type Service struct {
-	cfg        Config
-	pool       *pgxpool.Pool
-	rpc        *rpcClient
-	entryPoint string
+	cfg                 Config
+	pool                *pgxpool.Pool
+	rpc                 *rpcClient
+	entryPoint          string
+	blockTimestampCache map[uint64]int64
+	cacheMu             sync.RWMutex
 }
+
+const blockTimestampCacheMaxEntries = 4096
 
 func New(cfg Config, pool *pgxpool.Pool) (*Service, error) {
 	normalizedEntryPoint, err := normalizeAddress(cfg.EntryPoint)
@@ -25,10 +31,11 @@ func New(cfg Config, pool *pgxpool.Pool) (*Service, error) {
 	}
 
 	return &Service{
-		cfg:        cfg,
-		pool:       pool,
-		rpc:        newRPCClient(cfg.RPCURL),
-		entryPoint: normalizedEntryPoint,
+		cfg:                 cfg,
+		pool:                pool,
+		rpc:                 newRPCClient(cfg.RPCURL),
+		entryPoint:          normalizedEntryPoint,
+		blockTimestampCache: make(map[uint64]int64),
 	}, nil
 }
 
@@ -160,9 +167,11 @@ func (s *Service) indexRange(ctx context.Context, fromBlock uint64, toBlock uint
 	txMetaByHash := make(map[string]map[string][]operationMeta)
 	blockTimestamps := make(map[uint64]int64)
 	if len(activeLogs) > 0 {
-		txMetaByHash, err = s.loadTransactionOperationMeta(ctx, activeLogs)
-		if err != nil {
-			return fmt.Errorf("load transaction metadata: %w", err)
+		if s.cfg.EnableTxEnrichment {
+			txMetaByHash, err = s.loadTransactionOperationMeta(ctx, activeLogs)
+			if err != nil {
+				return fmt.Errorf("load transaction metadata: %w", err)
+			}
 		}
 
 		blockTimestamps, err = s.loadBlockTimestamps(ctx, activeLogs)
@@ -237,33 +246,105 @@ func (s *Service) indexRange(ctx context.Context, fromBlock uint64, toBlock uint
 
 func (s *Service) loadTransactionOperationMeta(ctx context.Context, logs []rpcLog) (map[string]map[string][]operationMeta, error) {
 	result := make(map[string]map[string][]operationMeta)
+
+	txHashes := make(map[string]string)
 	for i := range logs {
 		log := logs[i]
-		txHash := strings.ToLower(log.TransactionHash)
-		if _, exists := result[txHash]; exists {
+		normalizedTxHash := strings.ToLower(log.TransactionHash)
+		if _, exists := txHashes[normalizedTxHash]; exists {
 			continue
 		}
+		txHashes[normalizedTxHash] = log.TransactionHash
+	}
 
-		requestCtx, cancel := context.WithTimeout(ctx, s.cfg.RequestTimeout)
-		tx, err := s.rpc.getTransactionByHash(requestCtx, log.TransactionHash)
+	type txJob struct {
+		normalizedHash string
+		rawHash        string
+	}
+
+	workerCount := s.cfg.RPCConcurrency
+	if workerCount < 1 {
+		workerCount = 1
+	}
+	if workerCount > len(txHashes) {
+		workerCount = len(txHashes)
+	}
+	if workerCount == 0 {
+		return result, nil
+	}
+
+	jobs := make(chan txJob)
+	workerCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	var firstErr error
+
+	setErr := func(err error) {
+		mu.Lock()
+		defer mu.Unlock()
+		if firstErr != nil {
+			return
+		}
+		firstErr = err
 		cancel()
-		if err != nil {
-			return nil, fmt.Errorf("load tx %s: %w", log.TransactionHash, err)
-		}
+	}
 
-		input, err := decodeHex(tx.Input)
-		if err != nil {
-			return nil, fmt.Errorf("decode tx input %s: %w", tx.Hash, err)
-		}
+	worker := func() {
+		defer wg.Done()
+		for job := range jobs {
+			if workerCtx.Err() != nil {
+				return
+			}
 
-		calls, err := decodeHandleOpsInput(input)
-		if err != nil {
-			slog.Debug("transaction input not handleOps or undecodable", "tx_hash", tx.Hash, "err", err)
-			result[txHash] = map[string][]operationMeta{}
-			continue
-		}
+			requestCtx, requestCancel := context.WithTimeout(workerCtx, s.cfg.RequestTimeout)
+			tx, err := s.rpc.getTransactionByHash(requestCtx, job.rawHash)
+			requestCancel()
+			if err != nil {
+				setErr(fmt.Errorf("load tx %s: %w", job.rawHash, err))
+				return
+			}
 
-		result[txHash] = toOperationMetaQueue(calls)
+			input, err := decodeHex(tx.Input)
+			if err != nil {
+				setErr(fmt.Errorf("decode tx input %s: %w", tx.Hash, err))
+				return
+			}
+
+			calls, err := decodeHandleOpsInput(input)
+			if err != nil {
+				slog.Debug("transaction input not handleOps or undecodable", "tx_hash", tx.Hash, "err", err)
+				mu.Lock()
+				result[job.normalizedHash] = map[string][]operationMeta{}
+				mu.Unlock()
+				continue
+			}
+
+			mu.Lock()
+			result[job.normalizedHash] = toOperationMetaQueue(calls)
+			mu.Unlock()
+		}
+	}
+
+	for i := 0; i < workerCount; i++ {
+		wg.Add(1)
+		go worker()
+	}
+
+enqueue:
+	for normalizedHash, rawHash := range txHashes {
+		select {
+		case <-workerCtx.Done():
+			break enqueue
+		case jobs <- txJob{normalizedHash: normalizedHash, rawHash: rawHash}:
+		}
+	}
+	close(jobs)
+	wg.Wait()
+
+	if firstErr != nil {
+		return nil, firstErr
 	}
 
 	return result, nil
@@ -271,37 +352,152 @@ func (s *Service) loadTransactionOperationMeta(ctx context.Context, logs []rpcLo
 
 func (s *Service) loadBlockTimestamps(ctx context.Context, logs []rpcLog) (map[uint64]int64, error) {
 	result := make(map[uint64]int64)
+	uniqueBlocks := make(map[uint64]struct{})
 	for i := range logs {
 		log := logs[i]
 		blockNumber, err := parseHexUint64(log.BlockNumber)
 		if err != nil {
 			return nil, fmt.Errorf("parse block number %q: %w", log.BlockNumber, err)
 		}
+		uniqueBlocks[blockNumber] = struct{}{}
+	}
 
-		if _, exists := result[blockNumber]; exists {
+	missingBlocks := make([]uint64, 0, len(uniqueBlocks))
+	for blockNumber := range uniqueBlocks {
+		if timestamp, ok := s.getCachedBlockTimestamp(blockNumber); ok {
+			result[blockNumber] = timestamp
 			continue
 		}
+		missingBlocks = append(missingBlocks, blockNumber)
+	}
 
-		requestCtx, cancel := context.WithTimeout(ctx, s.cfg.RequestTimeout)
-		block, err := s.rpc.getBlockByNumber(requestCtx, blockNumber)
+	if len(missingBlocks) == 0 {
+		return result, nil
+	}
+
+	type blockJob struct {
+		blockNumber uint64
+	}
+
+	workerCount := s.cfg.RPCConcurrency
+	if workerCount < 1 {
+		workerCount = 1
+	}
+	if workerCount > len(missingBlocks) {
+		workerCount = len(missingBlocks)
+	}
+
+	jobs := make(chan blockJob)
+	workerCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	fetched := make(map[uint64]int64, len(missingBlocks))
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	var firstErr error
+
+	setErr := func(err error) {
+		mu.Lock()
+		defer mu.Unlock()
+		if firstErr != nil {
+			return
+		}
+		firstErr = err
 		cancel()
-		if err != nil {
-			return nil, fmt.Errorf("load block %d: %w", blockNumber, err)
-		}
+	}
 
-		timestampUint, err := parseHexUint64(block.Timestamp)
-		if err != nil {
-			return nil, fmt.Errorf("parse block %d timestamp %q: %w", blockNumber, block.Timestamp, err)
-		}
-		timestampInt64, err := toInt64(timestampUint)
-		if err != nil {
-			return nil, fmt.Errorf("convert block %d timestamp %d: %w", blockNumber, timestampUint, err)
-		}
+	worker := func() {
+		defer wg.Done()
+		for job := range jobs {
+			if workerCtx.Err() != nil {
+				return
+			}
 
-		result[blockNumber] = timestampInt64
+			requestCtx, requestCancel := context.WithTimeout(workerCtx, s.cfg.RequestTimeout)
+			block, err := s.rpc.getBlockByNumber(requestCtx, job.blockNumber)
+			requestCancel()
+			if err != nil {
+				setErr(fmt.Errorf("load block %d: %w", job.blockNumber, err))
+				return
+			}
+
+			timestampUint, err := parseHexUint64(block.Timestamp)
+			if err != nil {
+				setErr(fmt.Errorf("parse block %d timestamp %q: %w", job.blockNumber, block.Timestamp, err))
+				return
+			}
+			timestampInt64, err := toInt64(timestampUint)
+			if err != nil {
+				setErr(fmt.Errorf("convert block %d timestamp %d: %w", job.blockNumber, timestampUint, err))
+				return
+			}
+
+			mu.Lock()
+			fetched[job.blockNumber] = timestampInt64
+			mu.Unlock()
+		}
+	}
+
+	for i := 0; i < workerCount; i++ {
+		wg.Add(1)
+		go worker()
+	}
+
+enqueue:
+	for i := range missingBlocks {
+		select {
+		case <-workerCtx.Done():
+			break enqueue
+		case jobs <- blockJob{blockNumber: missingBlocks[i]}:
+		}
+	}
+	close(jobs)
+	wg.Wait()
+
+	if firstErr != nil {
+		return nil, firstErr
+	}
+
+	s.storeBlockTimestamps(fetched)
+	for blockNumber, timestamp := range fetched {
+		result[blockNumber] = timestamp
 	}
 
 	return result, nil
+}
+
+func (s *Service) getCachedBlockTimestamp(blockNumber uint64) (int64, bool) {
+	s.cacheMu.RLock()
+	defer s.cacheMu.RUnlock()
+
+	timestamp, ok := s.blockTimestampCache[blockNumber]
+	return timestamp, ok
+}
+
+func (s *Service) storeBlockTimestamps(values map[uint64]int64) {
+	s.cacheMu.Lock()
+	defer s.cacheMu.Unlock()
+
+	for blockNumber, timestamp := range values {
+		s.blockTimestampCache[blockNumber] = timestamp
+	}
+
+	if len(s.blockTimestampCache) <= blockTimestampCacheMaxEntries {
+		return
+	}
+
+	keys := make([]uint64, 0, len(s.blockTimestampCache))
+	for blockNumber := range s.blockTimestampCache {
+		keys = append(keys, blockNumber)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		return keys[i] < keys[j]
+	})
+
+	toRemove := len(s.blockTimestampCache) - blockTimestampCacheMaxEntries
+	for i := 0; i < toRemove; i++ {
+		delete(s.blockTimestampCache, keys[i])
+	}
 }
 
 func popOperationMeta(

--- a/indexer/internal/indexer/indexer.go
+++ b/indexer/internal/indexer/indexer.go
@@ -120,6 +120,9 @@ func (s *Service) planScanRange(cursor uint64, hasCursor bool, safeHead uint64) 
 		if cursor > safeHead {
 			cursor = safeHead
 		}
+		if cursor >= safeHead {
+			return 0, 0, false
+		}
 		if cursor > s.cfg.ReorgWindow {
 			from = cursor - s.cfg.ReorgWindow
 		} else {

--- a/indexer/internal/indexer/indexer.go
+++ b/indexer/internal/indexer/indexer.go
@@ -280,8 +280,13 @@ func (s *Service) indexRangeAttempt(ctx context.Context, fromBlock uint64, toBlo
 
 		event, err := decodeUserOperationEventLog(log)
 		if err != nil {
-			slog.Warn("skip malformed user operation event", "err", err, "tx_hash", log.TransactionHash)
-			continue
+			return fmt.Errorf(
+				"decode user operation event tx %s block %s log_index %s: %w",
+				log.TransactionHash,
+				log.BlockNumber,
+				log.LogIndex,
+				err,
+			)
 		}
 
 		blockTimestamp, ok := blockTimestamps[event.BlockNumber]

--- a/indexer/internal/indexer/indexer.go
+++ b/indexer/internal/indexer/indexer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"math"
 	"sort"
 	"strings"
 	"sync"
@@ -42,6 +43,9 @@ func New(cfg Config, pool *pgxpool.Pool) (*Service, error) {
 	}
 	if cfg.RPCResponseMaxBytes <= 0 {
 		return nil, fmt.Errorf("RPCResponseMaxBytes must be greater than 0")
+	}
+	if cfg.RPCResponseMaxBytes >= math.MaxInt64 {
+		return nil, fmt.Errorf("RPCResponseMaxBytes must be less than %d", math.MaxInt64)
 	}
 	if cfg.StateKey == "" {
 		return nil, fmt.Errorf("StateKey is required")

--- a/indexer/internal/indexer/indexer.go
+++ b/indexer/internal/indexer/indexer.go
@@ -40,6 +40,9 @@ func New(cfg Config, pool *pgxpool.Pool) (*Service, error) {
 	if cfg.RPCConcurrency <= 0 {
 		return nil, fmt.Errorf("RPCConcurrency must be greater than 0")
 	}
+	if cfg.RPCResponseMaxBytes <= 0 {
+		return nil, fmt.Errorf("RPCResponseMaxBytes must be greater than 0")
+	}
 	if cfg.StateKey == "" {
 		return nil, fmt.Errorf("StateKey is required")
 	}
@@ -55,7 +58,7 @@ func New(cfg Config, pool *pgxpool.Pool) (*Service, error) {
 	return &Service{
 		cfg:                 cfg,
 		pool:                pool,
-		rpc:                 newRPCClient(cfg.RPCURL),
+		rpc:                 newRPCClient(cfg.RPCURL, cfg.RPCResponseMaxBytes),
 		entryPoint:          normalizedEntryPoint,
 		blockTimestampCache: make(map[uint64]int64),
 	}, nil
@@ -101,9 +104,13 @@ func (s *Service) Run(ctx context.Context) error {
 }
 
 func (s *Service) indexOnce(ctx context.Context) error {
-	safeHead, err := s.safeHead(ctx)
+	safeHead, hasSafeHead, err := s.safeHead(ctx)
 	if err != nil {
 		return fmt.Errorf("fetch safe head: %w", err)
+	}
+	if !hasSafeHead {
+		slog.Debug("indexer idle", "reason", "no_safe_head_yet")
+		return nil
 	}
 
 	cursor, hasCursor, err := db.GetStateUint64(ctx, s.pool, s.cfg.StateKey)
@@ -165,9 +172,9 @@ func (s *Service) indexOnce(ctx context.Context) error {
 	return nil
 }
 
-func (s *Service) safeHead(ctx context.Context) (uint64, error) {
+func (s *Service) safeHead(ctx context.Context) (uint64, bool, error) {
 	if err := ctx.Err(); err != nil {
-		return 0, err
+		return 0, false, err
 	}
 
 	requestCtx, cancel := context.WithTimeout(ctx, s.cfg.RequestTimeout)
@@ -175,14 +182,14 @@ func (s *Service) safeHead(ctx context.Context) (uint64, error) {
 
 	latest, err := s.rpc.latestBlockNumber(requestCtx)
 	if err != nil {
-		return 0, err
+		return 0, false, err
 	}
 
 	if latest < s.cfg.Confirmations {
-		return 0, nil
+		return 0, false, nil
 	}
 
-	return latest - s.cfg.Confirmations, nil
+	return latest - s.cfg.Confirmations, true, nil
 }
 
 func (s *Service) planScanRange(cursor uint64, hasCursor bool, safeHead uint64) (uint64, uint64, bool) {
@@ -213,6 +220,25 @@ func (s *Service) planScanRange(cursor uint64, hasCursor bool, safeHead uint64) 
 }
 
 func (s *Service) indexRange(ctx context.Context, fromBlock uint64, toBlock uint64) error {
+	if fromBlock > toBlock {
+		return fmt.Errorf("invalid block range: from %d > to %d", fromBlock, toBlock)
+	}
+
+	if err := s.indexRangeAttempt(ctx, fromBlock, toBlock); err != nil {
+		if isRPCResponseTooLarge(err) && fromBlock < toBlock {
+			mid := fromBlock + (toBlock-fromBlock)/2
+			if err := s.indexRange(ctx, fromBlock, mid); err != nil {
+				return err
+			}
+			return s.indexRange(ctx, mid+1, toBlock)
+		}
+		return err
+	}
+
+	return nil
+}
+
+func (s *Service) indexRangeAttempt(ctx context.Context, fromBlock uint64, toBlock uint64) error {
 	requestCtx, cancel := context.WithTimeout(ctx, s.cfg.RequestTimeout)
 	logs, err := s.rpc.getLogs(requestCtx, s.entryPoint, userOperationEventTopic, fromBlock, toBlock)
 	cancel()

--- a/indexer/internal/indexer/indexer.go
+++ b/indexer/internal/indexer/indexer.go
@@ -1,0 +1,310 @@
+package indexer
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/flwrenn/bastion/indexer/internal/db"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+type Service struct {
+	cfg        Config
+	pool       *pgxpool.Pool
+	rpc        *rpcClient
+	entryPoint string
+}
+
+func New(cfg Config, pool *pgxpool.Pool) (*Service, error) {
+	normalizedEntryPoint, err := normalizeAddress(cfg.EntryPoint)
+	if err != nil {
+		return nil, fmt.Errorf("normalize entrypoint: %w", err)
+	}
+
+	return &Service{
+		cfg:        cfg,
+		pool:       pool,
+		rpc:        newRPCClient(cfg.RPCURL),
+		entryPoint: normalizedEntryPoint,
+	}, nil
+}
+
+func (s *Service) Run(ctx context.Context) error {
+	if err := s.indexOnce(ctx); err != nil {
+		return err
+	}
+
+	ticker := time.NewTicker(s.cfg.PollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			if err := s.indexOnce(ctx); err != nil {
+				slog.Error("index iteration failed", "err", err)
+			}
+		}
+	}
+}
+
+func (s *Service) indexOnce(ctx context.Context) error {
+	safeHead, err := s.safeHead(ctx)
+	if err != nil {
+		return fmt.Errorf("fetch safe head: %w", err)
+	}
+
+	cursor, hasCursor, err := db.GetStateUint64(ctx, s.pool, s.cfg.StateKey)
+	if err != nil {
+		return fmt.Errorf("load cursor: %w", err)
+	}
+
+	from, to, ok := s.planScanRange(cursor, hasCursor, safeHead)
+	if !ok {
+		slog.Debug("indexer idle", "safe_head", safeHead, "cursor", cursor, "has_cursor", hasCursor)
+		return nil
+	}
+
+	for batchFrom := from; batchFrom <= to; {
+		batchTo := batchFrom + s.cfg.BatchSize - 1
+		if batchTo > to || batchTo < batchFrom {
+			batchTo = to
+		}
+
+		if err := s.indexRange(ctx, batchFrom, batchTo); err != nil {
+			return err
+		}
+
+		if batchTo == to {
+			break
+		}
+		batchFrom = batchTo + 1
+	}
+
+	return nil
+}
+
+func (s *Service) safeHead(ctx context.Context) (uint64, error) {
+	requestCtx, cancel := context.WithTimeout(ctx, s.cfg.RequestTimeout)
+	defer cancel()
+
+	latest, err := s.rpc.latestBlockNumber(requestCtx)
+	if err != nil {
+		return 0, err
+	}
+
+	if latest < s.cfg.Confirmations {
+		return 0, nil
+	}
+
+	return latest - s.cfg.Confirmations, nil
+}
+
+func (s *Service) planScanRange(cursor uint64, hasCursor bool, safeHead uint64) (uint64, uint64, bool) {
+	var from uint64
+	if hasCursor {
+		if cursor > safeHead {
+			cursor = safeHead
+		}
+		if cursor > s.cfg.ReorgWindow {
+			from = cursor - s.cfg.ReorgWindow
+		} else {
+			from = 0
+		}
+	} else if s.cfg.HasStartBlock {
+		from = s.cfg.StartBlock
+	} else {
+		from = safeHead
+	}
+
+	if from > safeHead {
+		return 0, 0, false
+	}
+
+	return from, safeHead, true
+}
+
+func (s *Service) indexRange(ctx context.Context, fromBlock uint64, toBlock uint64) error {
+	requestCtx, cancel := context.WithTimeout(ctx, s.cfg.RequestTimeout)
+	logs, err := s.rpc.getLogs(requestCtx, s.entryPoint, userOperationEventTopic, fromBlock, toBlock)
+	cancel()
+	if err != nil {
+		return fmt.Errorf("fetch logs [%d,%d]: %w", fromBlock, toBlock, err)
+	}
+
+	txMetaByHash, err := s.loadTransactionOperationMeta(ctx, logs)
+	if err != nil {
+		return fmt.Errorf("load transaction metadata: %w", err)
+	}
+
+	blockTimestamps, err := s.loadBlockTimestamps(ctx, logs)
+	if err != nil {
+		return fmt.Errorf("load block timestamps: %w", err)
+	}
+
+	operations := make([]db.UserOperation, 0, len(logs))
+	for i := range logs {
+		log := logs[i]
+		if log.Removed {
+			continue
+		}
+
+		event, err := decodeUserOperationEventLog(log)
+		if err != nil {
+			slog.Warn("skip malformed user operation event", "err", err, "tx_hash", log.TransactionHash)
+			continue
+		}
+
+		blockTimestamp, ok := blockTimestamps[event.BlockNumber]
+		if !ok {
+			return fmt.Errorf("missing timestamp for block %d", event.BlockNumber)
+		}
+
+		meta := popOperationMeta(txMetaByHash, event.TxHashHex, event.Sender, event.Nonce)
+
+		blockNumberInt64, err := toInt64(event.BlockNumber)
+		if err != nil {
+			return fmt.Errorf("convert block number %d: %w", event.BlockNumber, err)
+		}
+
+		operations = append(operations, db.UserOperation{
+			UserOpHash:     event.UserOpHash,
+			Sender:         event.Sender,
+			Paymaster:      event.Paymaster,
+			Target:         meta.Target,
+			Calldata:       meta.Calldata,
+			Nonce:          event.Nonce,
+			Success:        event.Success,
+			ActualGasCost:  event.ActualGasCost,
+			ActualGasUsed:  event.ActualGasUsed,
+			TxHash:         event.TxHash,
+			BlockNumber:    blockNumberInt64,
+			BlockTimestamp: blockTimestamp,
+			LogIndex:       event.LogIndex,
+		})
+	}
+
+	if err := db.ReplaceOperationsAndSetCursor(
+		ctx,
+		s.pool,
+		s.cfg.StateKey,
+		fromBlock,
+		toBlock,
+		toBlock,
+		operations,
+	); err != nil {
+		return fmt.Errorf("persist range [%d,%d]: %w", fromBlock, toBlock, err)
+	}
+
+	slog.Info(
+		"indexed block range",
+		"from",
+		fromBlock,
+		"to",
+		toBlock,
+		"events",
+		len(operations),
+	)
+
+	return nil
+}
+
+func (s *Service) loadTransactionOperationMeta(ctx context.Context, logs []rpcLog) (map[string]map[string][]operationMeta, error) {
+	result := make(map[string]map[string][]operationMeta)
+	for i := range logs {
+		log := logs[i]
+		txHash := strings.ToLower(log.TransactionHash)
+		if _, exists := result[txHash]; exists {
+			continue
+		}
+
+		requestCtx, cancel := context.WithTimeout(ctx, s.cfg.RequestTimeout)
+		tx, err := s.rpc.getTransactionByHash(requestCtx, log.TransactionHash)
+		cancel()
+		if err != nil {
+			return nil, fmt.Errorf("load tx %s: %w", log.TransactionHash, err)
+		}
+
+		input, err := decodeHex(tx.Input)
+		if err != nil {
+			return nil, fmt.Errorf("decode tx input %s: %w", tx.Hash, err)
+		}
+
+		calls, err := decodeHandleOpsInput(input)
+		if err != nil {
+			slog.Debug("transaction input not handleOps or undecodable", "tx_hash", tx.Hash, "err", err)
+			result[txHash] = map[string][]operationMeta{}
+			continue
+		}
+
+		result[txHash] = toOperationMetaQueue(calls)
+	}
+
+	return result, nil
+}
+
+func (s *Service) loadBlockTimestamps(ctx context.Context, logs []rpcLog) (map[uint64]int64, error) {
+	result := make(map[uint64]int64)
+	for i := range logs {
+		log := logs[i]
+		blockNumber, err := parseHexUint64(log.BlockNumber)
+		if err != nil {
+			return nil, fmt.Errorf("parse block number %q: %w", log.BlockNumber, err)
+		}
+
+		if _, exists := result[blockNumber]; exists {
+			continue
+		}
+
+		requestCtx, cancel := context.WithTimeout(ctx, s.cfg.RequestTimeout)
+		block, err := s.rpc.getBlockByNumber(requestCtx, blockNumber)
+		cancel()
+		if err != nil {
+			return nil, fmt.Errorf("load block %d: %w", blockNumber, err)
+		}
+
+		timestampUint, err := parseHexUint64(block.Timestamp)
+		if err != nil {
+			return nil, fmt.Errorf("parse block %d timestamp %q: %w", blockNumber, block.Timestamp, err)
+		}
+		timestampInt64, err := toInt64(timestampUint)
+		if err != nil {
+			return nil, fmt.Errorf("convert block %d timestamp %d: %w", blockNumber, timestampUint, err)
+		}
+
+		result[blockNumber] = timestampInt64
+	}
+
+	return result, nil
+}
+
+func popOperationMeta(
+	txMetaByHash map[string]map[string][]operationMeta,
+	txHash string,
+	sender []byte,
+	nonce string,
+) operationMeta {
+	txMeta, ok := txMetaByHash[txHash]
+	if !ok {
+		return operationMeta{}
+	}
+
+	key := operationKey(sender, nonce)
+	queue := txMeta[key]
+	if len(queue) == 0 {
+		return operationMeta{}
+	}
+
+	meta := queue[0]
+	if len(queue) == 1 {
+		delete(txMeta, key)
+	} else {
+		txMeta[key] = queue[1:]
+	}
+
+	return meta
+}

--- a/indexer/internal/indexer/indexer.go
+++ b/indexer/internal/indexer/indexer.go
@@ -34,7 +34,10 @@ func New(cfg Config, pool *pgxpool.Pool) (*Service, error) {
 
 func (s *Service) Run(ctx context.Context) error {
 	if err := s.indexOnce(ctx); err != nil {
-		return err
+		if ctx.Err() != nil {
+			return nil
+		}
+		slog.Error("initial index iteration failed", "err", err)
 	}
 
 	ticker := time.NewTicker(s.cfg.PollInterval)
@@ -46,6 +49,9 @@ func (s *Service) Run(ctx context.Context) error {
 			return nil
 		case <-ticker.C:
 			if err := s.indexOnce(ctx); err != nil {
+				if ctx.Err() != nil {
+					return nil
+				}
 				slog.Error("index iteration failed", "err", err)
 			}
 		}
@@ -89,6 +95,10 @@ func (s *Service) indexOnce(ctx context.Context) error {
 }
 
 func (s *Service) safeHead(ctx context.Context) (uint64, error) {
+	if err := ctx.Err(); err != nil {
+		return 0, err
+	}
+
 	requestCtx, cancel := context.WithTimeout(ctx, s.cfg.RequestTimeout)
 	defer cancel()
 

--- a/indexer/internal/indexer/indexer.go
+++ b/indexer/internal/indexer/indexer.go
@@ -44,7 +44,7 @@ func (s *Service) Run(ctx context.Context) error {
 		if ctx.Err() != nil {
 			return nil
 		}
-		slog.Error("initial index iteration failed", "err", err)
+		return fmt.Errorf("initial index iteration failed: %w", err)
 	}
 
 	ticker := time.NewTicker(s.cfg.PollInterval)
@@ -74,6 +74,19 @@ func (s *Service) indexOnce(ctx context.Context) error {
 	cursor, hasCursor, err := db.GetStateUint64(ctx, s.pool, s.cfg.StateKey)
 	if err != nil {
 		return fmt.Errorf("load cursor: %w", err)
+	}
+	if hasCursor && cursor > safeHead {
+		slog.Warn(
+			"cursor ahead of safe head; trimming future rows",
+			"cursor",
+			cursor,
+			"safe_head",
+			safeHead,
+		)
+		if err := db.TrimOperationsAboveBlockAndSetCursor(ctx, s.pool, s.cfg.StateKey, safeHead); err != nil {
+			return fmt.Errorf("reconcile cursor to safe head: %w", err)
+		}
+		cursor = safeHead
 	}
 
 	from, to, ok := s.planScanRange(cursor, hasCursor, safeHead)

--- a/indexer/internal/indexer/indexer.go
+++ b/indexer/internal/indexer/indexer.go
@@ -43,6 +43,9 @@ func New(cfg Config, pool *pgxpool.Pool) (*Service, error) {
 	if cfg.StateKey == "" {
 		return nil, fmt.Errorf("StateKey is required")
 	}
+	if pool == nil {
+		return nil, fmt.Errorf("pool is required")
+	}
 
 	normalizedEntryPoint, err := normalizeAddress(cfg.EntryPoint)
 	if err != nil {
@@ -59,6 +62,19 @@ func New(cfg Config, pool *pgxpool.Pool) (*Service, error) {
 }
 
 func (s *Service) Run(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		return nil
+	}
+	if s.cfg.PollInterval <= 0 {
+		return fmt.Errorf("PollInterval must be greater than 0")
+	}
+	if s.pool == nil {
+		return fmt.Errorf("pool is required")
+	}
+	if s.rpc == nil {
+		return fmt.Errorf("rpc client is required")
+	}
+
 	if err := s.indexOnce(ctx); err != nil {
 		if ctx.Err() != nil {
 			return nil

--- a/indexer/internal/indexer/indexer.go
+++ b/indexer/internal/indexer/indexer.go
@@ -121,6 +121,7 @@ func (s *Service) indexOnce(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("load cursor: %w", err)
 	}
+	trimmedCursor := false
 	if hasCursor && cursor > safeHead {
 		delta := cursor - safeHead
 		if !s.cfg.AllowCursorTrim {
@@ -149,6 +150,16 @@ func (s *Service) indexOnce(ctx context.Context) error {
 			return fmt.Errorf("reconcile cursor to safe head: %w", err)
 		}
 		cursor = safeHead
+		trimmedCursor = true
+	}
+
+	if trimmedCursor {
+		from, to := rewindRangeToSafeHead(safeHead, s.cfg.ReorgWindow)
+		slog.Info("resyncing rewind window after cursor trim", "from", from, "to", to)
+		if err := s.indexRange(ctx, from, to); err != nil {
+			return err
+		}
+		return nil
 	}
 
 	from, to, ok := s.planScanRange(cursor, hasCursor, safeHead)
@@ -194,6 +205,13 @@ func (s *Service) safeHead(ctx context.Context) (uint64, bool, error) {
 	}
 
 	return latest - s.cfg.Confirmations, true, nil
+}
+
+func rewindRangeToSafeHead(safeHead uint64, reorgWindow uint64) (uint64, uint64) {
+	if safeHead > reorgWindow {
+		return safeHead - reorgWindow, safeHead
+	}
+	return 0, safeHead
 }
 
 func (s *Service) planScanRange(cursor uint64, hasCursor bool, safeHead uint64) (uint64, uint64, bool) {

--- a/indexer/internal/indexer/indexer.go
+++ b/indexer/internal/indexer/indexer.go
@@ -25,6 +25,25 @@ type Service struct {
 const blockTimestampCacheMaxEntries = 4096
 
 func New(cfg Config, pool *pgxpool.Pool) (*Service, error) {
+	if cfg.RPCURL == "" {
+		return nil, fmt.Errorf("RPCURL is required")
+	}
+	if cfg.PollInterval <= 0 {
+		return nil, fmt.Errorf("PollInterval must be greater than 0")
+	}
+	if cfg.BatchSize == 0 {
+		return nil, fmt.Errorf("BatchSize must be greater than 0")
+	}
+	if cfg.RequestTimeout <= 0 {
+		return nil, fmt.Errorf("RequestTimeout must be greater than 0")
+	}
+	if cfg.RPCConcurrency <= 0 {
+		return nil, fmt.Errorf("RPCConcurrency must be greater than 0")
+	}
+	if cfg.StateKey == "" {
+		return nil, fmt.Errorf("StateKey is required")
+	}
+
 	normalizedEntryPoint, err := normalizeAddress(cfg.EntryPoint)
 	if err != nil {
 		return nil, fmt.Errorf("normalize entrypoint: %w", err)
@@ -76,12 +95,28 @@ func (s *Service) indexOnce(ctx context.Context) error {
 		return fmt.Errorf("load cursor: %w", err)
 	}
 	if hasCursor && cursor > safeHead {
+		delta := cursor - safeHead
+		if !s.cfg.AllowCursorTrim {
+			slog.Warn(
+				"cursor ahead of safe head; skipping iteration",
+				"cursor",
+				cursor,
+				"safe_head",
+				safeHead,
+				"delta",
+				delta,
+			)
+			return nil
+		}
+
 		slog.Warn(
 			"cursor ahead of safe head; trimming future rows",
 			"cursor",
 			cursor,
 			"safe_head",
 			safeHead,
+			"delta",
+			delta,
 		)
 		if err := db.TrimOperationsAboveBlockAndSetCursor(ctx, s.pool, s.cfg.StateKey, safeHead); err != nil {
 			return fmt.Errorf("reconcile cursor to safe head: %w", err)

--- a/indexer/internal/indexer/indexer.go
+++ b/indexer/internal/indexer/indexer.go
@@ -136,22 +136,31 @@ func (s *Service) indexRange(ctx context.Context, fromBlock uint64, toBlock uint
 		return fmt.Errorf("fetch logs [%d,%d]: %w", fromBlock, toBlock, err)
 	}
 
-	txMetaByHash, err := s.loadTransactionOperationMeta(ctx, logs)
-	if err != nil {
-		return fmt.Errorf("load transaction metadata: %w", err)
-	}
-
-	blockTimestamps, err := s.loadBlockTimestamps(ctx, logs)
-	if err != nil {
-		return fmt.Errorf("load block timestamps: %w", err)
-	}
-
-	operations := make([]db.UserOperation, 0, len(logs))
+	activeLogs := make([]rpcLog, 0, len(logs))
 	for i := range logs {
-		log := logs[i]
-		if log.Removed {
+		if logs[i].Removed {
 			continue
 		}
+		activeLogs = append(activeLogs, logs[i])
+	}
+
+	txMetaByHash := make(map[string]map[string][]operationMeta)
+	blockTimestamps := make(map[uint64]int64)
+	if len(activeLogs) > 0 {
+		txMetaByHash, err = s.loadTransactionOperationMeta(ctx, activeLogs)
+		if err != nil {
+			return fmt.Errorf("load transaction metadata: %w", err)
+		}
+
+		blockTimestamps, err = s.loadBlockTimestamps(ctx, activeLogs)
+		if err != nil {
+			return fmt.Errorf("load block timestamps: %w", err)
+		}
+	}
+
+	operations := make([]db.UserOperation, 0, len(activeLogs))
+	for i := range activeLogs {
+		log := activeLogs[i]
 
 		event, err := decodeUserOperationEventLog(log)
 		if err != nil {

--- a/indexer/internal/indexer/indexer_test.go
+++ b/indexer/internal/indexer/indexer_test.go
@@ -70,3 +70,17 @@ func TestPlanScanRange_StartBlockAboveSafeHead(t *testing.T) {
 		t.Fatal("expected no scan range when start block > safe head")
 	}
 }
+
+func TestRewindRangeToSafeHead(t *testing.T) {
+	t.Parallel()
+
+	from, to := rewindRangeToSafeHead(100, 20)
+	if from != 80 || to != 100 {
+		t.Fatalf("expected [80,100], got [%d,%d]", from, to)
+	}
+
+	from, to = rewindRangeToSafeHead(5, 20)
+	if from != 0 || to != 5 {
+		t.Fatalf("expected [0,5], got [%d,%d]", from, to)
+	}
+}

--- a/indexer/internal/indexer/indexer_test.go
+++ b/indexer/internal/indexer/indexer_test.go
@@ -41,16 +41,23 @@ func TestPlanScanRange_WithCursorAndReorgWindow(t *testing.T) {
 	}
 }
 
-func TestPlanScanRange_ClampsCursorToSafeHead(t *testing.T) {
+func TestPlanScanRange_CursorAheadOfSafeHeadReturnsNoRange(t *testing.T) {
 	t.Parallel()
 
 	svc := Service{cfg: Config{ReorgWindow: 3}}
-	from, to, ok := svc.planScanRange(200, true, 50)
-	if !ok {
-		t.Fatal("expected scan range to be available")
+	_, _, ok := svc.planScanRange(200, true, 50)
+	if ok {
+		t.Fatal("expected no scan range when cursor is ahead of safe head")
 	}
-	if from != 47 || to != 50 {
-		t.Fatalf("expected range [47,50], got [%d,%d]", from, to)
+}
+
+func TestPlanScanRange_CursorAtSafeHeadReturnsNoRange(t *testing.T) {
+	t.Parallel()
+
+	svc := Service{cfg: Config{ReorgWindow: 3}}
+	_, _, ok := svc.planScanRange(50, true, 50)
+	if ok {
+		t.Fatal("expected no scan range when cursor is at safe head")
 	}
 }
 

--- a/indexer/internal/indexer/indexer_test.go
+++ b/indexer/internal/indexer/indexer_test.go
@@ -1,0 +1,65 @@
+package indexer
+
+import "testing"
+
+func TestPlanScanRange_NoCursor_NoStartBlock(t *testing.T) {
+	t.Parallel()
+
+	svc := Service{cfg: Config{}}
+	from, to, ok := svc.planScanRange(0, false, 100)
+	if !ok {
+		t.Fatal("expected scan range to be available")
+	}
+	if from != 100 || to != 100 {
+		t.Fatalf("expected range [100,100], got [%d,%d]", from, to)
+	}
+}
+
+func TestPlanScanRange_NoCursor_WithStartBlock(t *testing.T) {
+	t.Parallel()
+
+	svc := Service{cfg: Config{HasStartBlock: true, StartBlock: 42}}
+	from, to, ok := svc.planScanRange(0, false, 100)
+	if !ok {
+		t.Fatal("expected scan range to be available")
+	}
+	if from != 42 || to != 100 {
+		t.Fatalf("expected range [42,100], got [%d,%d]", from, to)
+	}
+}
+
+func TestPlanScanRange_WithCursorAndReorgWindow(t *testing.T) {
+	t.Parallel()
+
+	svc := Service{cfg: Config{ReorgWindow: 5}}
+	from, to, ok := svc.planScanRange(20, true, 30)
+	if !ok {
+		t.Fatal("expected scan range to be available")
+	}
+	if from != 15 || to != 30 {
+		t.Fatalf("expected range [15,30], got [%d,%d]", from, to)
+	}
+}
+
+func TestPlanScanRange_ClampsCursorToSafeHead(t *testing.T) {
+	t.Parallel()
+
+	svc := Service{cfg: Config{ReorgWindow: 3}}
+	from, to, ok := svc.planScanRange(200, true, 50)
+	if !ok {
+		t.Fatal("expected scan range to be available")
+	}
+	if from != 47 || to != 50 {
+		t.Fatalf("expected range [47,50], got [%d,%d]", from, to)
+	}
+}
+
+func TestPlanScanRange_StartBlockAboveSafeHead(t *testing.T) {
+	t.Parallel()
+
+	svc := Service{cfg: Config{HasStartBlock: true, StartBlock: 1000}}
+	_, _, ok := svc.planScanRange(0, false, 100)
+	if ok {
+		t.Fatal("expected no scan range when start block > safe head")
+	}
+}

--- a/indexer/internal/indexer/rpc.go
+++ b/indexer/internal/indexer/rpc.go
@@ -9,7 +9,10 @@ import (
 	"net/http"
 )
 
-const jsonRPCVersion = "2.0"
+const (
+	jsonRPCVersion     = "2.0"
+	maxRPCResponseSize = 8 * 1024 * 1024
+)
 
 type rpcClient struct {
 	url        string
@@ -90,9 +93,12 @@ func (c *rpcClient) call(ctx context.Context, method string, params any, out any
 	}
 	defer httpResp.Body.Close()
 
-	body, err := io.ReadAll(httpResp.Body)
+	body, err := io.ReadAll(io.LimitReader(httpResp.Body, maxRPCResponseSize+1))
 	if err != nil {
 		return fmt.Errorf("read rpc response %s: %w", method, err)
+	}
+	if len(body) > maxRPCResponseSize {
+		return fmt.Errorf("rpc %s response exceeds %d bytes", method, maxRPCResponseSize)
 	}
 
 	if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {

--- a/indexer/internal/indexer/rpc.go
+++ b/indexer/internal/indexer/rpc.go
@@ -1,0 +1,174 @@
+package indexer
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+const jsonRPCVersion = "2.0"
+
+type rpcClient struct {
+	url        string
+	httpClient *http.Client
+}
+
+type rpcRequest struct {
+	JSONRPC string `json:"jsonrpc"`
+	ID      uint64 `json:"id"`
+	Method  string `json:"method"`
+	Params  any    `json:"params"`
+}
+
+type rpcError struct {
+	Code    int             `json:"code"`
+	Message string          `json:"message"`
+	Data    json.RawMessage `json:"data"`
+}
+
+type rpcResponse struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      uint64          `json:"id"`
+	Result  json.RawMessage `json:"result"`
+	Error   *rpcError       `json:"error"`
+}
+
+type rpcLog struct {
+	Address         string   `json:"address"`
+	Topics          []string `json:"topics"`
+	Data            string   `json:"data"`
+	TransactionHash string   `json:"transactionHash"`
+	BlockNumber     string   `json:"blockNumber"`
+	LogIndex        string   `json:"logIndex"`
+	Removed         bool     `json:"removed"`
+}
+
+type rpcTransaction struct {
+	Hash  string `json:"hash"`
+	Input string `json:"input"`
+}
+
+type rpcBlock struct {
+	Number    string `json:"number"`
+	Timestamp string `json:"timestamp"`
+}
+
+func newRPCClient(url string) *rpcClient {
+	return &rpcClient{
+		url: url,
+		httpClient: &http.Client{
+			Timeout: 0,
+		},
+	}
+}
+
+func (c *rpcClient) call(ctx context.Context, method string, params any, out any) error {
+	reqBody := rpcRequest{
+		JSONRPC: jsonRPCVersion,
+		ID:      1,
+		Method:  method,
+		Params:  params,
+	}
+
+	payload, err := json.Marshal(reqBody)
+	if err != nil {
+		return fmt.Errorf("marshal rpc request %s: %w", method, err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, c.url, bytes.NewReader(payload))
+	if err != nil {
+		return fmt.Errorf("create rpc request %s: %w", method, err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	httpResp, err := c.httpClient.Do(httpReq)
+	if err != nil {
+		return fmt.Errorf("send rpc request %s: %w", method, err)
+	}
+	defer httpResp.Body.Close()
+
+	body, err := io.ReadAll(httpResp.Body)
+	if err != nil {
+		return fmt.Errorf("read rpc response %s: %w", method, err)
+	}
+
+	if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {
+		return fmt.Errorf("rpc %s returned status %d: %s", method, httpResp.StatusCode, string(body))
+	}
+
+	var rpcResp rpcResponse
+	if err := json.Unmarshal(body, &rpcResp); err != nil {
+		return fmt.Errorf("decode rpc response %s: %w", method, err)
+	}
+
+	if rpcResp.Error != nil {
+		return fmt.Errorf("rpc %s error %d: %s", method, rpcResp.Error.Code, rpcResp.Error.Message)
+	}
+
+	if out == nil {
+		return nil
+	}
+
+	if err := json.Unmarshal(rpcResp.Result, out); err != nil {
+		return fmt.Errorf("decode rpc result %s: %w", method, err)
+	}
+
+	return nil
+}
+
+func (c *rpcClient) latestBlockNumber(ctx context.Context) (uint64, error) {
+	var raw string
+	if err := c.call(ctx, "eth_blockNumber", []any{}, &raw); err != nil {
+		return 0, err
+	}
+
+	value, err := parseHexUint64(raw)
+	if err != nil {
+		return 0, fmt.Errorf("parse block number: %w", err)
+	}
+
+	return value, nil
+}
+
+func (c *rpcClient) getLogs(ctx context.Context, address string, topic0 string, fromBlock uint64, toBlock uint64) ([]rpcLog, error) {
+	filter := map[string]any{
+		"address":   address,
+		"fromBlock": fmt.Sprintf("0x%x", fromBlock),
+		"toBlock":   fmt.Sprintf("0x%x", toBlock),
+		"topics":    []any{topic0},
+	}
+
+	var logs []rpcLog
+	if err := c.call(ctx, "eth_getLogs", []any{filter}, &logs); err != nil {
+		return nil, err
+	}
+
+	return logs, nil
+}
+
+func (c *rpcClient) getTransactionByHash(ctx context.Context, txHash string) (rpcTransaction, error) {
+	var tx *rpcTransaction
+	if err := c.call(ctx, "eth_getTransactionByHash", []any{txHash}, &tx); err != nil {
+		return rpcTransaction{}, err
+	}
+	if tx == nil {
+		return rpcTransaction{}, fmt.Errorf("transaction %s not found", txHash)
+	}
+
+	return *tx, nil
+}
+
+func (c *rpcClient) getBlockByNumber(ctx context.Context, number uint64) (rpcBlock, error) {
+	var block *rpcBlock
+	if err := c.call(ctx, "eth_getBlockByNumber", []any{fmt.Sprintf("0x%x", number), false}, &block); err != nil {
+		return rpcBlock{}, err
+	}
+	if block == nil {
+		return rpcBlock{}, fmt.Errorf("block %d not found", number)
+	}
+
+	return *block, nil
+}

--- a/indexer/internal/indexer/rpc.go
+++ b/indexer/internal/indexer/rpc.go
@@ -4,19 +4,20 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 )
 
-const (
-	jsonRPCVersion     = "2.0"
-	maxRPCResponseSize = 8 * 1024 * 1024
-)
+const jsonRPCVersion = "2.0"
+
+var errRPCResponseTooLarge = errors.New("rpc response exceeds size limit")
 
 type rpcClient struct {
-	url        string
-	httpClient *http.Client
+	url              string
+	maxResponseBytes int64
+	httpClient       *http.Client
 }
 
 type rpcRequest struct {
@@ -59,9 +60,10 @@ type rpcBlock struct {
 	Timestamp string `json:"timestamp"`
 }
 
-func newRPCClient(url string) *rpcClient {
+func newRPCClient(url string, maxResponseBytes int64) *rpcClient {
 	return &rpcClient{
-		url: url,
+		url:              url,
+		maxResponseBytes: maxResponseBytes,
 		httpClient: &http.Client{
 			Timeout: 0,
 		},
@@ -93,12 +95,12 @@ func (c *rpcClient) call(ctx context.Context, method string, params any, out any
 	}
 	defer httpResp.Body.Close()
 
-	body, err := io.ReadAll(io.LimitReader(httpResp.Body, maxRPCResponseSize+1))
+	body, err := io.ReadAll(io.LimitReader(httpResp.Body, c.maxResponseBytes+1))
 	if err != nil {
 		return fmt.Errorf("read rpc response %s: %w", method, err)
 	}
-	if len(body) > maxRPCResponseSize {
-		return fmt.Errorf("rpc %s response exceeds %d bytes", method, maxRPCResponseSize)
+	if int64(len(body)) > c.maxResponseBytes {
+		return fmt.Errorf("%w: rpc %s response exceeds %d bytes", errRPCResponseTooLarge, method, c.maxResponseBytes)
 	}
 
 	if httpResp.StatusCode < 200 || httpResp.StatusCode >= 300 {
@@ -123,6 +125,10 @@ func (c *rpcClient) call(ctx context.Context, method string, params any, out any
 	}
 
 	return nil
+}
+
+func isRPCResponseTooLarge(err error) bool {
+	return errors.Is(err, errRPCResponseTooLarge)
 }
 
 func (c *rpcClient) latestBlockNumber(ctx context.Context) (uint64, error) {

--- a/indexer/internal/indexer/rpc_test.go
+++ b/indexer/internal/indexer/rpc_test.go
@@ -1,0 +1,37 @@
+package indexer
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestRPCCallRejectsOversizedResponse(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"jsonrpc":"2.0","id":1,"result":"`)
+		chunk := make([]byte, maxRPCResponseSize)
+		for i := range chunk {
+			chunk[i] = 'a'
+		}
+		_, _ = w.Write(chunk)
+		_, _ = fmt.Fprint(w, `"}`)
+	}))
+	defer server.Close()
+
+	client := newRPCClient(server.URL)
+	err := client.call(context.Background(), "eth_blockNumber", []any{}, nil)
+	if err == nil {
+		t.Fatal("expected oversized response error")
+	}
+
+	expected := fmt.Sprintf("exceeds %d bytes", maxRPCResponseSize)
+	if got := err.Error(); got == "" || !strings.Contains(got, expected) {
+		t.Fatalf("expected error containing %q, got %q", expected, got)
+	}
+}

--- a/indexer/internal/indexer/rpc_test.go
+++ b/indexer/internal/indexer/rpc_test.go
@@ -12,10 +12,12 @@ import (
 func TestRPCCallRejectsOversizedResponse(t *testing.T) {
 	t.Parallel()
 
+	const limit = int64(1024)
+
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = fmt.Fprint(w, `{"jsonrpc":"2.0","id":1,"result":"`)
-		chunk := make([]byte, maxRPCResponseSize)
+		chunk := make([]byte, limit)
 		for i := range chunk {
 			chunk[i] = 'a'
 		}
@@ -24,13 +26,17 @@ func TestRPCCallRejectsOversizedResponse(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client := newRPCClient(server.URL)
+	client := newRPCClient(server.URL, limit)
 	err := client.call(context.Background(), "eth_blockNumber", []any{}, nil)
 	if err == nil {
 		t.Fatal("expected oversized response error")
 	}
 
-	expected := fmt.Sprintf("exceeds %d bytes", maxRPCResponseSize)
+	if !isRPCResponseTooLarge(err) {
+		t.Fatalf("expected oversized-response sentinel error, got %v", err)
+	}
+
+	expected := fmt.Sprintf("exceeds %d bytes", limit)
 	if got := err.Error(); got == "" || !strings.Contains(got, expected) {
 		t.Fatalf("expected error containing %q, got %q", expected, got)
 	}

--- a/indexer/internal/indexer/run_test.go
+++ b/indexer/internal/indexer/run_test.go
@@ -1,0 +1,20 @@
+package indexer
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestRunReturnsNilWhenContextCancelledBeforeInitialIteration(t *testing.T) {
+	t.Parallel()
+
+	svc := &Service{cfg: Config{PollInterval: time.Millisecond}}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	if err := svc.Run(ctx); err != nil {
+		t.Fatalf("expected nil error on canceled context, got %v", err)
+	}
+}

--- a/indexer/internal/indexer/run_test.go
+++ b/indexer/internal/indexer/run_test.go
@@ -2,6 +2,7 @@ package indexer
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 )
@@ -33,5 +34,114 @@ func TestRunReturnsErrorWhenInitialIterationFails(t *testing.T) {
 	err := svc.Run(context.Background())
 	if err == nil {
 		t.Fatal("expected initial iteration error")
+	}
+}
+
+func TestNewRejectsInvalidConfig(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		cfg     Config
+		wantErr string
+	}{
+		{
+			name: "missing rpc url",
+			cfg: Config{
+				EntryPoint:         defaultEntryPoint,
+				PollInterval:       time.Second,
+				BatchSize:          1,
+				RequestTimeout:     time.Second,
+				RPCConcurrency:     1,
+				EnableTxEnrichment: true,
+				StateKey:           stateKeyLastIndexedBlock,
+			},
+			wantErr: "RPCURL is required",
+		},
+		{
+			name: "non-positive poll interval",
+			cfg: Config{
+				RPCURL:             "http://127.0.0.1:8545",
+				EntryPoint:         defaultEntryPoint,
+				PollInterval:       0,
+				BatchSize:          1,
+				RequestTimeout:     time.Second,
+				RPCConcurrency:     1,
+				EnableTxEnrichment: true,
+				StateKey:           stateKeyLastIndexedBlock,
+			},
+			wantErr: "PollInterval must be greater than 0",
+		},
+		{
+			name: "zero batch size",
+			cfg: Config{
+				RPCURL:             "http://127.0.0.1:8545",
+				EntryPoint:         defaultEntryPoint,
+				PollInterval:       time.Second,
+				BatchSize:          0,
+				RequestTimeout:     time.Second,
+				RPCConcurrency:     1,
+				EnableTxEnrichment: true,
+				StateKey:           stateKeyLastIndexedBlock,
+			},
+			wantErr: "BatchSize must be greater than 0",
+		},
+		{
+			name: "non-positive request timeout",
+			cfg: Config{
+				RPCURL:             "http://127.0.0.1:8545",
+				EntryPoint:         defaultEntryPoint,
+				PollInterval:       time.Second,
+				BatchSize:          1,
+				RequestTimeout:     0,
+				RPCConcurrency:     1,
+				EnableTxEnrichment: true,
+				StateKey:           stateKeyLastIndexedBlock,
+			},
+			wantErr: "RequestTimeout must be greater than 0",
+		},
+		{
+			name: "non-positive rpc concurrency",
+			cfg: Config{
+				RPCURL:             "http://127.0.0.1:8545",
+				EntryPoint:         defaultEntryPoint,
+				PollInterval:       time.Second,
+				BatchSize:          1,
+				RequestTimeout:     time.Second,
+				RPCConcurrency:     0,
+				EnableTxEnrichment: true,
+				StateKey:           stateKeyLastIndexedBlock,
+			},
+			wantErr: "RPCConcurrency must be greater than 0",
+		},
+		{
+			name: "missing state key",
+			cfg: Config{
+				RPCURL:             "http://127.0.0.1:8545",
+				EntryPoint:         defaultEntryPoint,
+				PollInterval:       time.Second,
+				BatchSize:          1,
+				RequestTimeout:     time.Second,
+				RPCConcurrency:     1,
+				EnableTxEnrichment: true,
+				StateKey:           "",
+			},
+			wantErr: "StateKey is required",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := New(tt.cfg, nil)
+			if err == nil {
+				t.Fatalf("expected error containing %q", tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("expected error containing %q, got %v", tt.wantErr, err)
+			}
+		})
 	}
 }

--- a/indexer/internal/indexer/run_test.go
+++ b/indexer/internal/indexer/run_test.go
@@ -22,29 +22,12 @@ func TestRunReturnsNilWhenContextCancelledBeforeInitialIteration(t *testing.T) {
 	}
 }
 
-func TestRunReturnsErrorWhenInitialIterationFails(t *testing.T) {
-	t.Parallel()
-
-	svc := &Service{
-		cfg: Config{
-			PollInterval:   time.Millisecond,
-			RequestTimeout: time.Millisecond,
-		},
-		rpc: newRPCClient("http://127.0.0.1:1"),
-	}
-
-	err := svc.Run(context.Background())
-	if err == nil {
-		t.Fatal("expected initial iteration error")
-	}
-}
-
 func TestRunReturnsErrorWhenPoolIsNil(t *testing.T) {
 	t.Parallel()
 
 	svc := &Service{
 		cfg: Config{PollInterval: time.Second},
-		rpc: newRPCClient("http://127.0.0.1:1"),
+		rpc: newRPCClient("http://127.0.0.1:1", 1024),
 	}
 
 	err := svc.Run(context.Background())
@@ -53,6 +36,23 @@ func TestRunReturnsErrorWhenPoolIsNil(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "pool is required") {
 		t.Fatalf("expected pool error, got %v", err)
+	}
+}
+
+func TestRunReturnsErrorWhenRPCClientIsNil(t *testing.T) {
+	t.Parallel()
+
+	svc := &Service{
+		cfg:  Config{PollInterval: time.Second},
+		pool: &pgxpool.Pool{},
+	}
+
+	err := svc.Run(context.Background())
+	if err == nil {
+		t.Fatal("expected error when rpc client is nil")
+	}
+	if !strings.Contains(err.Error(), "rpc client is required") {
+		t.Fatalf("expected rpc client error, got %v", err)
 	}
 }
 
@@ -67,97 +67,119 @@ func TestNewRejectsInvalidConfig(t *testing.T) {
 		{
 			name: "nil pool",
 			cfg: Config{
-				RPCURL:             "http://127.0.0.1:8545",
-				EntryPoint:         defaultEntryPoint,
-				PollInterval:       time.Second,
-				BatchSize:          1,
-				RequestTimeout:     time.Second,
-				RPCConcurrency:     1,
-				EnableTxEnrichment: true,
-				StateKey:           stateKeyLastIndexedBlock,
+				RPCURL:              "http://127.0.0.1:8545",
+				EntryPoint:          defaultEntryPoint,
+				PollInterval:        time.Second,
+				BatchSize:           1,
+				RequestTimeout:      time.Second,
+				RPCConcurrency:      1,
+				RPCResponseMaxBytes: 1024,
+				EnableTxEnrichment:  true,
+				StateKey:            stateKeyLastIndexedBlock,
 			},
 			wantErr: "pool is required",
 		},
 		{
 			name: "missing rpc url",
 			cfg: Config{
-				EntryPoint:         defaultEntryPoint,
-				PollInterval:       time.Second,
-				BatchSize:          1,
-				RequestTimeout:     time.Second,
-				RPCConcurrency:     1,
-				EnableTxEnrichment: true,
-				StateKey:           stateKeyLastIndexedBlock,
+				EntryPoint:          defaultEntryPoint,
+				PollInterval:        time.Second,
+				BatchSize:           1,
+				RequestTimeout:      time.Second,
+				RPCConcurrency:      1,
+				RPCResponseMaxBytes: 1024,
+				EnableTxEnrichment:  true,
+				StateKey:            stateKeyLastIndexedBlock,
 			},
 			wantErr: "RPCURL is required",
 		},
 		{
 			name: "non-positive poll interval",
 			cfg: Config{
-				RPCURL:             "http://127.0.0.1:8545",
-				EntryPoint:         defaultEntryPoint,
-				PollInterval:       0,
-				BatchSize:          1,
-				RequestTimeout:     time.Second,
-				RPCConcurrency:     1,
-				EnableTxEnrichment: true,
-				StateKey:           stateKeyLastIndexedBlock,
+				RPCURL:              "http://127.0.0.1:8545",
+				EntryPoint:          defaultEntryPoint,
+				PollInterval:        0,
+				BatchSize:           1,
+				RequestTimeout:      time.Second,
+				RPCConcurrency:      1,
+				RPCResponseMaxBytes: 1024,
+				EnableTxEnrichment:  true,
+				StateKey:            stateKeyLastIndexedBlock,
 			},
 			wantErr: "PollInterval must be greater than 0",
 		},
 		{
 			name: "zero batch size",
 			cfg: Config{
-				RPCURL:             "http://127.0.0.1:8545",
-				EntryPoint:         defaultEntryPoint,
-				PollInterval:       time.Second,
-				BatchSize:          0,
-				RequestTimeout:     time.Second,
-				RPCConcurrency:     1,
-				EnableTxEnrichment: true,
-				StateKey:           stateKeyLastIndexedBlock,
+				RPCURL:              "http://127.0.0.1:8545",
+				EntryPoint:          defaultEntryPoint,
+				PollInterval:        time.Second,
+				BatchSize:           0,
+				RequestTimeout:      time.Second,
+				RPCConcurrency:      1,
+				RPCResponseMaxBytes: 1024,
+				EnableTxEnrichment:  true,
+				StateKey:            stateKeyLastIndexedBlock,
 			},
 			wantErr: "BatchSize must be greater than 0",
 		},
 		{
 			name: "non-positive request timeout",
 			cfg: Config{
-				RPCURL:             "http://127.0.0.1:8545",
-				EntryPoint:         defaultEntryPoint,
-				PollInterval:       time.Second,
-				BatchSize:          1,
-				RequestTimeout:     0,
-				RPCConcurrency:     1,
-				EnableTxEnrichment: true,
-				StateKey:           stateKeyLastIndexedBlock,
+				RPCURL:              "http://127.0.0.1:8545",
+				EntryPoint:          defaultEntryPoint,
+				PollInterval:        time.Second,
+				BatchSize:           1,
+				RequestTimeout:      0,
+				RPCConcurrency:      1,
+				RPCResponseMaxBytes: 1024,
+				EnableTxEnrichment:  true,
+				StateKey:            stateKeyLastIndexedBlock,
 			},
 			wantErr: "RequestTimeout must be greater than 0",
 		},
 		{
 			name: "non-positive rpc concurrency",
 			cfg: Config{
-				RPCURL:             "http://127.0.0.1:8545",
-				EntryPoint:         defaultEntryPoint,
-				PollInterval:       time.Second,
-				BatchSize:          1,
-				RequestTimeout:     time.Second,
-				RPCConcurrency:     0,
-				EnableTxEnrichment: true,
-				StateKey:           stateKeyLastIndexedBlock,
+				RPCURL:              "http://127.0.0.1:8545",
+				EntryPoint:          defaultEntryPoint,
+				PollInterval:        time.Second,
+				BatchSize:           1,
+				RequestTimeout:      time.Second,
+				RPCConcurrency:      0,
+				RPCResponseMaxBytes: 1024,
+				EnableTxEnrichment:  true,
+				StateKey:            stateKeyLastIndexedBlock,
 			},
 			wantErr: "RPCConcurrency must be greater than 0",
 		},
 		{
+			name: "non-positive rpc response size",
+			cfg: Config{
+				RPCURL:              "http://127.0.0.1:8545",
+				EntryPoint:          defaultEntryPoint,
+				PollInterval:        time.Second,
+				BatchSize:           1,
+				RequestTimeout:      time.Second,
+				RPCConcurrency:      1,
+				RPCResponseMaxBytes: 0,
+				EnableTxEnrichment:  true,
+				StateKey:            stateKeyLastIndexedBlock,
+			},
+			wantErr: "RPCResponseMaxBytes must be greater than 0",
+		},
+		{
 			name: "missing state key",
 			cfg: Config{
-				RPCURL:             "http://127.0.0.1:8545",
-				EntryPoint:         defaultEntryPoint,
-				PollInterval:       time.Second,
-				BatchSize:          1,
-				RequestTimeout:     time.Second,
-				RPCConcurrency:     1,
-				EnableTxEnrichment: true,
-				StateKey:           "",
+				RPCURL:              "http://127.0.0.1:8545",
+				EntryPoint:          defaultEntryPoint,
+				PollInterval:        time.Second,
+				BatchSize:           1,
+				RequestTimeout:      time.Second,
+				RPCConcurrency:      1,
+				RPCResponseMaxBytes: 1024,
+				EnableTxEnrichment:  true,
+				StateKey:            "",
 			},
 			wantErr: "StateKey is required",
 		},

--- a/indexer/internal/indexer/run_test.go
+++ b/indexer/internal/indexer/run_test.go
@@ -169,6 +169,21 @@ func TestNewRejectsInvalidConfig(t *testing.T) {
 			wantErr: "RPCResponseMaxBytes must be greater than 0",
 		},
 		{
+			name: "overflow-prone rpc response size",
+			cfg: Config{
+				RPCURL:              "http://127.0.0.1:8545",
+				EntryPoint:          defaultEntryPoint,
+				PollInterval:        time.Second,
+				BatchSize:           1,
+				RequestTimeout:      time.Second,
+				RPCConcurrency:      1,
+				RPCResponseMaxBytes: int64(^uint64(0) >> 1),
+				EnableTxEnrichment:  true,
+				StateKey:            stateKeyLastIndexedBlock,
+			},
+			wantErr: "RPCResponseMaxBytes must be less than",
+		},
+		{
 			name: "missing state key",
 			cfg: Config{
 				RPCURL:              "http://127.0.0.1:8545",

--- a/indexer/internal/indexer/run_test.go
+++ b/indexer/internal/indexer/run_test.go
@@ -18,3 +18,20 @@ func TestRunReturnsNilWhenContextCancelledBeforeInitialIteration(t *testing.T) {
 		t.Fatalf("expected nil error on canceled context, got %v", err)
 	}
 }
+
+func TestRunReturnsErrorWhenInitialIterationFails(t *testing.T) {
+	t.Parallel()
+
+	svc := &Service{
+		cfg: Config{
+			PollInterval:   time.Millisecond,
+			RequestTimeout: time.Millisecond,
+		},
+		rpc: newRPCClient("http://127.0.0.1:1"),
+	}
+
+	err := svc.Run(context.Background())
+	if err == nil {
+		t.Fatal("expected initial iteration error")
+	}
+}

--- a/indexer/internal/indexer/run_test.go
+++ b/indexer/internal/indexer/run_test.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
 )
 
 func TestRunReturnsNilWhenContextCancelledBeforeInitialIteration(t *testing.T) {
@@ -37,6 +39,23 @@ func TestRunReturnsErrorWhenInitialIterationFails(t *testing.T) {
 	}
 }
 
+func TestRunReturnsErrorWhenPoolIsNil(t *testing.T) {
+	t.Parallel()
+
+	svc := &Service{
+		cfg: Config{PollInterval: time.Second},
+		rpc: newRPCClient("http://127.0.0.1:1"),
+	}
+
+	err := svc.Run(context.Background())
+	if err == nil {
+		t.Fatal("expected error when pool is nil")
+	}
+	if !strings.Contains(err.Error(), "pool is required") {
+		t.Fatalf("expected pool error, got %v", err)
+	}
+}
+
 func TestNewRejectsInvalidConfig(t *testing.T) {
 	t.Parallel()
 
@@ -45,6 +64,20 @@ func TestNewRejectsInvalidConfig(t *testing.T) {
 		cfg     Config
 		wantErr string
 	}{
+		{
+			name: "nil pool",
+			cfg: Config{
+				RPCURL:             "http://127.0.0.1:8545",
+				EntryPoint:         defaultEntryPoint,
+				PollInterval:       time.Second,
+				BatchSize:          1,
+				RequestTimeout:     time.Second,
+				RPCConcurrency:     1,
+				EnableTxEnrichment: true,
+				StateKey:           stateKeyLastIndexedBlock,
+			},
+			wantErr: "pool is required",
+		},
 		{
 			name: "missing rpc url",
 			cfg: Config{
@@ -135,7 +168,12 @@ func TestNewRejectsInvalidConfig(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			_, err := New(tt.cfg, nil)
+			pool := &pgxpool.Pool{}
+			if tt.name == "nil pool" {
+				pool = nil
+			}
+
+			_, err := New(tt.cfg, pool)
 			if err == nil {
 				t.Fatalf("expected error containing %q", tt.wantErr)
 			}

--- a/indexer/internal/indexer/safe_head_test.go
+++ b/indexer/internal/indexer/safe_head_test.go
@@ -1,0 +1,35 @@
+package indexer
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestSafeHeadReturnsNoSafeHeadWhenConfirmationsNotMet(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"jsonrpc":"2.0","id":1,"result":"0x2"}`))
+	}))
+	defer server.Close()
+
+	service := &Service{
+		cfg: Config{
+			Confirmations:  5,
+			RequestTimeout: time.Second,
+		},
+		rpc: newRPCClient(server.URL, 1024),
+	}
+
+	_, ok, err := service.safeHead(context.Background())
+	if err != nil {
+		t.Fatalf("safeHead returned error: %v", err)
+	}
+	if ok {
+		t.Fatal("expected no safe head when latest block has fewer confirmations")
+	}
+}

--- a/indexer/internal/numconv/numconv.go
+++ b/indexer/internal/numconv/numconv.go
@@ -1,0 +1,14 @@
+package numconv
+
+import (
+	"fmt"
+	"math"
+)
+
+func Uint64ToInt64(value uint64) (int64, error) {
+	if value > math.MaxInt64 {
+		return 0, fmt.Errorf("value %d overflows int64", value)
+	}
+
+	return int64(value), nil
+}


### PR DESCRIPTION
## What

Implement core Issue #9 indexing flow for `UserOperationEvent` with resumable polling and PostgreSQL persistence.

- Add a new `indexer/internal/indexer` package that:
  - loads indexer config from env,
  - polls `eth_getLogs` for EntryPoint `UserOperationEvent`,
  - decodes event fields,
  - enriches with block timestamp and tx input,
  - extracts `target` and inner calldata from `handleOps(...)->execute(...)` calls.
- Add DB helpers for:
  - cursor state read/write in `indexer_state`,
  - atomic block-range replacement + cursor update.
- Wire worker lifecycle into `cmd/indexer/main.go` so indexing runs with the existing API process.
- Add unit tests for config parsing, decode paths, and scan-range planning.
- Update docs/env examples for new indexer runtime knobs.

## Why

Issue #9 requires decoding and storing `UserOperationEvent` with resumability and basic reorg handling. This change delivers that core ingestion loop and sets the foundation for later API/live-feed issues.

## Scope

- [ ] Contracts
- [x] Backend
- [ ] Frontend
- [ ] Tooling / CI
- [x] Documentation
- [x] Test

## How to verify

```sh
# unit tests
cd indexer && go test ./...

# optional smoke run
POSTGRES_PORT=55432 make db-up
DATABASE_URL=postgres://bastion:bastion@localhost:55432/bastion?sslmode=disable \
RPC_URL=https://ethereum-rpc.publicnode.com \
PORT=3301 \
INDEXER_BATCH_SIZE=100 \
INDEXER_CONFIRMATIONS=3 \
INDEXER_POLL_INTERVAL=2s \
cd indexer && go run ./cmd/indexer

# in another shell
curl http://127.0.0.1:3301/
curl http://127.0.0.1:3301/readyz
psql "postgres://bastion:bastion@localhost:55432/bastion?sslmode=disable" \
  -c "SELECT key, value FROM indexer_state;"
psql "postgres://bastion:bastion@localhost:55432/bastion?sslmode=disable" \
  -c "SELECT count(*) FROM user_operations;"

# cleanup
make db-down
```

## Related issues

closes #9