### PR TITLE
feat(indexer): require start block for first-run historical backfill

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,8 +22,8 @@ RPC_URL=https://eth-sepolia.g.alchemy.com/v2/YOUR_KEY
 # Optional: override EntryPoint address (defaults to canonical v0.7)
 # ENTRYPOINT=0x0000000071727De22E5E9d8BAf0edAc6f37da032
 
-# Optional: first block to begin indexing from.
-# If omitted and no cursor exists, the indexer starts at current safe head.
+# Required on first run: block to begin historical backfill from.
+# After a cursor exists, the persisted cursor is used.
 # INDEXER_START_BLOCK=0
 
 # Optional: max blocks per eth_getLogs request (default: 500)

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ indexer/indexer
 
 # Local
 tmp/
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -81,11 +81,11 @@ Required env vars:
 
 - `DATABASE_URL` — PostgreSQL DSN
 - `RPC_URL` — chain JSON-RPC endpoint
+- `INDEXER_START_BLOCK` — required on first run (no cursor) to define historical backfill start block
 
 Optional indexer env vars:
 
 - `ENTRYPOINT` — override EntryPoint address (default: canonical v0.7)
-- `INDEXER_START_BLOCK` — initial block when no cursor exists
 - `INDEXER_BATCH_SIZE` — max block span per `eth_getLogs` batch (default `500`)
 - `INDEXER_CONFIRMATIONS` — confirmation lag before indexing (default `3`)
 - `INDEXER_REORG_WINDOW` — rewind window from cursor each loop (default = confirmations)

--- a/indexer/internal/indexer/indexer.go
+++ b/indexer/internal/indexer/indexer.go
@@ -2,6 +2,7 @@ package indexer
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"math"
@@ -24,6 +25,8 @@ type Service struct {
 }
 
 const blockTimestampCacheMaxEntries = 4096
+
+var errInitialBackfillStartBlockRequired = errors.New("initial backfill start block is required")
 
 func New(cfg Config, pool *pgxpool.Pool) (*Service, error) {
 	if cfg.RPCURL == "" {
@@ -101,10 +104,17 @@ func (s *Service) Run(ctx context.Context) error {
 				if ctx.Err() != nil {
 					return nil
 				}
+				if isFatalIndexIterationError(err) {
+					return fmt.Errorf("index iteration failed: %w", err)
+				}
 				slog.Error("index iteration failed", "err", err)
 			}
 		}
 	}
+}
+
+func isFatalIndexIterationError(err error) bool {
+	return errors.Is(err, errInitialBackfillStartBlockRequired)
 }
 
 func (s *Service) indexOnce(ctx context.Context) error {
@@ -282,7 +292,10 @@ func (s *Service) validateInitialBackfillConfig(hasCursor bool) error {
 		return nil
 	}
 
-	return fmt.Errorf("INDEXER_START_BLOCK is required on first run when no cursor exists")
+	return fmt.Errorf(
+		"%w: INDEXER_START_BLOCK is required on first run when no cursor exists",
+		errInitialBackfillStartBlockRequired,
+	)
 }
 
 func (s *Service) indexRange(ctx context.Context, fromBlock uint64, toBlock uint64) error {

--- a/indexer/internal/indexer/indexer.go
+++ b/indexer/internal/indexer/indexer.go
@@ -204,21 +204,29 @@ func (s *Service) indexOnce(ctx context.Context) error {
 		if initialBackfill {
 			processedBlocks += batchTo - batchFrom + 1
 			remainingBlocks := totalBlocks - processedBlocks
-			slog.Info(
-				"indexing progress",
-				"batch",
-				batchIndex,
-				"batch_from",
-				batchFrom,
-				"batch_to",
-				batchTo,
-				"processed_blocks",
-				processedBlocks,
-				"total_blocks",
-				totalBlocks,
-				"remaining_blocks",
-				remainingBlocks,
-			)
+			if remainingBlocks == 0 {
+				slog.Info(
+					"historical backfill complete",
+					"batches",
+					batchIndex,
+					"processed_blocks",
+					processedBlocks,
+					"total_blocks",
+					totalBlocks,
+				)
+			} else {
+				slog.Debug(
+					"historical backfill progress",
+					"batch",
+					batchIndex,
+					"processed_blocks",
+					processedBlocks,
+					"total_blocks",
+					totalBlocks,
+					"remaining_blocks",
+					remainingBlocks,
+				)
+			}
 		}
 
 		if batchTo == to {

--- a/indexer/internal/indexer/indexer.go
+++ b/indexer/internal/indexer/indexer.go
@@ -121,6 +121,9 @@ func (s *Service) indexOnce(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("load cursor: %w", err)
 	}
+	if err := s.validateInitialBackfillConfig(hasCursor); err != nil {
+		return err
+	}
 	trimmedCursor := false
 	if hasCursor && cursor > safeHead {
 		delta := cursor - safeHead
@@ -168,14 +171,44 @@ func (s *Service) indexOnce(ctx context.Context) error {
 		return nil
 	}
 
+	initialBackfill := !hasCursor
+	if initialBackfill {
+		slog.Info("starting historical backfill", "from", from, "to", to)
+	}
+
+	totalBlocks := to - from + 1
+	processedBlocks := uint64(0)
+	batchIndex := uint64(0)
+
 	for batchFrom := from; batchFrom <= to; {
 		batchTo := batchFrom + s.cfg.BatchSize - 1
 		if batchTo > to || batchTo < batchFrom {
 			batchTo = to
 		}
+		batchIndex++
 
 		if err := s.indexRange(ctx, batchFrom, batchTo); err != nil {
 			return err
+		}
+
+		if initialBackfill {
+			processedBlocks += batchTo - batchFrom + 1
+			remainingBlocks := totalBlocks - processedBlocks
+			slog.Info(
+				"indexing progress",
+				"batch",
+				batchIndex,
+				"batch_from",
+				batchFrom,
+				"batch_to",
+				batchTo,
+				"processed_blocks",
+				processedBlocks,
+				"total_blocks",
+				totalBlocks,
+				"remaining_blocks",
+				remainingBlocks,
+			)
 		}
 
 		if batchTo == to {
@@ -231,7 +264,7 @@ func (s *Service) planScanRange(cursor uint64, hasCursor bool, safeHead uint64) 
 	} else if s.cfg.HasStartBlock {
 		from = s.cfg.StartBlock
 	} else {
-		from = safeHead
+		return 0, 0, false
 	}
 
 	if from > safeHead {
@@ -239,6 +272,17 @@ func (s *Service) planScanRange(cursor uint64, hasCursor bool, safeHead uint64) 
 	}
 
 	return from, safeHead, true
+}
+
+func (s *Service) validateInitialBackfillConfig(hasCursor bool) error {
+	if hasCursor {
+		return nil
+	}
+	if s.cfg.HasStartBlock {
+		return nil
+	}
+
+	return fmt.Errorf("INDEXER_START_BLOCK is required on first run when no cursor exists")
 }
 
 func (s *Service) indexRange(ctx context.Context, fromBlock uint64, toBlock uint64) error {

--- a/indexer/internal/indexer/indexer.go
+++ b/indexer/internal/indexer/indexer.go
@@ -118,6 +118,14 @@ func isFatalIndexIterationError(err error) bool {
 }
 
 func (s *Service) indexOnce(ctx context.Context) error {
+	cursor, hasCursor, err := db.GetStateUint64(ctx, s.pool, s.cfg.StateKey)
+	if err != nil {
+		return fmt.Errorf("load cursor: %w", err)
+	}
+	if err := s.validateInitialBackfillConfig(hasCursor); err != nil {
+		return err
+	}
+
 	safeHead, hasSafeHead, err := s.safeHead(ctx)
 	if err != nil {
 		return fmt.Errorf("fetch safe head: %w", err)
@@ -127,13 +135,6 @@ func (s *Service) indexOnce(ctx context.Context) error {
 		return nil
 	}
 
-	cursor, hasCursor, err := db.GetStateUint64(ctx, s.pool, s.cfg.StateKey)
-	if err != nil {
-		return fmt.Errorf("load cursor: %w", err)
-	}
-	if err := s.validateInitialBackfillConfig(hasCursor); err != nil {
-		return err
-	}
 	trimmedCursor := false
 	if hasCursor && cursor > safeHead {
 		delta := cursor - safeHead

--- a/indexer/internal/indexer/indexer_test.go
+++ b/indexer/internal/indexer/indexer_test.go
@@ -6,12 +6,9 @@ func TestPlanScanRange_NoCursor_NoStartBlock(t *testing.T) {
 	t.Parallel()
 
 	svc := Service{cfg: Config{}}
-	from, to, ok := svc.planScanRange(0, false, 100)
-	if !ok {
-		t.Fatal("expected scan range to be available")
-	}
-	if from != 100 || to != 100 {
-		t.Fatalf("expected range [100,100], got [%d,%d]", from, to)
+	_, _, ok := svc.planScanRange(0, false, 100)
+	if ok {
+		t.Fatal("expected no scan range when start block is not configured")
 	}
 }
 
@@ -82,5 +79,35 @@ func TestRewindRangeToSafeHead(t *testing.T) {
 	from, to = rewindRangeToSafeHead(5, 20)
 	if from != 0 || to != 5 {
 		t.Fatalf("expected [0,5], got [%d,%d]", from, to)
+	}
+}
+
+func TestValidateInitialBackfillConfig_RequiresStartBlockWithoutCursor(t *testing.T) {
+	t.Parallel()
+
+	svc := Service{cfg: Config{HasStartBlock: false}}
+	err := svc.validateInitialBackfillConfig(false)
+	if err == nil {
+		t.Fatal("expected validation error when cursor and start block are missing")
+	}
+}
+
+func TestValidateInitialBackfillConfig_AllowsMissingStartBlockWithCursor(t *testing.T) {
+	t.Parallel()
+
+	svc := Service{cfg: Config{HasStartBlock: false}}
+	err := svc.validateInitialBackfillConfig(true)
+	if err != nil {
+		t.Fatalf("expected no error when cursor exists, got %v", err)
+	}
+}
+
+func TestValidateInitialBackfillConfig_AllowsStartBlockWithoutCursor(t *testing.T) {
+	t.Parallel()
+
+	svc := Service{cfg: Config{HasStartBlock: true, StartBlock: 123}}
+	err := svc.validateInitialBackfillConfig(false)
+	if err != nil {
+		t.Fatalf("expected no error when start block is configured, got %v", err)
 	}
 }

--- a/indexer/internal/indexer/indexer_test.go
+++ b/indexer/internal/indexer/indexer_test.go
@@ -1,6 +1,10 @@
 package indexer
 
-import "testing"
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
 
 func TestPlanScanRange_NoCursor_NoStartBlock(t *testing.T) {
 	t.Parallel()
@@ -90,6 +94,9 @@ func TestValidateInitialBackfillConfig_RequiresStartBlockWithoutCursor(t *testin
 	if err == nil {
 		t.Fatal("expected validation error when cursor and start block are missing")
 	}
+	if !errors.Is(err, errInitialBackfillStartBlockRequired) {
+		t.Fatalf("expected sentinel error, got %v", err)
+	}
 }
 
 func TestValidateInitialBackfillConfig_AllowsMissingStartBlockWithCursor(t *testing.T) {
@@ -109,5 +116,22 @@ func TestValidateInitialBackfillConfig_AllowsStartBlockWithoutCursor(t *testing.
 	err := svc.validateInitialBackfillConfig(false)
 	if err != nil {
 		t.Fatalf("expected no error when start block is configured, got %v", err)
+	}
+}
+
+func TestIsFatalIndexIterationError(t *testing.T) {
+	t.Parallel()
+
+	if !isFatalIndexIterationError(errInitialBackfillStartBlockRequired) {
+		t.Fatal("expected sentinel to be fatal")
+	}
+
+	wrapped := fmt.Errorf("wrapped: %w", errInitialBackfillStartBlockRequired)
+	if !isFatalIndexIterationError(wrapped) {
+		t.Fatal("expected wrapped sentinel to be fatal")
+	}
+
+	if isFatalIndexIterationError(errors.New("other error")) {
+		t.Fatal("expected non-sentinel error to be non-fatal")
 	}
 }


### PR DESCRIPTION
## What
- enforce `INDEXER_START_BLOCK` on first run when no cursor exists, instead of silently starting at safe head
- load cursor + validate first-run start-block requirement before safe-head RPC checks so misconfiguration fails deterministically at startup
- add initial backfill progress/completion logging while keeping steady-state range logs
- add tests for first-run backfill config validation and fatal error classification
- update `.env.example` and README docs to reflect first-run requirement

## Why
Issue #10 requires historical catch-up from a configurable start block. Requiring an explicit start block on first run avoids accidental partial indexing and makes startup behavior deterministic.

## Scope
- [ ] Contracts
- [x] Backend
- [ ] Frontend
- [ ] Tooling / CI
- [x] Documentation
- [x] Test

## How to verify
```sh
cd indexer && go test ./...
```

Optional manual checks:
```sh
# fresh DB with no cursor, start block missing -> fails fast
cd indexer && DATABASE_URL=postgres://... RPC_URL=https://... go run ./cmd/indexer

# fresh DB with start block configured -> begins historical backfill
cd indexer && DATABASE_URL=postgres://... RPC_URL=https://... INDEXER_START_BLOCK=0 go run ./cmd/indexer
```

## Related issues
closes #10