### PR TITLE
feat(indexer): add websocket new-head subscription wakeups

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,10 @@ DATABASE_URL=postgres://bastion:bastion@localhost:5432/bastion?sslmode=disable
 # JSON-RPC endpoint for the chain to index
 RPC_URL=https://eth-sepolia.g.alchemy.com/v2/YOUR_KEY
 
+# Optional: WebSocket RPC endpoint to trigger immediate indexing on new heads.
+# Falls back to poll-only behavior when omitted.
+# WS_RPC_URL=wss://eth-sepolia.g.alchemy.com/v2/YOUR_KEY
+
 # Optional: override EntryPoint address (defaults to canonical v0.7)
 # ENTRYPOINT=0x0000000071727De22E5E9d8BAf0edAc6f37da032
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Required env vars:
 
 Optional indexer env vars:
 
+- `WS_RPC_URL` — WebSocket RPC endpoint for `eth_subscribe` new-head triggers (falls back to poll-only when unset)
 - `ENTRYPOINT` — override EntryPoint address (default: canonical v0.7)
 - `INDEXER_BATCH_SIZE` — max block span per `eth_getLogs` batch (default `500`)
 - `INDEXER_CONFIRMATIONS` — confirmation lag before indexing (default `3`)

--- a/indexer/go.mod
+++ b/indexer/go.mod
@@ -2,12 +2,15 @@ module github.com/flwrenn/bastion/indexer
 
 go 1.25.0
 
-require github.com/jackc/pgx/v5 v5.8.0
+require (
+	github.com/jackc/pgx/v5 v5.8.0
+	golang.org/x/net v0.52.0
+)
 
 require (
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
-	golang.org/x/sync v0.17.0 // indirect
-	golang.org/x/text v0.29.0 // indirect
+	golang.org/x/sync v0.20.0 // indirect
+	golang.org/x/text v0.35.0 // indirect
 )

--- a/indexer/go.sum
+++ b/indexer/go.sum
@@ -16,10 +16,12 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-golang.org/x/sync v0.17.0 h1:l60nONMj9l5drqw6jlhIELNv9I0A4OFgRsG9k2oT9Ug=
-golang.org/x/sync v0.17.0/go.mod h1:9KTHXmSnoGruLpwFjVSX0lNNA75CykiMECbovNTZqGI=
-golang.org/x/text v0.29.0 h1:1neNs90w9YzJ9BocxfsQNHKuAT4pkghyXc4nhZ6sJvk=
-golang.org/x/text v0.29.0/go.mod h1:7MhJOA9CD2qZyOKYazxdYMF85OwPdEr9jTtBpO7ydH4=
+golang.org/x/net v0.52.0 h1:He/TN1l0e4mmR3QqHMT2Xab3Aj3L9qjbhRm78/6jrW0=
+golang.org/x/net v0.52.0/go.mod h1:R1MAz7uMZxVMualyPXb+VaqGSa3LIaUqk0eEt3w36Sw=
+golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
+golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
+golang.org/x/text v0.35.0 h1:JOVx6vVDFokkpaq1AEptVzLTpDe9KGpj5tR4/X+ybL8=
+golang.org/x/text v0.35.0/go.mod h1:khi/HExzZJ2pGnjenulevKNX1W67CUy0AsXcNubPGCA=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/indexer/internal/indexer/config.go
+++ b/indexer/internal/indexer/config.go
@@ -3,6 +3,7 @@ package indexer
 import (
 	"fmt"
 	"math"
+	"net/url"
 	"os"
 	"strconv"
 	"strings"
@@ -23,6 +24,7 @@ const (
 
 type Config struct {
 	RPCURL              string
+	WSURL               string
 	EntryPoint          string
 	StartBlock          uint64
 	HasStartBlock       bool
@@ -54,6 +56,14 @@ func LoadConfigFromEnv() (Config, error) {
 
 	if cfg.RPCURL == "" {
 		return Config{}, fmt.Errorf("RPC_URL is not set")
+	}
+
+	if value := strings.TrimSpace(os.Getenv("WS_RPC_URL")); value != "" {
+		normalizedWSURL, err := normalizeWebSocketURL(value)
+		if err != nil {
+			return Config{}, fmt.Errorf("parse WS_RPC_URL: %w", err)
+		}
+		cfg.WSURL = normalizedWSURL
 	}
 
 	if value := strings.TrimSpace(os.Getenv("ENTRYPOINT")); value != "" {
@@ -166,4 +176,19 @@ func LoadConfigFromEnv() (Config, error) {
 	}
 
 	return cfg, nil
+}
+
+func normalizeWebSocketURL(value string) (string, error) {
+	parsed, err := url.Parse(strings.TrimSpace(value))
+	if err != nil {
+		return "", err
+	}
+	if parsed.Scheme != "ws" && parsed.Scheme != "wss" {
+		return "", fmt.Errorf("scheme must be ws or wss")
+	}
+	if parsed.Host == "" {
+		return "", fmt.Errorf("host is required")
+	}
+
+	return parsed.String(), nil
 }

--- a/indexer/internal/indexer/config_test.go
+++ b/indexer/internal/indexer/config_test.go
@@ -91,6 +91,7 @@ func TestLoadConfigFromEnv_Defaults(t *testing.T) {
 
 func TestLoadConfigFromEnv_ParsesOptionals(t *testing.T) {
 	t.Setenv("RPC_URL", "https://rpc.example")
+	t.Setenv("WS_RPC_URL", "wss://ws.example")
 	t.Setenv("ENTRYPOINT", "0X0000000071727De22E5E9d8BAf0edAc6f37da032")
 	t.Setenv("INDEXER_START_BLOCK", "123")
 	t.Setenv("INDEXER_BATCH_SIZE", "777")
@@ -110,6 +111,9 @@ func TestLoadConfigFromEnv_ParsesOptionals(t *testing.T) {
 
 	if !cfg.HasStartBlock || cfg.StartBlock != 123 {
 		t.Fatalf("expected start block 123, got has=%v block=%d", cfg.HasStartBlock, cfg.StartBlock)
+	}
+	if cfg.WSURL != "wss://ws.example" {
+		t.Fatalf("expected ws url %q, got %q", "wss://ws.example", cfg.WSURL)
 	}
 	if cfg.BatchSize != 777 {
 		t.Fatalf("expected batch size 777, got %d", cfg.BatchSize)
@@ -137,6 +141,19 @@ func TestLoadConfigFromEnv_ParsesOptionals(t *testing.T) {
 	}
 	if !cfg.AllowCursorTrim {
 		t.Fatal("expected cursor trim to be enabled")
+	}
+}
+
+func TestLoadConfigFromEnv_InvalidWebSocketURL(t *testing.T) {
+	t.Setenv("RPC_URL", "https://rpc.example")
+	t.Setenv("WS_RPC_URL", "https://ws.example")
+
+	_, err := LoadConfigFromEnv()
+	if err == nil {
+		t.Fatal("expected websocket url validation error")
+	}
+	if !strings.Contains(err.Error(), "WS_RPC_URL") {
+		t.Fatalf("expected WS_RPC_URL parse error, got %v", err)
 	}
 }
 
@@ -219,6 +236,7 @@ func TestLoadConfigFromEnv_InvalidDurationsAndBools(t *testing.T) {
 func clearOptionalIndexerEnv(t *testing.T) {
 	t.Helper()
 	t.Setenv("ENTRYPOINT", "")
+	t.Setenv("WS_RPC_URL", "")
 	t.Setenv("INDEXER_START_BLOCK", "")
 	t.Setenv("INDEXER_BATCH_SIZE", "")
 	t.Setenv("INDEXER_CONFIRMATIONS", "")

--- a/indexer/internal/indexer/indexer.go
+++ b/indexer/internal/indexer/indexer.go
@@ -60,6 +60,13 @@ func New(cfg Config, pool *pgxpool.Pool) (*Service, error) {
 	if pool == nil {
 		return nil, fmt.Errorf("pool is required")
 	}
+	if cfg.WSURL != "" {
+		normalizedWSURL, err := normalizeWebSocketURL(cfg.WSURL)
+		if err != nil {
+			return nil, fmt.Errorf("normalize WSURL: %w", err)
+		}
+		cfg.WSURL = normalizedWSURL
+	}
 
 	normalizedEntryPoint, err := normalizeAddress(cfg.EntryPoint)
 	if err != nil {

--- a/indexer/internal/indexer/indexer.go
+++ b/indexer/internal/indexer/indexer.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"math"
+	"net/url"
 	"sort"
 	"strings"
 	"sync"
@@ -101,7 +102,7 @@ func (s *Service) Run(ctx context.Context) error {
 	wakeCh := make(chan struct{}, 1)
 
 	if s.cfg.WSURL != "" {
-		slog.Info("starting head subscription", "ws_url", s.cfg.WSURL)
+		slog.Info("starting head subscription", "ws_endpoint", websocketLogEndpoint(s.cfg.WSURL))
 		go s.runHeadSubscriptionLoop(ctx, wakeCh)
 	}
 
@@ -150,7 +151,7 @@ func (s *Service) runHeadSubscriptionLoop(ctx context.Context, wakeCh chan<- str
 			if s.cfg.WSURL == "" {
 				return
 			}
-			slog.Warn("head subscription connect failed; retrying", "err", err)
+			slog.Warn("head subscription connect failed; retrying", "err", redactWebSocketURLError(err, s.cfg.WSURL))
 			if !sleepContext(ctx, s.subscriptionBackoff()) {
 				return
 			}
@@ -170,12 +171,40 @@ func (s *Service) runHeadSubscriptionLoop(ctx context.Context, wakeCh chan<- str
 		}
 
 		if err != nil {
-			slog.Warn("head subscription disconnected; reconnecting", "err", err)
+			slog.Warn("head subscription disconnected; reconnecting", "err", redactWebSocketURLError(err, s.cfg.WSURL))
 		}
 		if !sleepContext(ctx, s.subscriptionBackoff()) {
 			return
 		}
 	}
+}
+
+func websocketLogEndpoint(wsURL string) string {
+	parsed, err := url.Parse(wsURL)
+	if err != nil || parsed.Host == "" {
+		return "invalid"
+	}
+
+	scheme := strings.ToLower(parsed.Scheme)
+	if scheme == "" {
+		return parsed.Host
+	}
+
+	return scheme + "://" + parsed.Host
+}
+
+func redactWebSocketURLError(err error, wsURL string) string {
+	if err == nil {
+		return ""
+	}
+
+	errText := err.Error()
+	if wsURL == "" {
+		return errText
+	}
+
+	endpoint := websocketLogEndpoint(wsURL)
+	return strings.ReplaceAll(errText, wsURL, endpoint)
 }
 
 func (s *Service) subscriptionBackoff() time.Duration {

--- a/indexer/internal/indexer/indexer.go
+++ b/indexer/internal/indexer/indexer.go
@@ -155,7 +155,9 @@ func (s *Service) runHeadSubscriptionLoop(ctx context.Context, wakeCh chan<- str
 			return
 		}
 
-		subscription, err := s.newHeadSubscription(ctx)
+		connectCtx, cancelConnect := context.WithTimeout(ctx, s.subscriptionConnectTimeout())
+		subscription, err := s.newHeadSubscription(connectCtx)
+		cancelConnect()
 		if err != nil {
 			if ctx.Err() != nil {
 				return
@@ -189,6 +191,14 @@ func (s *Service) runHeadSubscriptionLoop(ctx context.Context, wakeCh chan<- str
 			return
 		}
 	}
+}
+
+func (s *Service) subscriptionConnectTimeout() time.Duration {
+	if s.cfg.RequestTimeout <= 0 {
+		return defaultRequestTimeout
+	}
+
+	return s.cfg.RequestTimeout
 }
 
 func websocketLogEndpoint(wsURL string) string {

--- a/indexer/internal/indexer/indexer.go
+++ b/indexer/internal/indexer/indexer.go
@@ -25,6 +25,7 @@ type Service struct {
 	cacheMu                      sync.RWMutex
 	newHeadSubscriptionFactory   func(context.Context, string) (headSubscription, error)
 	subscriptionReconnectBackoff time.Duration
+	indexOnceFunc                func(context.Context) error
 }
 
 const blockTimestampCacheMaxEntries = 4096
@@ -90,12 +91,15 @@ func (s *Service) Run(ctx context.Context) error {
 		return fmt.Errorf("rpc client is required")
 	}
 
-	if err := s.indexOnce(ctx); err != nil {
+	if err := s.runIndexOnce(ctx); err != nil {
 		if ctx.Err() != nil {
 			return nil
 		}
 		return fmt.Errorf("initial index iteration failed: %w", err)
 	}
+
+	runCtx, stopRun := context.WithCancel(ctx)
+	defer stopRun()
 
 	ticker := time.NewTicker(s.cfg.PollInterval)
 	defer ticker.Stop()
@@ -103,15 +107,15 @@ func (s *Service) Run(ctx context.Context) error {
 
 	if s.cfg.WSURL != "" {
 		slog.Info("starting head subscription", "ws_endpoint", websocketLogEndpoint(s.cfg.WSURL))
-		go s.runHeadSubscriptionLoop(ctx, wakeCh)
+		go s.runHeadSubscriptionLoop(runCtx, wakeCh)
 	}
 
 	runIteration := func() error {
-		err := s.indexOnce(ctx)
+		err := s.runIndexOnce(runCtx)
 		if err == nil {
 			return nil
 		}
-		if ctx.Err() != nil {
+		if runCtx.Err() != nil {
 			return nil
 		}
 		if isFatalIndexIterationError(err) {
@@ -123,7 +127,7 @@ func (s *Service) Run(ctx context.Context) error {
 
 	for {
 		select {
-		case <-ctx.Done():
+		case <-runCtx.Done():
 			return nil
 		case <-ticker.C:
 			if err := runIteration(); err != nil {
@@ -135,6 +139,14 @@ func (s *Service) Run(ctx context.Context) error {
 			}
 		}
 	}
+}
+
+func (s *Service) runIndexOnce(ctx context.Context) error {
+	if s.indexOnceFunc != nil {
+		return s.indexOnceFunc(ctx)
+	}
+
+	return s.indexOnce(ctx)
 }
 
 func (s *Service) runHeadSubscriptionLoop(ctx context.Context, wakeCh chan<- struct{}) {
@@ -193,18 +205,23 @@ func websocketLogEndpoint(wsURL string) string {
 	return scheme + "://" + parsed.Host
 }
 
-func redactWebSocketURLError(err error, wsURL string) string {
+func redactWebSocketURLError(err error, wsURL string) error {
 	if err == nil {
-		return ""
+		return nil
+	}
+	if wsURL == "" {
+		return err
 	}
 
 	errText := err.Error()
-	if wsURL == "" {
-		return errText
-	}
 
 	endpoint := websocketLogEndpoint(wsURL)
-	return strings.ReplaceAll(errText, wsURL, endpoint)
+	redacted := strings.ReplaceAll(errText, wsURL, endpoint)
+	if redacted == errText {
+		return err
+	}
+
+	return errors.New(redacted)
 }
 
 func (s *Service) subscriptionBackoff() time.Duration {

--- a/indexer/internal/indexer/indexer.go
+++ b/indexer/internal/indexer/indexer.go
@@ -231,7 +231,20 @@ func redactWebSocketURLError(err error, wsURL string) error {
 		return err
 	}
 
-	return errors.New(redacted)
+	return &redactedWebSocketError{message: redacted, cause: err}
+}
+
+type redactedWebSocketError struct {
+	message string
+	cause   error
+}
+
+func (e *redactedWebSocketError) Error() string {
+	return e.message
+}
+
+func (e *redactedWebSocketError) Unwrap() error {
+	return e.cause
 }
 
 func (s *Service) subscriptionBackoff() time.Duration {

--- a/indexer/internal/indexer/indexer.go
+++ b/indexer/internal/indexer/indexer.go
@@ -16,12 +16,14 @@ import (
 )
 
 type Service struct {
-	cfg                 Config
-	pool                *pgxpool.Pool
-	rpc                 *rpcClient
-	entryPoint          string
-	blockTimestampCache map[uint64]int64
-	cacheMu             sync.RWMutex
+	cfg                          Config
+	pool                         *pgxpool.Pool
+	rpc                          *rpcClient
+	entryPoint                   string
+	blockTimestampCache          map[uint64]int64
+	cacheMu                      sync.RWMutex
+	newHeadSubscriptionFactory   func(context.Context, string) (headSubscription, error)
+	subscriptionReconnectBackoff time.Duration
 }
 
 const blockTimestampCacheMaxEntries = 4096
@@ -63,11 +65,13 @@ func New(cfg Config, pool *pgxpool.Pool) (*Service, error) {
 	}
 
 	return &Service{
-		cfg:                 cfg,
-		pool:                pool,
-		rpc:                 newRPCClient(cfg.RPCURL, cfg.RPCResponseMaxBytes),
-		entryPoint:          normalizedEntryPoint,
-		blockTimestampCache: make(map[uint64]int64),
+		cfg:                          cfg,
+		pool:                         pool,
+		rpc:                          newRPCClient(cfg.RPCURL, cfg.RPCResponseMaxBytes),
+		entryPoint:                   normalizedEntryPoint,
+		blockTimestampCache:          make(map[uint64]int64),
+		newHeadSubscriptionFactory:   newWebSocketHeadSubscription,
+		subscriptionReconnectBackoff: defaultSubscriptionBackoff,
 	}, nil
 }
 
@@ -94,22 +98,125 @@ func (s *Service) Run(ctx context.Context) error {
 
 	ticker := time.NewTicker(s.cfg.PollInterval)
 	defer ticker.Stop()
+	wakeCh := make(chan struct{}, 1)
+
+	if s.cfg.WSURL != "" {
+		slog.Info("starting head subscription", "ws_url", s.cfg.WSURL)
+		go s.runHeadSubscriptionLoop(ctx, wakeCh)
+	}
+
+	runIteration := func() error {
+		err := s.indexOnce(ctx)
+		if err == nil {
+			return nil
+		}
+		if ctx.Err() != nil {
+			return nil
+		}
+		if isFatalIndexIterationError(err) {
+			return fmt.Errorf("index iteration failed: %w", err)
+		}
+		slog.Error("index iteration failed", "err", err)
+		return nil
+	}
 
 	for {
 		select {
 		case <-ctx.Done():
 			return nil
 		case <-ticker.C:
-			if err := s.indexOnce(ctx); err != nil {
-				if ctx.Err() != nil {
-					return nil
-				}
-				if isFatalIndexIterationError(err) {
-					return fmt.Errorf("index iteration failed: %w", err)
-				}
-				slog.Error("index iteration failed", "err", err)
+			if err := runIteration(); err != nil {
+				return err
+			}
+		case <-wakeCh:
+			if err := runIteration(); err != nil {
+				return err
 			}
 		}
+	}
+}
+
+func (s *Service) runHeadSubscriptionLoop(ctx context.Context, wakeCh chan<- struct{}) {
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+
+		subscription, err := s.newHeadSubscription(ctx)
+		if err != nil {
+			if ctx.Err() != nil {
+				return
+			}
+			if s.cfg.WSURL == "" {
+				return
+			}
+			slog.Warn("head subscription connect failed; retrying", "err", err)
+			if !sleepContext(ctx, s.subscriptionBackoff()) {
+				return
+			}
+			continue
+		}
+
+		slog.Info("head subscription connected")
+
+		err = s.consumeHeadSubscription(ctx, subscription, wakeCh)
+		closeErr := subscription.Close()
+		if closeErr != nil && ctx.Err() == nil {
+			slog.Warn("head subscription close failed", "err", closeErr)
+		}
+
+		if ctx.Err() != nil {
+			return
+		}
+
+		if err != nil {
+			slog.Warn("head subscription disconnected; reconnecting", "err", err)
+		}
+		if !sleepContext(ctx, s.subscriptionBackoff()) {
+			return
+		}
+	}
+}
+
+func (s *Service) subscriptionBackoff() time.Duration {
+	if s.subscriptionReconnectBackoff <= 0 {
+		return defaultSubscriptionBackoff
+	}
+
+	return s.subscriptionReconnectBackoff
+}
+
+func (s *Service) newHeadSubscription(ctx context.Context) (headSubscription, error) {
+	factory := s.newHeadSubscriptionFactory
+	if factory == nil {
+		factory = newWebSocketHeadSubscription
+	}
+
+	return factory(ctx, s.cfg.WSURL)
+}
+
+func (s *Service) consumeHeadSubscription(ctx context.Context, subscription headSubscription, wakeCh chan<- struct{}) error {
+	for {
+		if err := subscription.Next(ctx); err != nil {
+			return err
+		}
+
+		select {
+		case wakeCh <- struct{}{}:
+		default:
+		}
+	}
+}
+
+func sleepContext(ctx context.Context, d time.Duration) bool {
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+
+	select {
+	case <-ctx.Done():
+		return false
+	case <-timer.C:
+		return true
 	}
 }
 

--- a/indexer/internal/indexer/indexer_test.go
+++ b/indexer/internal/indexer/indexer_test.go
@@ -161,6 +161,9 @@ func TestRedactWebSocketURLError(t *testing.T) {
 	if redacted == nil {
 		t.Fatal("expected redacted error")
 	}
+	if !errors.Is(redacted, err) {
+		t.Fatal("expected redacted error to preserve original cause")
+	}
 
 	if redacted.Error() == err.Error() {
 		t.Fatal("expected websocket url to be redacted")

--- a/indexer/internal/indexer/indexer_test.go
+++ b/indexer/internal/indexer/indexer_test.go
@@ -135,3 +135,34 @@ func TestIsFatalIndexIterationError(t *testing.T) {
 		t.Fatal("expected non-sentinel error to be non-fatal")
 	}
 }
+
+func TestWebsocketLogEndpoint(t *testing.T) {
+	t.Parallel()
+
+	if got := websocketLogEndpoint("wss://rpc.example/ws?key=secret"); got != "wss://rpc.example" {
+		t.Fatalf("expected redacted endpoint, got %q", got)
+	}
+
+	if got := websocketLogEndpoint("ws://localhost:8546/path"); got != "ws://localhost:8546" {
+		t.Fatalf("expected endpoint with host+port, got %q", got)
+	}
+
+	if got := websocketLogEndpoint("bad://"); got != "invalid" {
+		t.Fatalf("expected invalid endpoint marker, got %q", got)
+	}
+}
+
+func TestRedactWebSocketURLError(t *testing.T) {
+	t.Parallel()
+
+	wsURL := "wss://rpc.example/ws?key=secret"
+	err := fmt.Errorf("dial failed for %s", wsURL)
+	redacted := redactWebSocketURLError(err, wsURL)
+
+	if redacted == err.Error() {
+		t.Fatal("expected websocket url to be redacted")
+	}
+	if redacted != "dial failed for wss://rpc.example" {
+		t.Fatalf("unexpected redacted error: %q", redacted)
+	}
+}

--- a/indexer/internal/indexer/indexer_test.go
+++ b/indexer/internal/indexer/indexer_test.go
@@ -158,11 +158,24 @@ func TestRedactWebSocketURLError(t *testing.T) {
 	wsURL := "wss://rpc.example/ws?key=secret"
 	err := fmt.Errorf("dial failed for %s", wsURL)
 	redacted := redactWebSocketURLError(err, wsURL)
+	if redacted == nil {
+		t.Fatal("expected redacted error")
+	}
 
-	if redacted == err.Error() {
+	if redacted.Error() == err.Error() {
 		t.Fatal("expected websocket url to be redacted")
 	}
-	if redacted != "dial failed for wss://rpc.example" {
-		t.Fatalf("unexpected redacted error: %q", redacted)
+	if redacted.Error() != "dial failed for wss://rpc.example" {
+		t.Fatalf("unexpected redacted error: %q", redacted.Error())
+	}
+}
+
+func TestRedactWebSocketURLError_ReturnsOriginalWhenNoURL(t *testing.T) {
+	t.Parallel()
+
+	err := errors.New("dial failed")
+	redacted := redactWebSocketURLError(err, "")
+	if !errors.Is(redacted, err) {
+		t.Fatal("expected original error when ws url is empty")
 	}
 }

--- a/indexer/internal/indexer/run_test.go
+++ b/indexer/internal/indexer/run_test.go
@@ -199,6 +199,22 @@ func TestNewRejectsInvalidConfig(t *testing.T) {
 			},
 			wantErr: "StateKey is required",
 		},
+		{
+			name: "invalid websocket url",
+			cfg: Config{
+				RPCURL:              "http://127.0.0.1:8545",
+				WSURL:               "https://ws.example",
+				EntryPoint:          defaultEntryPoint,
+				PollInterval:        time.Second,
+				BatchSize:           1,
+				RequestTimeout:      time.Second,
+				RPCConcurrency:      1,
+				RPCResponseMaxBytes: 1024,
+				EnableTxEnrichment:  true,
+				StateKey:            stateKeyLastIndexedBlock,
+			},
+			wantErr: "normalize WSURL",
+		},
 	}
 
 	for _, tt := range tests {
@@ -219,6 +235,33 @@ func TestNewRejectsInvalidConfig(t *testing.T) {
 				t.Fatalf("expected error containing %q, got %v", tt.wantErr, err)
 			}
 		})
+	}
+}
+
+func TestNewNormalizesWebSocketURL(t *testing.T) {
+	t.Parallel()
+
+	svc, err := New(
+		Config{
+			RPCURL:              "http://127.0.0.1:8545",
+			WSURL:               "  wss://ws.example/path?apiKey=secret  ",
+			EntryPoint:          defaultEntryPoint,
+			PollInterval:        time.Second,
+			BatchSize:           1,
+			RequestTimeout:      time.Second,
+			RPCConcurrency:      1,
+			RPCResponseMaxBytes: 1024,
+			EnableTxEnrichment:  true,
+			StateKey:            stateKeyLastIndexedBlock,
+		},
+		&pgxpool.Pool{},
+	)
+	if err != nil {
+		t.Fatalf("New returned error: %v", err)
+	}
+
+	if svc.cfg.WSURL != "wss://ws.example/path?apiKey=secret" {
+		t.Fatalf("expected normalized WSURL, got %q", svc.cfg.WSURL)
 	}
 }
 

--- a/indexer/internal/indexer/run_test.go
+++ b/indexer/internal/indexer/run_test.go
@@ -264,6 +264,12 @@ func TestRunCancelsSubscriptionLoopOnFatalIterationError(t *testing.T) {
 			return nil
 		}
 
+		select {
+		case <-started:
+		case <-time.After(250 * time.Millisecond):
+			t.Fatal("expected subscription loop to start before fatal iteration")
+		}
+
 		return errInitialBackfillStartBlockRequired
 	}
 
@@ -273,12 +279,6 @@ func TestRunCancelsSubscriptionLoopOnFatalIterationError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "index iteration failed") {
 		t.Fatalf("expected iteration failure error, got %v", err)
-	}
-
-	select {
-	case <-started:
-	default:
-		t.Fatal("expected subscription loop to start")
 	}
 
 	select {

--- a/indexer/internal/indexer/run_test.go
+++ b/indexer/internal/indexer/run_test.go
@@ -3,6 +3,7 @@ package indexer
 import (
 	"context"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -218,5 +219,75 @@ func TestNewRejectsInvalidConfig(t *testing.T) {
 				t.Fatalf("expected error containing %q, got %v", tt.wantErr, err)
 			}
 		})
+	}
+}
+
+func TestRunCancelsSubscriptionLoopOnFatalIterationError(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	started := make(chan struct{}, 1)
+	stopped := make(chan struct{}, 1)
+	var calls atomic.Int32
+
+	svc := &Service{
+		cfg: Config{
+			PollInterval:   5 * time.Millisecond,
+			WSURL:          "wss://ws.example",
+			HasStartBlock:  true,
+			StateKey:       stateKeyLastIndexedBlock,
+			RequestTimeout: time.Second,
+			BatchSize:      1,
+		},
+		pool: &pgxpool.Pool{},
+		rpc:  &rpcClient{},
+		newHeadSubscriptionFactory: func(context.Context, string) (headSubscription, error) {
+			calls.Add(1)
+			started <- struct{}{}
+			return &stubHeadSubscription{
+				nextFn: func(ctx context.Context) error {
+					<-ctx.Done()
+					stopped <- struct{}{}
+					return ctx.Err()
+				},
+			}, nil
+		},
+		subscriptionReconnectBackoff: time.Millisecond,
+	}
+
+	indexCalls := 0
+	svc.indexOnceFunc = func(context.Context) error {
+		indexCalls++
+		if indexCalls == 1 {
+			return nil
+		}
+
+		return errInitialBackfillStartBlockRequired
+	}
+
+	err := svc.Run(ctx)
+	if err == nil {
+		t.Fatal("expected fatal iteration error")
+	}
+	if !strings.Contains(err.Error(), "index iteration failed") {
+		t.Fatalf("expected iteration failure error, got %v", err)
+	}
+
+	select {
+	case <-started:
+	default:
+		t.Fatal("expected subscription loop to start")
+	}
+
+	select {
+	case <-stopped:
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("expected subscription loop to be cancelled when Run returns")
+	}
+
+	if calls.Load() == 0 {
+		t.Fatal("expected subscription factory to be called")
 	}
 }

--- a/indexer/internal/indexer/subscription.go
+++ b/indexer/internal/indexer/subscription.go
@@ -1,0 +1,224 @@
+package indexer
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"sync"
+	"time"
+
+	"golang.org/x/net/websocket"
+)
+
+const (
+	subscriptionTypeNewHeads   = "newHeads"
+	defaultSubscriptionBackoff = 2 * time.Second
+)
+
+type headSubscription interface {
+	Next(ctx context.Context) error
+	Close() error
+}
+
+type websocketHeadSubscription struct {
+	ws        *websocket.Conn
+	nextMu    sync.Mutex
+	closeOnce sync.Once
+}
+
+func newWebSocketHeadSubscription(ctx context.Context, wsURL string) (headSubscription, error) {
+	config, err := websocket.NewConfig(wsURL, originForWebSocketURL(wsURL))
+	if err != nil {
+		return nil, fmt.Errorf("create websocket config: %w", err)
+	}
+
+	ws, err := config.DialContext(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("dial websocket: %w", err)
+	}
+
+	if err := sendSubscribeRequest(ctx, ws); err != nil {
+		_ = ws.Close()
+		return nil, err
+	}
+
+	sub := &websocketHeadSubscription{ws: ws}
+	if err := waitForSubscriptionAck(ctx, sub); err != nil {
+		_ = sub.Close()
+		return nil, err
+	}
+
+	return sub, nil
+}
+
+func sendSubscribeRequest(ctx context.Context, ws *websocket.Conn) error {
+	payload, err := json.Marshal(rpcRequest{
+		JSONRPC: jsonRPCVersion,
+		ID:      1,
+		Method:  "eth_subscribe",
+		Params:  []any{subscriptionTypeNewHeads},
+	})
+	if err != nil {
+		return fmt.Errorf("marshal subscribe request: %w", err)
+	}
+
+	if err := writeWebSocketMessage(ctx, ws, payload); err != nil {
+		return fmt.Errorf("send subscribe request: %w", err)
+	}
+
+	return nil
+}
+
+func waitForSubscriptionAck(ctx context.Context, sub *websocketHeadSubscription) error {
+	for {
+		message, err := sub.read(ctx)
+		if err != nil {
+			return fmt.Errorf("read subscription ack: %w", err)
+		}
+
+		var response rpcResponse
+		if err := json.Unmarshal(message, &response); err == nil && response.ID == 1 {
+			if response.Error != nil {
+				return fmt.Errorf("subscription rejected %d: %s", response.Error.Code, response.Error.Message)
+			}
+			if len(response.Result) == 0 || string(response.Result) == "null" {
+				return fmt.Errorf("subscription ack missing result")
+			}
+			return nil
+		}
+
+		if rpcErr := decodeRPCError(message); rpcErr != nil {
+			return rpcErr
+		}
+	}
+}
+
+func (s *websocketHeadSubscription) Next(ctx context.Context) error {
+	for {
+		message, err := s.read(ctx)
+		if err != nil {
+			return err
+		}
+
+		var notification rpcSubscriptionNotification
+		if err := json.Unmarshal(message, &notification); err != nil {
+			continue
+		}
+
+		if notification.Method != "eth_subscription" {
+			if rpcErr := decodeRPCError(message); rpcErr != nil {
+				return rpcErr
+			}
+			continue
+		}
+		if notification.Params.Subscription == "" {
+			continue
+		}
+
+		var head rpcSubscriptionHead
+		if err := json.Unmarshal(notification.Params.Result, &head); err != nil {
+			continue
+		}
+		if head.Number == "" {
+			continue
+		}
+
+		return nil
+	}
+}
+
+func (s *websocketHeadSubscription) Close() error {
+	var closeErr error
+	s.closeOnce.Do(func() {
+		closeErr = s.ws.Close()
+	})
+
+	return closeErr
+}
+
+func (s *websocketHeadSubscription) read(ctx context.Context) ([]byte, error) {
+	s.nextMu.Lock()
+	defer s.nextMu.Unlock()
+
+	for {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+
+		readDeadline := time.Now().Add(500 * time.Millisecond)
+		if err := s.ws.SetReadDeadline(readDeadline); err != nil {
+			return nil, fmt.Errorf("set read deadline: %w", err)
+		}
+
+		var message []byte
+		err := websocket.Message.Receive(s.ws, &message)
+		if err == nil {
+			if len(message) == 0 {
+				continue
+			}
+			return message, nil
+		}
+
+		if ne, ok := err.(net.Error); ok && ne.Timeout() {
+			continue
+		}
+
+		return nil, err
+	}
+}
+
+func writeWebSocketMessage(ctx context.Context, ws *websocket.Conn, payload []byte) error {
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		writeDeadline := time.Now().Add(500 * time.Millisecond)
+		if err := ws.SetWriteDeadline(writeDeadline); err != nil {
+			return fmt.Errorf("set write deadline: %w", err)
+		}
+
+		err := websocket.Message.Send(ws, payload)
+		if err == nil {
+			return nil
+		}
+		if ne, ok := err.(net.Error); ok && ne.Timeout() {
+			continue
+		}
+
+		return err
+	}
+}
+
+type rpcSubscriptionNotification struct {
+	Method string `json:"method"`
+	Params struct {
+		Subscription string          `json:"subscription"`
+		Result       json.RawMessage `json:"result"`
+	} `json:"params"`
+}
+
+type rpcSubscriptionHead struct {
+	Number string `json:"number"`
+}
+
+func originForWebSocketURL(wsURL string) string {
+	if len(wsURL) >= 6 && wsURL[:6] == "wss://" {
+		return "https://bastion.local"
+	}
+
+	return "http://bastion.local"
+}
+
+func decodeRPCError(message []byte) error {
+	var response rpcResponse
+	if err := json.Unmarshal(message, &response); err != nil {
+		return nil
+	}
+	if response.Error == nil {
+		return nil
+	}
+
+	return fmt.Errorf("subscription rpc error %d: %s", response.Error.Code, response.Error.Message)
+}

--- a/indexer/internal/indexer/subscription.go
+++ b/indexer/internal/indexer/subscription.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+	"net/url"
+	"strings"
 	"sync"
 	"time"
 
@@ -204,7 +206,17 @@ type rpcSubscriptionHead struct {
 }
 
 func originForWebSocketURL(wsURL string) string {
-	if len(wsURL) >= 6 && wsURL[:6] == "wss://" {
+	parsed, err := url.Parse(wsURL)
+	if err == nil && parsed.Host != "" {
+		scheme := "http"
+		if strings.EqualFold(parsed.Scheme, "wss") {
+			scheme = "https"
+		}
+
+		return scheme + "://" + parsed.Host
+	}
+
+	if strings.HasPrefix(strings.ToLower(wsURL), "wss://") {
 		return "https://bastion.local"
 	}
 

--- a/indexer/internal/indexer/subscription.go
+++ b/indexer/internal/indexer/subscription.go
@@ -172,26 +172,25 @@ func (s *websocketHeadSubscription) read(ctx context.Context) ([]byte, error) {
 }
 
 func writeWebSocketMessage(ctx context.Context, ws *websocket.Conn, payload []byte) error {
-	for {
-		if err := ctx.Err(); err != nil {
-			return err
-		}
-
-		writeDeadline := time.Now().Add(subscriptionIODeadline)
-		if err := ws.SetWriteDeadline(writeDeadline); err != nil {
-			return fmt.Errorf("set write deadline: %w", err)
-		}
-
-		err := websocket.Message.Send(ws, payload)
-		if err == nil {
-			return nil
-		}
-		if ne, ok := err.(net.Error); ok && ne.Timeout() {
-			continue
-		}
-
+	if err := ctx.Err(); err != nil {
 		return err
 	}
+
+	writeDeadline := time.Now().Add(subscriptionIODeadline)
+	if err := ws.SetWriteDeadline(writeDeadline); err != nil {
+		return fmt.Errorf("set write deadline: %w", err)
+	}
+
+	err := websocket.Message.Send(ws, payload)
+	if err == nil {
+		return nil
+	}
+
+	if ne, ok := err.(net.Error); ok && ne.Timeout() {
+		return fmt.Errorf("websocket write timeout: %w", err)
+	}
+
+	return err
 }
 
 type rpcSubscriptionNotification struct {

--- a/indexer/internal/indexer/subscription.go
+++ b/indexer/internal/indexer/subscription.go
@@ -16,6 +16,7 @@ import (
 const (
 	subscriptionTypeNewHeads   = "newHeads"
 	defaultSubscriptionBackoff = 2 * time.Second
+	subscriptionIODeadline     = 500 * time.Millisecond
 )
 
 type headSubscription interface {
@@ -148,7 +149,7 @@ func (s *websocketHeadSubscription) read(ctx context.Context) ([]byte, error) {
 			return nil, err
 		}
 
-		readDeadline := time.Now().Add(500 * time.Millisecond)
+		readDeadline := time.Now().Add(subscriptionIODeadline)
 		if err := s.ws.SetReadDeadline(readDeadline); err != nil {
 			return nil, fmt.Errorf("set read deadline: %w", err)
 		}
@@ -176,7 +177,7 @@ func writeWebSocketMessage(ctx context.Context, ws *websocket.Conn, payload []by
 			return err
 		}
 
-		writeDeadline := time.Now().Add(500 * time.Millisecond)
+		writeDeadline := time.Now().Add(subscriptionIODeadline)
 		if err := ws.SetWriteDeadline(writeDeadline); err != nil {
 			return fmt.Errorf("set write deadline: %w", err)
 		}

--- a/indexer/internal/indexer/subscription_test.go
+++ b/indexer/internal/indexer/subscription_test.go
@@ -135,3 +135,15 @@ func TestRunHeadSubscriptionLoopSkipsWhenContextCanceled(t *testing.T) {
 	wakeCh := make(chan struct{}, 1)
 	service.runHeadSubscriptionLoop(ctx, wakeCh)
 }
+
+func TestOriginForWebSocketURL_DerivesHostBasedOrigin(t *testing.T) {
+	t.Parallel()
+
+	if got := originForWebSocketURL("wss://rpc.example/ws?key=secret"); got != "https://rpc.example" {
+		t.Fatalf("expected https origin, got %q", got)
+	}
+
+	if got := originForWebSocketURL("ws://localhost:8546/path"); got != "http://localhost:8546" {
+		t.Fatalf("expected http origin with port, got %q", got)
+	}
+}

--- a/indexer/internal/indexer/subscription_test.go
+++ b/indexer/internal/indexer/subscription_test.go
@@ -1,0 +1,137 @@
+package indexer
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+type stubHeadSubscription struct {
+	nextFn  func(context.Context) error
+	closed  bool
+	closeFn func() error
+}
+
+func (s *stubHeadSubscription) Next(ctx context.Context) error {
+	if s.nextFn == nil {
+		<-ctx.Done()
+		return ctx.Err()
+	}
+
+	return s.nextFn(ctx)
+}
+
+func (s *stubHeadSubscription) Close() error {
+	s.closed = true
+	if s.closeFn != nil {
+		return s.closeFn()
+	}
+
+	return nil
+}
+
+func TestConsumeHeadSubscriptionSignalsWakeWithoutBlocking(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	nextCalls := 0
+	subscription := &stubHeadSubscription{
+		nextFn: func(context.Context) error {
+			nextCalls++
+			if nextCalls >= 3 {
+				return errors.New("done")
+			}
+			return nil
+		},
+	}
+
+	service := &Service{}
+	wakeCh := make(chan struct{}, 1)
+	err := service.consumeHeadSubscription(ctx, subscription, wakeCh)
+	if err == nil {
+		t.Fatal("expected consumeHeadSubscription error")
+	}
+
+	if len(wakeCh) != 1 {
+		t.Fatalf("expected wake signal to be buffered once, got %d", len(wakeCh))
+	}
+}
+
+func TestRunHeadSubscriptionLoopReconnectsAndSignalsWake(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	wakeCh := make(chan struct{}, 4)
+	connectAttempts := 0
+	firstSubscription := &stubHeadSubscription{
+		nextFn: func(context.Context) error {
+			return errors.New("connection lost")
+		},
+	}
+	secondSubscription := &stubHeadSubscription{}
+	secondSubscription.nextFn = func(context.Context) error {
+		select {
+		case wakeCh <- struct{}{}:
+		default:
+		}
+		cancel()
+		return context.Canceled
+	}
+
+	service := &Service{
+		cfg: Config{WSURL: "wss://ws.example"},
+		newHeadSubscriptionFactory: func(context.Context, string) (headSubscription, error) {
+			connectAttempts++
+			if connectAttempts == 1 {
+				return firstSubscription, nil
+			}
+			return secondSubscription, nil
+		},
+		subscriptionReconnectBackoff: time.Millisecond,
+	}
+
+	done := make(chan struct{})
+	go func() {
+		service.runHeadSubscriptionLoop(ctx, wakeCh)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("subscription loop did not stop")
+	}
+
+	if connectAttempts < 2 {
+		t.Fatalf("expected at least 2 connection attempts, got %d", connectAttempts)
+	}
+	if !firstSubscription.closed {
+		t.Fatal("expected first subscription to be closed")
+	}
+	if !secondSubscription.closed {
+		t.Fatal("expected second subscription to be closed")
+	}
+}
+
+func TestRunHeadSubscriptionLoopSkipsWhenContextCanceled(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	service := &Service{
+		cfg: Config{WSURL: "wss://ws.example"},
+		newHeadSubscriptionFactory: func(context.Context, string) (headSubscription, error) {
+			t.Fatal("factory should not be called after context cancellation")
+			return nil, nil
+		},
+	}
+
+	wakeCh := make(chan struct{}, 1)
+	service.runHeadSubscriptionLoop(ctx, wakeCh)
+}

--- a/indexer/internal/indexer/subscription_test.go
+++ b/indexer/internal/indexer/subscription_test.go
@@ -118,6 +118,47 @@ func TestRunHeadSubscriptionLoopReconnectsAndSignalsWake(t *testing.T) {
 	}
 }
 
+func TestRunHeadSubscriptionLoopTimesOutStuckConnect(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	wakeCh := make(chan struct{}, 1)
+	connectAttempts := 0
+	service := &Service{
+		cfg: Config{
+			WSURL:          "wss://ws.example",
+			RequestTimeout: 10 * time.Millisecond,
+		},
+		newHeadSubscriptionFactory: func(ctx context.Context, _ string) (headSubscription, error) {
+			connectAttempts++
+			<-ctx.Done()
+			if connectAttempts >= 2 {
+				cancel()
+			}
+			return nil, ctx.Err()
+		},
+		subscriptionReconnectBackoff: time.Millisecond,
+	}
+
+	done := make(chan struct{})
+	go func() {
+		service.runHeadSubscriptionLoop(ctx, wakeCh)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(300 * time.Millisecond):
+		t.Fatal("expected subscription loop to stop after timeout and cancellation")
+	}
+
+	if connectAttempts < 2 {
+		t.Fatalf("expected reconnect attempts after timeout, got %d", connectAttempts)
+	}
+}
+
 func TestRunHeadSubscriptionLoopSkipsWhenContextCanceled(t *testing.T) {
 	t.Parallel()
 
@@ -134,6 +175,24 @@ func TestRunHeadSubscriptionLoopSkipsWhenContextCanceled(t *testing.T) {
 
 	wakeCh := make(chan struct{}, 1)
 	service.runHeadSubscriptionLoop(ctx, wakeCh)
+}
+
+func TestSubscriptionConnectTimeoutDefaultsWhenRequestTimeoutInvalid(t *testing.T) {
+	t.Parallel()
+
+	service := &Service{cfg: Config{RequestTimeout: 0}}
+	if got := service.subscriptionConnectTimeout(); got != defaultRequestTimeout {
+		t.Fatalf("expected default request timeout %s, got %s", defaultRequestTimeout, got)
+	}
+}
+
+func TestSubscriptionConnectTimeoutUsesRequestTimeout(t *testing.T) {
+	t.Parallel()
+
+	service := &Service{cfg: Config{RequestTimeout: 7 * time.Second}}
+	if got := service.subscriptionConnectTimeout(); got != 7*time.Second {
+		t.Fatalf("expected request timeout %s, got %s", 7*time.Second, got)
+	}
 }
 
 func TestOriginForWebSocketURL_DerivesHostBasedOrigin(t *testing.T) {

--- a/indexer/internal/indexer/subscription_test.go
+++ b/indexer/internal/indexer/subscription_test.go
@@ -66,22 +66,22 @@ func TestRunHeadSubscriptionLoopReconnectsAndSignalsWake(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	wakeCh := make(chan struct{}, 4)
+	wakeCh := make(chan struct{}, 1)
 	connectAttempts := 0
 	firstSubscription := &stubHeadSubscription{
 		nextFn: func(context.Context) error {
 			return errors.New("connection lost")
 		},
 	}
-	secondSubscription := &stubHeadSubscription{}
-	secondSubscription.nextFn = func(context.Context) error {
-		select {
-		case wakeCh <- struct{}{}:
-		default:
+	secondNextCalls := 0
+	secondSubscription := &stubHeadSubscription{nextFn: func(context.Context) error {
+		secondNextCalls++
+		if secondNextCalls == 1 {
+			return nil
 		}
 		cancel()
 		return context.Canceled
-	}
+	}}
 
 	service := &Service{
 		cfg: Config{WSURL: "wss://ws.example"},
@@ -115,6 +115,18 @@ func TestRunHeadSubscriptionLoopReconnectsAndSignalsWake(t *testing.T) {
 	}
 	if !secondSubscription.closed {
 		t.Fatal("expected second subscription to be closed")
+	}
+
+	select {
+	case <-wakeCh:
+	default:
+		t.Fatal("expected wake signal from subscription consumer")
+	}
+
+	select {
+	case <-wakeCh:
+		t.Fatal("expected exactly one wake signal")
+	default:
 	}
 }
 


### PR DESCRIPTION
## What
- add optional `WS_RPC_URL` config for websocket RPC subscriptions with strict `ws://` / `wss://` validation
- add a websocket `eth_subscribe` (`newHeads`) client and subscription lifecycle (connect, ack, consume, reconnect)
- trigger immediate index iterations on new-head notifications while preserving existing polling as fallback
- keep startup flow as backfill/catch-up first, then real-time wakeups
- add focused tests for subscription wake signaling, reconnect behavior, and `WS_RPC_URL` config parsing
- update `.env.example`, README, and architecture notes for optional websocket wakeups

## Why
Issue #11 requires real-time event subscription behavior and resilience to connection drops while keeping seamless transition from backfill/live mode. Using websocket new-head notifications as a wake signal reduces latency, and polling remains the safety net when websocket is unavailable.

## Scope
- [ ] Contracts
- [x] Backend
- [ ] Frontend
- [ ] Tooling / CI
- [x] Documentation
- [x] Test

## How to verify
```sh
cd indexer && go test ./...
```

Optional manual checks:
```sh
# poll-only mode (no websocket)
cd indexer && DATABASE_URL=postgres://... RPC_URL=https://... INDEXER_START_BLOCK=0 go run ./cmd/indexer

# websocket wakeups enabled
cd indexer && DATABASE_URL=postgres://... RPC_URL=https://... WS_RPC_URL=wss://... INDEXER_START_BLOCK=0 go run ./cmd/indexer
```

## Related issues
closes #11