### PR TITLE
feat(indexer): add REST API endpoints

### DIFF
--- a/indexer/cmd/indexer/main.go
+++ b/indexer/cmd/indexer/main.go
@@ -10,6 +10,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/flwrenn/bastion/indexer/internal/api"
 	"github.com/flwrenn/bastion/indexer/internal/db"
 	"github.com/flwrenn/bastion/indexer/internal/indexer"
 )
@@ -71,6 +72,9 @@ func run() error {
 
 	mux := http.NewServeMux()
 
+	apiHandler := api.New(pool)
+	apiHandler.Register(mux)
+
 	mux.HandleFunc("GET /", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		fmt.Fprintf(w, `{"name":"bastion-indexer","status":"ok"}`)
@@ -91,7 +95,7 @@ func run() error {
 
 	srv := &http.Server{
 		Addr:    ":" + port,
-		Handler: mux,
+		Handler: api.CORS(mux),
 	}
 
 	// Shut down gracefully on signal, draining in-flight requests.

--- a/indexer/cmd/indexer/main.go
+++ b/indexer/cmd/indexer/main.go
@@ -72,9 +72,13 @@ func run() error {
 
 	mux := http.NewServeMux()
 
+	// API routes — CORS enabled for frontend access.
+	apiMux := http.NewServeMux()
 	apiHandler := api.New(pool)
-	apiHandler.Register(mux)
+	apiHandler.Register(apiMux)
+	mux.Handle("/api/", api.CORS(apiMux))
 
+	// Health endpoints — no CORS (internal probes only).
 	mux.HandleFunc("GET /", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		fmt.Fprintf(w, `{"name":"bastion-indexer","status":"ok"}`)
@@ -95,7 +99,7 @@ func run() error {
 
 	srv := &http.Server{
 		Addr:    ":" + port,
-		Handler: api.CORS(mux),
+		Handler: mux,
 	}
 
 	// Shut down gracefully on signal, draining in-flight requests.

--- a/indexer/internal/api/handler.go
+++ b/indexer/internal/api/handler.go
@@ -1,0 +1,223 @@
+package api
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/flwrenn/bastion/indexer/internal/db"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// Handler serves the indexer REST API.
+type Handler struct {
+	pool *pgxpool.Pool
+}
+
+// New creates an API handler backed by the given connection pool.
+func New(pool *pgxpool.Pool) *Handler {
+	return &Handler{pool: pool}
+}
+
+// Register mounts all API routes on the provided mux.
+func (h *Handler) Register(mux *http.ServeMux) {
+	mux.HandleFunc("GET /api/operations/{hash}", h.GetOperation)
+	mux.HandleFunc("GET /api/operations", h.ListOperations)
+	mux.HandleFunc("GET /api/stats", h.GetStats)
+}
+
+// CORS wraps a handler with permissive CORS headers for frontend access.
+func CORS(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+		w.Header().Set("Access-Control-Allow-Methods", "GET, OPTIONS")
+		w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+		if r.Method == http.MethodOptions {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+// --- handlers ---
+
+// ListOperations handles GET /api/operations.
+func (h *Handler) ListOperations(w http.ResponseWriter, r *http.Request) {
+	params := db.ListParams{
+		Limit:  intQuery(r, "limit", 20),
+		Offset: intQuery(r, "offset", 0),
+	}
+
+	if s := r.URL.Query().Get("sender"); s != "" {
+		b, err := decodeHexBytes(s)
+		if err != nil || len(b) != 20 {
+			writeError(w, http.StatusBadRequest, "invalid sender address")
+			return
+		}
+		params.Sender = b
+	}
+
+	ops, total, err := db.ListOperations(r.Context(), h.pool, params)
+	if err != nil {
+		slog.Error("list operations", "error", err)
+		writeError(w, http.StatusInternalServerError, "internal error")
+		return
+	}
+
+	data := make([]operationResponse, len(ops))
+	for i := range ops {
+		data[i] = toResponse(ops[i])
+	}
+
+	writeJSON(w, http.StatusOK, listResponse{
+		Data:   data,
+		Total:  total,
+		Limit:  params.Limit,
+		Offset: params.Offset,
+	})
+}
+
+// GetOperation handles GET /api/operations/{hash}.
+func (h *Handler) GetOperation(w http.ResponseWriter, r *http.Request) {
+	raw := r.PathValue("hash")
+	hash, err := decodeHexBytes(raw)
+	if err != nil || len(hash) != 32 {
+		writeError(w, http.StatusBadRequest, "invalid userOpHash")
+		return
+	}
+
+	op, err := db.GetOperationByHash(r.Context(), h.pool, hash)
+	if err != nil {
+		slog.Error("get operation", "error", err)
+		writeError(w, http.StatusInternalServerError, "internal error")
+		return
+	}
+	if op == nil {
+		writeError(w, http.StatusNotFound, "operation not found")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, toResponse(*op))
+}
+
+// GetStats handles GET /api/stats.
+func (h *Handler) GetStats(w http.ResponseWriter, r *http.Request) {
+	s, err := db.GetStats(r.Context(), h.pool)
+	if err != nil {
+		slog.Error("get stats", "error", err)
+		writeError(w, http.StatusInternalServerError, "internal error")
+		return
+	}
+
+	var rate float64
+	if s.TotalOps > 0 {
+		rate = float64(s.SuccessCount) / float64(s.TotalOps)
+	}
+
+	writeJSON(w, http.StatusOK, statsResponse{
+		TotalOps:      s.TotalOps,
+		SuccessCount:  s.SuccessCount,
+		SuccessRate:   rate,
+		UniqueSenders: s.UniqueSenders,
+	})
+}
+
+// --- response types ---
+
+type operationResponse struct {
+	UserOpHash     string `json:"userOpHash"`
+	Sender         string `json:"sender"`
+	Paymaster      string `json:"paymaster"`
+	Target         string `json:"target,omitempty"`
+	Calldata       string `json:"calldata,omitempty"`
+	Nonce          string `json:"nonce"`
+	Success        bool   `json:"success"`
+	ActualGasCost  string `json:"actualGasCost"`
+	ActualGasUsed  string `json:"actualGasUsed"`
+	TxHash         string `json:"txHash"`
+	BlockNumber    int64  `json:"blockNumber"`
+	BlockTimestamp int64  `json:"blockTimestamp"`
+	LogIndex       int32  `json:"logIndex"`
+}
+
+type listResponse struct {
+	Data   []operationResponse `json:"data"`
+	Total  int                 `json:"total"`
+	Limit  int                 `json:"limit"`
+	Offset int                 `json:"offset"`
+}
+
+type statsResponse struct {
+	TotalOps      int64   `json:"totalOps"`
+	SuccessCount  int64   `json:"successCount"`
+	SuccessRate   float64 `json:"successRate"`
+	UniqueSenders int64   `json:"uniqueSenders"`
+}
+
+func toResponse(op db.UserOperation) operationResponse {
+	return operationResponse{
+		UserOpHash:     encodeHex(op.UserOpHash),
+		Sender:         encodeHex(op.Sender),
+		Paymaster:      encodeHex(op.Paymaster),
+		Target:         encodeHex(op.Target),
+		Calldata:       encodeHex(op.Calldata),
+		Nonce:          op.Nonce,
+		Success:        op.Success,
+		ActualGasCost:  op.ActualGasCost,
+		ActualGasUsed:  op.ActualGasUsed,
+		TxHash:         encodeHex(op.TxHash),
+		BlockNumber:    op.BlockNumber,
+		BlockTimestamp: op.BlockTimestamp,
+		LogIndex:       op.LogIndex,
+	}
+}
+
+// --- helpers ---
+
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		slog.Error("encode json response", "error", err)
+	}
+}
+
+func writeError(w http.ResponseWriter, status int, msg string) {
+	writeJSON(w, status, map[string]string{"error": msg})
+}
+
+func encodeHex(b []byte) string {
+	if len(b) == 0 {
+		return ""
+	}
+	return "0x" + hex.EncodeToString(b)
+}
+
+func decodeHexBytes(s string) ([]byte, error) {
+	s = strings.TrimSpace(s)
+	if len(s) < 2 || (s[:2] != "0x" && s[:2] != "0X") {
+		return nil, fmt.Errorf("missing 0x prefix")
+	}
+	h := s[2:]
+	if len(h)%2 != 0 {
+		return nil, fmt.Errorf("odd hex length")
+	}
+	return hex.DecodeString(h)
+}
+
+func intQuery(r *http.Request, key string, def int) int {
+	v := r.URL.Query().Get(key)
+	if v == "" {
+		return def
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil {
+		return def
+	}
+	return n
+}

--- a/indexer/internal/api/handler.go
+++ b/indexer/internal/api/handler.go
@@ -52,6 +52,7 @@ func (h *Handler) ListOperations(w http.ResponseWriter, r *http.Request) {
 		Limit:  intQuery(r, "limit", 20),
 		Offset: intQuery(r, "offset", 0),
 	}
+	db.ClampListParams(&params)
 
 	if s := r.URL.Query().Get("sender"); s != "" {
 		b, err := decodeHexBytes(s)

--- a/indexer/internal/api/handler.go
+++ b/indexer/internal/api/handler.go
@@ -54,7 +54,7 @@ func (h *Handler) ListOperations(w http.ResponseWriter, r *http.Request) {
 	}
 	db.ClampListParams(&params)
 
-	if s := r.URL.Query().Get("sender"); s != "" {
+	if s := strings.TrimSpace(r.URL.Query().Get("sender")); s != "" {
 		if len(s) != 42 { // "0x" + 40 hex chars = 20 bytes
 			writeError(w, http.StatusBadRequest, "invalid sender address")
 			return
@@ -89,7 +89,7 @@ func (h *Handler) ListOperations(w http.ResponseWriter, r *http.Request) {
 
 // GetOperation handles GET /api/operations/{hash}.
 func (h *Handler) GetOperation(w http.ResponseWriter, r *http.Request) {
-	raw := r.PathValue("hash")
+	raw := strings.TrimSpace(r.PathValue("hash"))
 	if len(raw) != 66 { // "0x" + 64 hex chars = 32 bytes
 		writeError(w, http.StatusBadRequest, "invalid userOpHash")
 		return

--- a/indexer/internal/api/handler.go
+++ b/indexer/internal/api/handler.go
@@ -55,8 +55,12 @@ func (h *Handler) ListOperations(w http.ResponseWriter, r *http.Request) {
 	db.ClampListParams(&params)
 
 	if s := r.URL.Query().Get("sender"); s != "" {
+		if len(s) != 42 { // "0x" + 40 hex chars = 20 bytes
+			writeError(w, http.StatusBadRequest, "invalid sender address")
+			return
+		}
 		b, err := decodeHexBytes(s)
-		if err != nil || len(b) != 20 {
+		if err != nil {
 			writeError(w, http.StatusBadRequest, "invalid sender address")
 			return
 		}
@@ -86,8 +90,12 @@ func (h *Handler) ListOperations(w http.ResponseWriter, r *http.Request) {
 // GetOperation handles GET /api/operations/{hash}.
 func (h *Handler) GetOperation(w http.ResponseWriter, r *http.Request) {
 	raw := r.PathValue("hash")
+	if len(raw) != 66 { // "0x" + 64 hex chars = 32 bytes
+		writeError(w, http.StatusBadRequest, "invalid userOpHash")
+		return
+	}
 	hash, err := decodeHexBytes(raw)
-	if err != nil || len(hash) != 32 {
+	if err != nil {
 		writeError(w, http.StatusBadRequest, "invalid userOpHash")
 		return
 	}

--- a/indexer/internal/api/handler.go
+++ b/indexer/internal/api/handler.go
@@ -201,7 +201,7 @@ func writeError(w http.ResponseWriter, status int, msg string) {
 }
 
 func encodeHex(b []byte) string {
-	if len(b) == 0 {
+	if b == nil {
 		return ""
 	}
 	return "0x" + hex.EncodeToString(b)

--- a/indexer/internal/api/handler.go
+++ b/indexer/internal/api/handler.go
@@ -147,7 +147,7 @@ type operationResponse struct {
 
 type listResponse struct {
 	Data   []operationResponse `json:"data"`
-	Total  int                 `json:"total"`
+	Total  int64               `json:"total"`
 	Limit  int                 `json:"limit"`
 	Offset int                 `json:"offset"`
 }

--- a/indexer/internal/api/handler_test.go
+++ b/indexer/internal/api/handler_test.go
@@ -18,7 +18,7 @@ func TestEncodeHex(t *testing.T) {
 		want string
 	}{
 		{"nil returns empty", nil, ""},
-		{"empty returns empty", []byte{}, ""},
+		{"empty returns 0x", []byte{}, "0x"},
 		{"20-byte address", make([]byte, 20), "0x0000000000000000000000000000000000000000"},
 		{"short bytes", []byte{0xca, 0xfe}, "0xcafe"},
 	}

--- a/indexer/internal/api/handler_test.go
+++ b/indexer/internal/api/handler_test.go
@@ -1,0 +1,262 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/flwrenn/bastion/indexer/internal/db"
+)
+
+func TestEncodeHex(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   []byte
+		want string
+	}{
+		{"nil returns empty", nil, ""},
+		{"empty returns empty", []byte{}, ""},
+		{"20-byte address", make([]byte, 20), "0x0000000000000000000000000000000000000000"},
+		{"short bytes", []byte{0xca, 0xfe}, "0xcafe"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := encodeHex(tt.in); got != tt.want {
+				t.Fatalf("encodeHex(%v) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDecodeHexBytes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		in      string
+		wantLen int
+		wantErr bool
+	}{
+		{"valid 20-byte address", "0x0000000000000000000000000000000000000001", 20, false},
+		{"valid 32-byte hash", "0x" + "ab" + "00000000000000000000000000000000000000000000000000000000000000", 32, false},
+		{"uppercase prefix", "0X00ff", 2, false},
+		{"missing prefix", "abcd", 0, true},
+		{"odd length", "0xabc", 0, true},
+		{"invalid hex char", "0xzzzz", 0, true},
+		{"empty after prefix", "0x", 0, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			b, err := decodeHexBytes(tt.in)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for %q", tt.in)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error for %q: %v", tt.in, err)
+			}
+			if len(b) != tt.wantLen {
+				t.Fatalf("len = %d, want %d", len(b), tt.wantLen)
+			}
+		})
+	}
+}
+
+func TestIntQuery(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		url  string
+		key  string
+		def  int
+		want int
+	}{
+		{"missing key uses default", "/path", "limit", 20, 20},
+		{"valid int", "/path?limit=50", "limit", 20, 50},
+		{"non-numeric uses default", "/path?limit=abc", "limit", 20, 20},
+		{"empty value uses default", "/path?limit=", "limit", 20, 20},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			r := httptest.NewRequest(http.MethodGet, tt.url, nil)
+			if got := intQuery(r, tt.key, tt.def); got != tt.want {
+				t.Fatalf("intQuery = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCORSHeaders(t *testing.T) {
+	t.Parallel()
+
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	handler := CORS(inner)
+
+	t.Run("GET request includes CORS headers", func(t *testing.T) {
+		t.Parallel()
+		r := httptest.NewRequest(http.MethodGet, "/api/stats", nil)
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, r)
+
+		if got := w.Header().Get("Access-Control-Allow-Origin"); got != "*" {
+			t.Fatalf("Allow-Origin = %q, want *", got)
+		}
+		if w.Code != http.StatusOK {
+			t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+		}
+	})
+
+	t.Run("OPTIONS preflight returns 204", func(t *testing.T) {
+		t.Parallel()
+		r := httptest.NewRequest(http.MethodOptions, "/api/operations", nil)
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, r)
+
+		if w.Code != http.StatusNoContent {
+			t.Fatalf("status = %d, want %d", w.Code, http.StatusNoContent)
+		}
+		if got := w.Header().Get("Access-Control-Allow-Methods"); got != "GET, OPTIONS" {
+			t.Fatalf("Allow-Methods = %q, want %q", got, "GET, OPTIONS")
+		}
+	})
+}
+
+func TestListOperationsBadSender(t *testing.T) {
+	t.Parallel()
+
+	h := New(nil)
+	mux := http.NewServeMux()
+	h.Register(mux)
+
+	r := httptest.NewRequest(http.MethodGet, "/api/operations?sender=not-hex", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+	var body map[string]string
+	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if body["error"] != "invalid sender address" {
+		t.Fatalf("error = %q, want %q", body["error"], "invalid sender address")
+	}
+}
+
+func TestListOperationsBadSenderLength(t *testing.T) {
+	t.Parallel()
+
+	h := New(nil)
+	mux := http.NewServeMux()
+	h.Register(mux)
+
+	r := httptest.NewRequest(http.MethodGet, "/api/operations?sender=0xdead", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+}
+
+func TestGetOperationBadHash(t *testing.T) {
+	t.Parallel()
+
+	h := New(nil)
+	mux := http.NewServeMux()
+	h.Register(mux)
+
+	r := httptest.NewRequest(http.MethodGet, "/api/operations/not-a-hash", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+	var body map[string]string
+	if err := json.NewDecoder(w.Body).Decode(&body); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if body["error"] != "invalid userOpHash" {
+		t.Fatalf("error = %q, want %q", body["error"], "invalid userOpHash")
+	}
+}
+
+func TestGetOperationShortHash(t *testing.T) {
+	t.Parallel()
+
+	h := New(nil)
+	mux := http.NewServeMux()
+	h.Register(mux)
+
+	r := httptest.NewRequest(http.MethodGet, "/api/operations/0xdeadbeef", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+}
+
+func TestToResponse(t *testing.T) {
+	t.Parallel()
+
+	resp := toResponse(testOp())
+
+	if resp.Sender != "0x"+testAddr {
+		t.Fatalf("sender = %q, want 0x%s", resp.Sender, testAddr)
+	}
+	if resp.UserOpHash != "0x"+testHash {
+		t.Fatalf("userOpHash = %q", resp.UserOpHash)
+	}
+	if resp.Nonce != "42" {
+		t.Fatalf("nonce = %q, want 42", resp.Nonce)
+	}
+	if !resp.Success {
+		t.Fatal("expected success = true")
+	}
+	if resp.BlockNumber != 100 {
+		t.Fatalf("blockNumber = %d, want 100", resp.BlockNumber)
+	}
+}
+
+const (
+	testAddr = "0000000000000000000000000000000000000001"
+	testHash = "0000000000000000000000000000000000000000000000000000000000000001"
+)
+
+func testOp() db.UserOperation {
+	sender := make([]byte, 20)
+	sender[19] = 1
+	hash := make([]byte, 32)
+	hash[31] = 1
+	return db.UserOperation{
+		ID:             1,
+		UserOpHash:     hash,
+		Sender:         sender,
+		Paymaster:      make([]byte, 20),
+		Nonce:          "42",
+		Success:        true,
+		ActualGasCost:  "1000",
+		ActualGasUsed:  "500",
+		TxHash:         make([]byte, 32),
+		BlockNumber:    100,
+		BlockTimestamp: 1700000000,
+		LogIndex:       0,
+	}
+}

--- a/indexer/internal/api/handler_test.go
+++ b/indexer/internal/api/handler_test.go
@@ -213,7 +213,7 @@ func TestGetOperationShortHash(t *testing.T) {
 	}
 }
 
-func TestListOperationsClampedResponse(t *testing.T) {
+func TestClampedParamsFromQuery(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {

--- a/indexer/internal/api/handler_test.go
+++ b/indexer/internal/api/handler_test.go
@@ -213,6 +213,40 @@ func TestGetOperationShortHash(t *testing.T) {
 	}
 }
 
+func TestListOperationsClampedResponse(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		query      string
+		wantLimit  int
+		wantOffset int
+	}{
+		{"over-max limit clamped to 100", "?limit=200", 100, 0},
+		{"zero limit defaults to 20", "?limit=0", 20, 0},
+		{"negative offset clamped to 0", "?offset=-5", 20, 0},
+		{"over-max offset clamped to 10000", "?offset=20000", 20, 10000},
+		{"combined out-of-range", "?limit=999&offset=-1", 100, 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			p := db.ListParams{
+				Limit:  intQuery(httptest.NewRequest(http.MethodGet, "/api/operations"+tt.query, nil), "limit", 20),
+				Offset: intQuery(httptest.NewRequest(http.MethodGet, "/api/operations"+tt.query, nil), "offset", 0),
+			}
+			db.ClampListParams(&p)
+			if p.Limit != tt.wantLimit {
+				t.Fatalf("limit: got %d, want %d", p.Limit, tt.wantLimit)
+			}
+			if p.Offset != tt.wantOffset {
+				t.Fatalf("offset: got %d, want %d", p.Offset, tt.wantOffset)
+			}
+		})
+	}
+}
+
 func TestToResponse(t *testing.T) {
 	t.Parallel()
 

--- a/indexer/internal/db/queries.go
+++ b/indexer/internal/db/queries.go
@@ -16,7 +16,10 @@ type ListParams struct {
 	Offset int
 }
 
-func clampListParams(p *ListParams) {
+// ClampListParams normalises pagination values to safe defaults.
+// It is exported so the API handler can clamp before calling ListOperations
+// and echo the effective values in the response.
+func ClampListParams(p *ListParams) {
 	if p.Limit <= 0 {
 		p.Limit = 20
 	}
@@ -37,7 +40,7 @@ func ListOperations(ctx context.Context, pool *pgxpool.Pool, p ListParams) ([]Us
 	if pool == nil {
 		return nil, 0, errors.New("pool is required")
 	}
-	clampListParams(&p)
+	ClampListParams(&p)
 
 	var total int64
 	var rows pgx.Rows

--- a/indexer/internal/db/queries.go
+++ b/indexer/internal/db/queries.go
@@ -16,9 +16,7 @@ type ListParams struct {
 	Offset int
 }
 
-// ListOperations returns a page of user operations ordered newest-first,
-// along with the total count matching the filter.
-func ListOperations(ctx context.Context, pool *pgxpool.Pool, p ListParams) ([]UserOperation, int, error) {
+func clampListParams(p *ListParams) {
 	if p.Limit <= 0 {
 		p.Limit = 20
 	}
@@ -28,6 +26,15 @@ func ListOperations(ctx context.Context, pool *pgxpool.Pool, p ListParams) ([]Us
 	if p.Offset < 0 {
 		p.Offset = 0
 	}
+}
+
+// ListOperations returns a page of user operations ordered newest-first,
+// along with the total count matching the filter.
+func ListOperations(ctx context.Context, pool *pgxpool.Pool, p ListParams) ([]UserOperation, int, error) {
+	if pool == nil {
+		return nil, 0, errors.New("pool is required")
+	}
+	clampListParams(&p)
 
 	var total int
 	var rows pgx.Rows
@@ -108,6 +115,9 @@ func ListOperations(ctx context.Context, pool *pgxpool.Pool, p ListParams) ([]Us
 // GetOperationByHash returns a single user operation by its userOpHash.
 // Returns nil, nil when no matching row exists.
 func GetOperationByHash(ctx context.Context, pool *pgxpool.Pool, hash []byte) (*UserOperation, error) {
+	if pool == nil {
+		return nil, errors.New("pool is required")
+	}
 	var op UserOperation
 	err := pool.QueryRow(ctx, `
 		SELECT id, user_op_hash, sender, paymaster, target, calldata,
@@ -150,6 +160,9 @@ type Stats struct {
 
 // GetStats returns aggregate statistics across all indexed operations.
 func GetStats(ctx context.Context, pool *pgxpool.Pool) (Stats, error) {
+	if pool == nil {
+		return Stats{}, errors.New("pool is required")
+	}
 	var s Stats
 	err := pool.QueryRow(ctx, `
 		SELECT count(*),

--- a/indexer/internal/db/queries.go
+++ b/indexer/internal/db/queries.go
@@ -130,7 +130,9 @@ func GetOperationByHash(ctx context.Context, pool *pgxpool.Pool, hash []byte) (*
 		       nonce, success, actual_gas_cost, actual_gas_used,
 		       tx_hash, block_number, block_timestamp, log_index
 		FROM user_operations
-		WHERE user_op_hash = $1`,
+		WHERE user_op_hash = $1
+		ORDER BY block_number DESC, log_index DESC
+		LIMIT 1`,
 		hash,
 	).Scan(
 		&op.ID,

--- a/indexer/internal/db/queries.go
+++ b/indexer/internal/db/queries.go
@@ -1,0 +1,164 @@
+package db
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// ListParams controls pagination and filtering for ListOperations.
+type ListParams struct {
+	Sender []byte // nil = no filter
+	Limit  int
+	Offset int
+}
+
+// ListOperations returns a page of user operations ordered newest-first,
+// along with the total count matching the filter.
+func ListOperations(ctx context.Context, pool *pgxpool.Pool, p ListParams) ([]UserOperation, int, error) {
+	if p.Limit <= 0 {
+		p.Limit = 20
+	}
+	if p.Limit > 100 {
+		p.Limit = 100
+	}
+	if p.Offset < 0 {
+		p.Offset = 0
+	}
+
+	var total int
+	var rows pgx.Rows
+	var err error
+
+	if p.Sender != nil {
+		err = pool.QueryRow(ctx,
+			"SELECT count(*) FROM user_operations WHERE sender = $1",
+			p.Sender,
+		).Scan(&total)
+		if err != nil {
+			return nil, 0, fmt.Errorf("count operations: %w", err)
+		}
+
+		rows, err = pool.Query(ctx, `
+			SELECT id, user_op_hash, sender, paymaster, target, calldata,
+			       nonce, success, actual_gas_cost, actual_gas_used,
+			       tx_hash, block_number, block_timestamp, log_index
+			FROM user_operations
+			WHERE sender = $1
+			ORDER BY block_number DESC, log_index DESC
+			LIMIT $2 OFFSET $3`,
+			p.Sender, p.Limit, p.Offset,
+		)
+	} else {
+		err = pool.QueryRow(ctx,
+			"SELECT count(*) FROM user_operations",
+		).Scan(&total)
+		if err != nil {
+			return nil, 0, fmt.Errorf("count operations: %w", err)
+		}
+
+		rows, err = pool.Query(ctx, `
+			SELECT id, user_op_hash, sender, paymaster, target, calldata,
+			       nonce, success, actual_gas_cost, actual_gas_used,
+			       tx_hash, block_number, block_timestamp, log_index
+			FROM user_operations
+			ORDER BY block_number DESC, log_index DESC
+			LIMIT $1 OFFSET $2`,
+			p.Limit, p.Offset,
+		)
+	}
+	if err != nil {
+		return nil, 0, fmt.Errorf("query operations: %w", err)
+	}
+	defer rows.Close()
+
+	var ops []UserOperation
+	for rows.Next() {
+		var op UserOperation
+		if err := rows.Scan(
+			&op.ID,
+			&op.UserOpHash,
+			&op.Sender,
+			&op.Paymaster,
+			&op.Target,
+			&op.Calldata,
+			&op.Nonce,
+			&op.Success,
+			&op.ActualGasCost,
+			&op.ActualGasUsed,
+			&op.TxHash,
+			&op.BlockNumber,
+			&op.BlockTimestamp,
+			&op.LogIndex,
+		); err != nil {
+			return nil, 0, fmt.Errorf("scan operation: %w", err)
+		}
+		ops = append(ops, op)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, 0, fmt.Errorf("iterate operations: %w", err)
+	}
+
+	return ops, total, nil
+}
+
+// GetOperationByHash returns a single user operation by its userOpHash.
+// Returns nil, nil when no matching row exists.
+func GetOperationByHash(ctx context.Context, pool *pgxpool.Pool, hash []byte) (*UserOperation, error) {
+	var op UserOperation
+	err := pool.QueryRow(ctx, `
+		SELECT id, user_op_hash, sender, paymaster, target, calldata,
+		       nonce, success, actual_gas_cost, actual_gas_used,
+		       tx_hash, block_number, block_timestamp, log_index
+		FROM user_operations
+		WHERE user_op_hash = $1`,
+		hash,
+	).Scan(
+		&op.ID,
+		&op.UserOpHash,
+		&op.Sender,
+		&op.Paymaster,
+		&op.Target,
+		&op.Calldata,
+		&op.Nonce,
+		&op.Success,
+		&op.ActualGasCost,
+		&op.ActualGasUsed,
+		&op.TxHash,
+		&op.BlockNumber,
+		&op.BlockTimestamp,
+		&op.LogIndex,
+	)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("query operation by hash: %w", err)
+	}
+	return &op, nil
+}
+
+// Stats holds aggregate statistics for indexed user operations.
+type Stats struct {
+	TotalOps      int64
+	SuccessCount  int64
+	UniqueSenders int64
+}
+
+// GetStats returns aggregate statistics across all indexed operations.
+func GetStats(ctx context.Context, pool *pgxpool.Pool) (Stats, error) {
+	var s Stats
+	err := pool.QueryRow(ctx, `
+		SELECT count(*),
+		       count(*) FILTER (WHERE success),
+		       count(DISTINCT sender)
+		FROM user_operations`,
+	).Scan(&s.TotalOps, &s.SuccessCount, &s.UniqueSenders)
+	if err != nil {
+		return Stats{}, fmt.Errorf("query stats: %w", err)
+	}
+	return s, nil
+}

--- a/indexer/internal/db/queries.go
+++ b/indexer/internal/db/queries.go
@@ -26,17 +26,20 @@ func clampListParams(p *ListParams) {
 	if p.Offset < 0 {
 		p.Offset = 0
 	}
+	if p.Offset > 10000 {
+		p.Offset = 10000
+	}
 }
 
 // ListOperations returns a page of user operations ordered newest-first,
 // along with the total count matching the filter.
-func ListOperations(ctx context.Context, pool *pgxpool.Pool, p ListParams) ([]UserOperation, int, error) {
+func ListOperations(ctx context.Context, pool *pgxpool.Pool, p ListParams) ([]UserOperation, int64, error) {
 	if pool == nil {
 		return nil, 0, errors.New("pool is required")
 	}
 	clampListParams(&p)
 
-	var total int
+	var total int64
 	var rows pgx.Rows
 	var err error
 

--- a/indexer/internal/db/queries_test.go
+++ b/indexer/internal/db/queries_test.go
@@ -32,6 +32,7 @@ func TestListOperationsClampsPagination(t *testing.T) {
 		{"negative limit defaults to 20", -5, 0, 20, 0},
 		{"over-100 clamped to 100", 200, 0, 100, 0},
 		{"negative offset clamped to 0", 10, -3, 10, 0},
+		{"over-10000 offset clamped to 10000", 20, 20000, 20, 10000},
 		{"valid values unchanged", 50, 10, 50, 10},
 	}
 
@@ -39,7 +40,7 @@ func TestListOperationsClampsPagination(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			p := ListParams{Limit: tt.limit, Offset: tt.offset}
-			clampListParams(&p)
+			ClampListParams(&p)
 			if p.Limit != tt.wantLimit {
 				t.Fatalf("limit: got %d, want %d", p.Limit, tt.wantLimit)
 			}

--- a/indexer/internal/db/queries_test.go
+++ b/indexer/internal/db/queries_test.go
@@ -1,0 +1,75 @@
+package db
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestListOperationsRejectsNilPool(t *testing.T) {
+	t.Parallel()
+
+	_, _, err := ListOperations(context.Background(), nil, ListParams{})
+	if err == nil {
+		t.Fatal("expected nil-pool error")
+	}
+	if !strings.Contains(err.Error(), "pool is required") {
+		t.Fatalf("expected pool error, got %v", err)
+	}
+}
+
+func TestListOperationsClampsPagination(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		limit      int
+		offset     int
+		wantLimit  int
+		wantOffset int
+	}{
+		{"zero limit defaults to 20", 0, 0, 20, 0},
+		{"negative limit defaults to 20", -5, 0, 20, 0},
+		{"over-100 clamped to 100", 200, 0, 100, 0},
+		{"negative offset clamped to 0", 10, -3, 10, 0},
+		{"valid values unchanged", 50, 10, 50, 10},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			p := ListParams{Limit: tt.limit, Offset: tt.offset}
+			clampListParams(&p)
+			if p.Limit != tt.wantLimit {
+				t.Fatalf("limit: got %d, want %d", p.Limit, tt.wantLimit)
+			}
+			if p.Offset != tt.wantOffset {
+				t.Fatalf("offset: got %d, want %d", p.Offset, tt.wantOffset)
+			}
+		})
+	}
+}
+
+func TestGetOperationByHashRejectsNilPool(t *testing.T) {
+	t.Parallel()
+
+	_, err := GetOperationByHash(context.Background(), nil, make([]byte, 32))
+	if err == nil {
+		t.Fatal("expected nil-pool error")
+	}
+	if !strings.Contains(err.Error(), "pool is required") {
+		t.Fatalf("expected pool error, got %v", err)
+	}
+}
+
+func TestGetStatsRejectsNilPool(t *testing.T) {
+	t.Parallel()
+
+	_, err := GetStats(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected nil-pool error")
+	}
+	if !strings.Contains(err.Error(), "pool is required") {
+		t.Fatalf("expected pool error, got %v", err)
+	}
+}


### PR DESCRIPTION
## What

Add three read-only JSON endpoints to the indexer HTTP server:

- `GET /api/operations` — paginated list, filterable by `?sender=0x…`
- `GET /api/operations/{hash}` — single operation by userOpHash
- `GET /api/stats` — total ops, success count/rate, unique senders

Plus CORS middleware for frontend cross-origin access.

## Why

The frontend dashboard needs to query indexed UserOperation data. These endpoints expose the data stored by the indexer's backfill and subscription pipeline.

## Scope

- [ ] Contracts
- [x] Backend
- [ ] Frontend
- [ ] Tooling / CI
- [ ] Documentation
- [x] Test

## How to verify

1. Start Postgres (`make db-up`) and the indexer (`cd indexer && go run ./cmd/indexer`)
2. `curl localhost:3001/api/operations` — returns paginated JSON
3. `curl localhost:3001/api/operations?sender=0x…&limit=5` — filtered
4. `curl localhost:3001/api/operations/0x<hash>` — single op or 404
5. `curl localhost:3001/api/stats` — aggregate stats
6. `curl -I -X OPTIONS localhost:3001/api/operations` — CORS preflight returns 204
7. `cd indexer && go test ./internal/db/ ./internal/api/ -v` — 24 tests pass

## Related issues

Closes #12