### PR TITLE
feat(indexer): websocket live feed

### DIFF
--- a/indexer/cmd/indexer/main.go
+++ b/indexer/cmd/indexer/main.go
@@ -61,6 +61,10 @@ func run() error {
 		return fmt.Errorf("init indexer service: %w", err)
 	}
 
+	// WebSocket live feed — broadcasts new operations to connected clients.
+	hub := api.NewHub()
+	svc.OnOperationsIndexed = hub.Broadcast
+
 	workerResultCh := make(chan error, 1)
 	go func() {
 		runErr := svc.Run(ctx)
@@ -77,6 +81,9 @@ func run() error {
 	apiHandler := api.New(pool)
 	apiHandler.Register(apiMux)
 	mux.Handle("/api/", api.CORS(apiMux))
+
+	// WebSocket live feed — outside /api/ (upgrade requests don't use CORS).
+	mux.HandleFunc("GET /ws", hub.ServeWS)
 
 	// Health endpoints — no CORS (internal probes only).
 	mux.HandleFunc("GET /", func(w http.ResponseWriter, r *http.Request) {
@@ -106,6 +113,7 @@ func run() error {
 	go func() {
 		<-ctx.Done()
 		slog.Info("shutting down")
+		hub.Shutdown()
 		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer shutdownCancel()
 		if err := srv.Shutdown(shutdownCtx); err != nil {

--- a/indexer/go.mod
+++ b/indexer/go.mod
@@ -3,8 +3,8 @@ module github.com/flwrenn/bastion/indexer
 go 1.25.0
 
 require (
+	github.com/coder/websocket v1.8.14
 	github.com/jackc/pgx/v5 v5.8.0
-	golang.org/x/net v0.52.0
 )
 
 require (

--- a/indexer/go.sum
+++ b/indexer/go.sum
@@ -1,3 +1,5 @@
+github.com/coder/websocket v1.8.14 h1:9L0p0iKiNOibykf283eHkKUHHrpG7f65OE3BhhO7v9g=
+github.com/coder/websocket v1.8.14/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6pumgx0mVg=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -16,8 +18,6 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-golang.org/x/net v0.52.0 h1:He/TN1l0e4mmR3QqHMT2Xab3Aj3L9qjbhRm78/6jrW0=
-golang.org/x/net v0.52.0/go.mod h1:R1MAz7uMZxVMualyPXb+VaqGSa3LIaUqk0eEt3w36Sw=
 golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
 golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 golang.org/x/text v0.35.0 h1:JOVx6vVDFokkpaq1AEptVzLTpDe9KGpj5tR4/X+ybL8=

--- a/indexer/internal/api/hub.go
+++ b/indexer/internal/api/hub.go
@@ -1,0 +1,134 @@
+package api
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"sync"
+
+	"github.com/coder/websocket"
+	"github.com/flwrenn/bastion/indexer/internal/db"
+)
+
+const clientSendBuffer = 32
+
+// Hub manages WebSocket clients and broadcasts new operations to them.
+type Hub struct {
+	mu      sync.Mutex
+	clients map[*wsClient]struct{}
+	closed  bool
+}
+
+type wsClient struct {
+	send chan []byte
+}
+
+// NewHub creates a Hub ready to accept WebSocket connections.
+func NewHub() *Hub {
+	return &Hub{clients: make(map[*wsClient]struct{})}
+}
+
+// Broadcast converts each operation to JSON and sends it to every connected
+// client. Slow consumers whose buffer is full are dropped immediately.
+func (h *Hub) Broadcast(ops []db.UserOperation) {
+	messages := make([][]byte, 0, len(ops))
+	for i := range ops {
+		data, err := json.Marshal(toResponse(ops[i]))
+		if err != nil {
+			slog.Error("marshal broadcast message", "error", err)
+			continue
+		}
+		messages = append(messages, data)
+	}
+	if len(messages) == 0 {
+		return
+	}
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	for c := range h.clients {
+		for _, msg := range messages {
+			select {
+			case c.send <- msg:
+			default:
+				// Slow client — drop it.
+				h.removeClientLocked(c)
+				break
+			}
+		}
+	}
+}
+
+// ServeWS upgrades an HTTP request to a WebSocket connection and streams
+// broadcast messages until the client disconnects or the hub shuts down.
+func (h *Hub) ServeWS(w http.ResponseWriter, r *http.Request) {
+	conn, err := websocket.Accept(w, r, &websocket.AcceptOptions{
+		InsecureSkipVerify: true, // Allow all origins (frontend is cross-origin).
+	})
+	if err != nil {
+		slog.Error("websocket accept", "error", err)
+		return
+	}
+
+	client := &wsClient{send: make(chan []byte, clientSendBuffer)}
+
+	h.mu.Lock()
+	if h.closed {
+		h.mu.Unlock()
+		conn.Close(websocket.StatusGoingAway, "server shutting down")
+		return
+	}
+	h.clients[client] = struct{}{}
+	h.mu.Unlock()
+
+	slog.Info("websocket client connected", "remote", r.RemoteAddr)
+
+	// CloseRead returns a context that is cancelled when the client sends a
+	// close frame or the underlying connection breaks.
+	ctx := conn.CloseRead(r.Context())
+
+	defer func() {
+		h.mu.Lock()
+		h.removeClientLocked(client)
+		h.mu.Unlock()
+		conn.Close(websocket.StatusNormalClosure, "")
+		slog.Info("websocket client disconnected", "remote", r.RemoteAddr)
+	}()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case msg, ok := <-client.send:
+			if !ok {
+				// Channel closed by Shutdown or Broadcast (slow client).
+				return
+			}
+			if err := conn.Write(ctx, websocket.MessageText, msg); err != nil {
+				return
+			}
+		}
+	}
+}
+
+// Shutdown closes every connected client and prevents new connections.
+func (h *Hub) Shutdown() {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	h.closed = true
+	for c := range h.clients {
+		h.removeClientLocked(c)
+	}
+}
+
+// removeClientLocked removes a client and closes its send channel.
+// Caller must hold h.mu.
+func (h *Hub) removeClientLocked(c *wsClient) {
+	if _, ok := h.clients[c]; !ok {
+		return
+	}
+	delete(h.clients, c)
+	close(c.send)
+}

--- a/indexer/internal/api/hub.go
+++ b/indexer/internal/api/hub.go
@@ -13,7 +13,11 @@ import (
 )
 
 const (
-	clientSendBuffer = 32
+	// clientSendBuffer is sized to absorb catch-up bursts (e.g. 50-100 ops
+	// after brief downtime) without dropping healthy clients. Backfill
+	// volumes can far exceed any reasonable buffer; clients needing
+	// historical data should use the REST API.
+	clientSendBuffer = 128
 	writeTimeout     = 5 * time.Second
 )
 

--- a/indexer/internal/api/hub.go
+++ b/indexer/internal/api/hub.go
@@ -50,22 +50,27 @@ func (h *Hub) Broadcast(ops []db.UserOperation) {
 		return
 	}
 
-	h.mu.Lock()
-	defer h.mu.Unlock()
+	var slow []*wsClient
 
+	h.mu.Lock()
 	for c := range h.clients {
 		for _, msg := range messages {
 			select {
 			case c.send <- msg:
 			default:
-				// Slow client — drop it and force-close the connection
-				// so any blocked Write unblocks promptly.
 				h.removeClientLocked(c)
-				if c.conn != nil {
-					c.conn.CloseNow()
-				}
+				slow = append(slow, c)
 				break
 			}
+		}
+	}
+	h.mu.Unlock()
+
+	// Force-close slow clients outside the lock so CloseNow never
+	// stalls other goroutines waiting on h.mu.
+	for _, c := range slow {
+		if c.conn != nil {
+			c.conn.CloseNow()
 		}
 	}
 }
@@ -73,6 +78,9 @@ func (h *Hub) Broadcast(ops []db.UserOperation) {
 // ServeWS upgrades an HTTP request to a WebSocket connection and streams
 // broadcast messages until the client disconnects or the hub shuts down.
 func (h *Hub) ServeWS(w http.ResponseWriter, r *http.Request) {
+	// Allow any origin: this endpoint is read-only, unauthenticated, and
+	// broadcasts publicly available on-chain data. Cross-site WebSocket
+	// hijacking is not a concern without session-based auth or private data.
 	conn, err := websocket.Accept(w, r, &websocket.AcceptOptions{
 		OriginPatterns: []string{"*"},
 	})
@@ -131,11 +139,15 @@ func (h *Hub) ServeWS(w http.ResponseWriter, r *http.Request) {
 // Shutdown closes every connected client and prevents new connections.
 func (h *Hub) Shutdown() {
 	h.mu.Lock()
-	defer h.mu.Unlock()
-
+	clients := make([]*wsClient, 0, len(h.clients))
 	h.closed = true
 	for c := range h.clients {
 		h.removeClientLocked(c)
+		clients = append(clients, c)
+	}
+	h.mu.Unlock()
+
+	for _, c := range clients {
 		if c.conn != nil {
 			c.conn.CloseNow()
 		}

--- a/indexer/internal/api/hub.go
+++ b/indexer/internal/api/hub.go
@@ -41,6 +41,17 @@ func NewHub() *Hub {
 // Broadcast converts each operation to JSON and sends it to every connected
 // client. Slow consumers whose buffer is full are dropped immediately.
 func (h *Hub) Broadcast(ops []db.UserOperation) {
+	if len(ops) == 0 {
+		return
+	}
+
+	h.mu.Lock()
+	empty := len(h.clients) == 0 || h.closed
+	h.mu.Unlock()
+	if empty {
+		return
+	}
+
 	messages := make([][]byte, 0, len(ops))
 	for i := range ops {
 		data, err := json.Marshal(toResponse(ops[i]))

--- a/indexer/internal/api/hub.go
+++ b/indexer/internal/api/hub.go
@@ -58,9 +58,12 @@ func (h *Hub) Broadcast(ops []db.UserOperation) {
 			select {
 			case c.send <- msg:
 			default:
-				// Slow client — drop it and close the connection so any
-				// blocked Write unblocks promptly.
+				// Slow client — drop it and force-close the connection
+				// so any blocked Write unblocks promptly.
 				h.removeClientLocked(c)
+				if c.conn != nil {
+					c.conn.CloseNow()
+				}
 				break
 			}
 		}
@@ -133,11 +136,15 @@ func (h *Hub) Shutdown() {
 	h.closed = true
 	for c := range h.clients {
 		h.removeClientLocked(c)
+		if c.conn != nil {
+			c.conn.CloseNow()
+		}
 	}
 }
 
-// removeClientLocked removes a client, closes its send channel, and forces
-// the underlying WebSocket connection closed so any blocked write unblocks.
+// removeClientLocked removes a client from the map and closes its send
+// channel. The caller is responsible for closing the underlying WebSocket
+// connection (gracefully via Close or forcefully via CloseNow).
 // Caller must hold h.mu.
 func (h *Hub) removeClientLocked(c *wsClient) {
 	if _, ok := h.clients[c]; !ok {
@@ -145,7 +152,4 @@ func (h *Hub) removeClientLocked(c *wsClient) {
 	}
 	delete(h.clients, c)
 	close(c.send)
-	if c.conn != nil {
-		c.conn.CloseNow()
-	}
 }

--- a/indexer/internal/api/hub.go
+++ b/indexer/internal/api/hub.go
@@ -1,16 +1,21 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"log/slog"
 	"net/http"
 	"sync"
+	"time"
 
 	"github.com/coder/websocket"
 	"github.com/flwrenn/bastion/indexer/internal/db"
 )
 
-const clientSendBuffer = 32
+const (
+	clientSendBuffer = 32
+	writeTimeout     = 5 * time.Second
+)
 
 // Hub manages WebSocket clients and broadcasts new operations to them.
 type Hub struct {
@@ -21,6 +26,7 @@ type Hub struct {
 
 type wsClient struct {
 	send chan []byte
+	conn *websocket.Conn
 }
 
 // NewHub creates a Hub ready to accept WebSocket connections.
@@ -52,7 +58,8 @@ func (h *Hub) Broadcast(ops []db.UserOperation) {
 			select {
 			case c.send <- msg:
 			default:
-				// Slow client — drop it.
+				// Slow client — drop it and close the connection so any
+				// blocked Write unblocks promptly.
 				h.removeClientLocked(c)
 				break
 			}
@@ -64,14 +71,17 @@ func (h *Hub) Broadcast(ops []db.UserOperation) {
 // broadcast messages until the client disconnects or the hub shuts down.
 func (h *Hub) ServeWS(w http.ResponseWriter, r *http.Request) {
 	conn, err := websocket.Accept(w, r, &websocket.AcceptOptions{
-		InsecureSkipVerify: true, // Allow all origins (frontend is cross-origin).
+		OriginPatterns: []string{"*"},
 	})
 	if err != nil {
 		slog.Error("websocket accept", "error", err)
 		return
 	}
 
-	client := &wsClient{send: make(chan []byte, clientSendBuffer)}
+	client := &wsClient{
+		send: make(chan []byte, clientSendBuffer),
+		conn: conn,
+	}
 
 	h.mu.Lock()
 	if h.closed {
@@ -105,7 +115,10 @@ func (h *Hub) ServeWS(w http.ResponseWriter, r *http.Request) {
 				// Channel closed by Shutdown or Broadcast (slow client).
 				return
 			}
-			if err := conn.Write(ctx, websocket.MessageText, msg); err != nil {
+			writeCtx, cancel := context.WithTimeout(ctx, writeTimeout)
+			err := conn.Write(writeCtx, websocket.MessageText, msg)
+			cancel()
+			if err != nil {
 				return
 			}
 		}
@@ -123,7 +136,8 @@ func (h *Hub) Shutdown() {
 	}
 }
 
-// removeClientLocked removes a client and closes its send channel.
+// removeClientLocked removes a client, closes its send channel, and forces
+// the underlying WebSocket connection closed so any blocked write unblocks.
 // Caller must hold h.mu.
 func (h *Hub) removeClientLocked(c *wsClient) {
 	if _, ok := h.clients[c]; !ok {
@@ -131,4 +145,7 @@ func (h *Hub) removeClientLocked(c *wsClient) {
 	}
 	delete(h.clients, c)
 	close(c.send)
+	if c.conn != nil {
+		c.conn.CloseNow()
+	}
 }

--- a/indexer/internal/api/hub_test.go
+++ b/indexer/internal/api/hub_test.go
@@ -1,0 +1,224 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/coder/websocket"
+	"github.com/flwrenn/bastion/indexer/internal/db"
+)
+
+func TestBroadcastNoClients(t *testing.T) {
+	t.Parallel()
+
+	hub := NewHub()
+	// Must not panic with zero clients.
+	hub.Broadcast([]db.UserOperation{testOp()})
+}
+
+func TestBroadcastEmptyOps(t *testing.T) {
+	t.Parallel()
+
+	hub := NewHub()
+	// Must not panic with empty slice.
+	hub.Broadcast(nil)
+	hub.Broadcast([]db.UserOperation{})
+}
+
+func TestBroadcastDelivered(t *testing.T) {
+	t.Parallel()
+
+	hub := NewHub()
+	client := &wsClient{send: make(chan []byte, clientSendBuffer)}
+	hub.mu.Lock()
+	hub.clients[client] = struct{}{}
+	hub.mu.Unlock()
+
+	hub.Broadcast([]db.UserOperation{testOp()})
+
+	select {
+	case msg := <-client.send:
+		var resp operationResponse
+		if err := json.Unmarshal(msg, &resp); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if resp.Sender != "0x"+testAddr {
+			t.Fatalf("sender = %q, want 0x%s", resp.Sender, testAddr)
+		}
+		if resp.Nonce != "42" {
+			t.Fatalf("nonce = %q, want 42", resp.Nonce)
+		}
+	default:
+		t.Fatal("expected message on client send channel")
+	}
+}
+
+func TestBroadcastDropsSlowClient(t *testing.T) {
+	t.Parallel()
+
+	hub := NewHub()
+	slow := &wsClient{send: make(chan []byte)} // unbuffered = always full
+	hub.mu.Lock()
+	hub.clients[slow] = struct{}{}
+	hub.mu.Unlock()
+
+	hub.Broadcast([]db.UserOperation{testOp()})
+
+	hub.mu.Lock()
+	_, exists := hub.clients[slow]
+	hub.mu.Unlock()
+
+	if exists {
+		t.Fatal("expected slow client to be removed")
+	}
+}
+
+func TestShutdownClosesClients(t *testing.T) {
+	t.Parallel()
+
+	hub := NewHub()
+	c := &wsClient{send: make(chan []byte, clientSendBuffer)}
+	hub.mu.Lock()
+	hub.clients[c] = struct{}{}
+	hub.mu.Unlock()
+
+	hub.Shutdown()
+
+	// send channel should be closed.
+	_, ok := <-c.send
+	if ok {
+		t.Fatal("expected send channel to be closed")
+	}
+
+	hub.mu.Lock()
+	count := len(hub.clients)
+	hub.mu.Unlock()
+	if count != 0 {
+		t.Fatalf("expected 0 clients, got %d", count)
+	}
+}
+
+func TestShutdownRejectsNewConnections(t *testing.T) {
+	t.Parallel()
+
+	hub := NewHub()
+	hub.Shutdown()
+
+	srv := httptest.NewServer(hub)
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	wsURL := "ws" + srv.URL[len("http"):]
+	conn, _, err := websocket.Dial(ctx, wsURL+"/ws", nil)
+	if err != nil {
+		// Connection refused or upgrade failed — acceptable.
+		return
+	}
+	defer conn.CloseNow()
+
+	// If the connection was accepted, the server should close it promptly.
+	_, _, err = conn.Read(ctx)
+	if err == nil {
+		t.Fatal("expected connection to be closed after shutdown")
+	}
+}
+
+func TestServeWSEndToEnd(t *testing.T) {
+	t.Parallel()
+
+	hub := NewHub()
+	defer hub.Shutdown()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /ws", hub.ServeWS)
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	wsURL := "ws" + srv.URL[len("http"):] + "/ws"
+	conn, _, err := websocket.Dial(ctx, wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.CloseNow()
+
+	// Give the server goroutine a moment to register the client.
+	time.Sleep(50 * time.Millisecond)
+
+	hub.Broadcast([]db.UserOperation{testOp()})
+
+	_, msg, err := conn.Read(ctx)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+
+	var resp operationResponse
+	if err := json.Unmarshal(msg, &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp.UserOpHash != "0x"+testHash {
+		t.Fatalf("userOpHash = %q, want 0x%s", resp.UserOpHash, testHash)
+	}
+	if resp.BlockNumber != 100 {
+		t.Fatalf("blockNumber = %d, want 100", resp.BlockNumber)
+	}
+}
+
+func TestServeWSMultipleMessages(t *testing.T) {
+	t.Parallel()
+
+	hub := NewHub()
+	defer hub.Shutdown()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /ws", hub.ServeWS)
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	wsURL := "ws" + srv.URL[len("http"):] + "/ws"
+	conn, _, err := websocket.Dial(ctx, wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.CloseNow()
+
+	time.Sleep(50 * time.Millisecond)
+
+	// Broadcast two operations in one batch.
+	op1 := testOp()
+	op2 := testOp()
+	op2.Nonce = "99"
+	hub.Broadcast([]db.UserOperation{op1, op2})
+
+	// Should receive two separate messages.
+	for _, wantNonce := range []string{"42", "99"} {
+		_, msg, err := conn.Read(ctx)
+		if err != nil {
+			t.Fatalf("read: %v", err)
+		}
+		var resp operationResponse
+		if err := json.Unmarshal(msg, &resp); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if resp.Nonce != wantNonce {
+			t.Fatalf("nonce = %q, want %q", resp.Nonce, wantNonce)
+		}
+	}
+}
+
+// hub implements http.Handler so httptest.NewServer can serve it directly
+// for the shutdown rejection test.
+func (h *Hub) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	h.ServeWS(w, r)
+}

--- a/indexer/internal/api/hub_test.go
+++ b/indexer/internal/api/hub_test.go
@@ -12,6 +12,28 @@ import (
 	"github.com/flwrenn/bastion/indexer/internal/db"
 )
 
+// waitForClients polls hub.clients until it reaches n or the deadline expires.
+func waitForClients(t *testing.T, hub *Hub, n int, deadline time.Duration) {
+	t.Helper()
+	timer := time.NewTimer(deadline)
+	defer timer.Stop()
+	ticker := time.NewTicker(5 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		hub.mu.Lock()
+		count := len(hub.clients)
+		hub.mu.Unlock()
+		if count >= n {
+			return
+		}
+		select {
+		case <-timer.C:
+			t.Fatalf("timed out waiting for %d client(s), have %d", n, count)
+		case <-ticker.C:
+		}
+	}
+}
+
 func TestBroadcastNoClients(t *testing.T) {
 	t.Parallel()
 
@@ -150,8 +172,7 @@ func TestServeWSEndToEnd(t *testing.T) {
 	}
 	defer conn.CloseNow()
 
-	// Give the server goroutine a moment to register the client.
-	time.Sleep(50 * time.Millisecond)
+	waitForClients(t, hub, 1, 2*time.Second)
 
 	hub.Broadcast([]db.UserOperation{testOp()})
 
@@ -193,7 +214,7 @@ func TestServeWSMultipleMessages(t *testing.T) {
 	}
 	defer conn.CloseNow()
 
-	time.Sleep(50 * time.Millisecond)
+	waitForClients(t, hub, 1, 2*time.Second)
 
 	// Broadcast two operations in one batch.
 	op1 := testOp()

--- a/indexer/internal/api/hub_test.go
+++ b/indexer/internal/api/hub_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -143,10 +144,24 @@ func TestShutdownRejectsNewConnections(t *testing.T) {
 	}
 	defer conn.CloseNow()
 
-	// Hub is shut down, so the server should close the connection promptly.
-	_, _, err = conn.Read(ctx)
+	// Use a short deadline so the test fails fast if the server doesn't
+	// close the connection, rather than silently passing on context timeout.
+	readCtx, readCancel := context.WithTimeout(ctx, 500*time.Millisecond)
+	defer readCancel()
+
+	_, _, err = conn.Read(readCtx)
 	if err == nil {
 		t.Fatal("expected connection to be closed after shutdown")
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		t.Fatal("server did not close connection promptly; timed out waiting")
+	}
+	var closeErr websocket.CloseError
+	if !errors.As(err, &closeErr) {
+		t.Fatalf("expected websocket.CloseError, got %T: %v", err, err)
+	}
+	if closeErr.Code != websocket.StatusGoingAway {
+		t.Fatalf("close code = %v, want StatusGoingAway", closeErr.Code)
 	}
 }
 

--- a/indexer/internal/api/hub_test.go
+++ b/indexer/internal/api/hub_test.go
@@ -139,12 +139,11 @@ func TestShutdownRejectsNewConnections(t *testing.T) {
 	wsURL := "ws" + srv.URL[len("http"):]
 	conn, _, err := websocket.Dial(ctx, wsURL+"/ws", nil)
 	if err != nil {
-		// Connection refused or upgrade failed — acceptable.
-		return
+		t.Fatalf("dial: %v", err)
 	}
 	defer conn.CloseNow()
 
-	// If the connection was accepted, the server should close it promptly.
+	// Hub is shut down, so the server should close the connection promptly.
 	_, _, err = conn.Read(ctx)
 	if err == nil {
 		t.Fatal("expected connection to be closed after shutdown")

--- a/indexer/internal/indexer/indexer.go
+++ b/indexer/internal/indexer/indexer.go
@@ -26,6 +26,10 @@ type Service struct {
 	newHeadSubscriptionFactory   func(context.Context, string) (headSubscription, error)
 	subscriptionReconnectBackoff time.Duration
 	indexOnceFunc                func(context.Context) error
+
+	// OnOperationsIndexed is called after new operations are persisted.
+	// It is safe to leave nil.
+	OnOperationsIndexed func([]db.UserOperation)
 }
 
 const blockTimestampCacheMaxEntries = 4096
@@ -606,6 +610,10 @@ func (s *Service) indexRangeAttempt(ctx context.Context, fromBlock uint64, toBlo
 		"events",
 		len(operations),
 	)
+
+	if len(operations) > 0 && s.OnOperationsIndexed != nil {
+		s.OnOperationsIndexed(operations)
+	}
 
 	return nil
 }

--- a/indexer/internal/indexer/subscription.go
+++ b/indexer/internal/indexer/subscription.go
@@ -4,19 +4,15 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"net"
-	"net/url"
-	"strings"
 	"sync"
 	"time"
 
-	"golang.org/x/net/websocket"
+	"github.com/coder/websocket"
 )
 
 const (
 	subscriptionTypeNewHeads   = "newHeads"
 	defaultSubscriptionBackoff = 2 * time.Second
-	subscriptionIODeadline     = 500 * time.Millisecond
 )
 
 type headSubscription interface {
@@ -25,28 +21,23 @@ type headSubscription interface {
 }
 
 type websocketHeadSubscription struct {
-	ws        *websocket.Conn
+	conn      *websocket.Conn
 	nextMu    sync.Mutex
 	closeOnce sync.Once
 }
 
 func newWebSocketHeadSubscription(ctx context.Context, wsURL string) (headSubscription, error) {
-	config, err := websocket.NewConfig(wsURL, originForWebSocketURL(wsURL))
-	if err != nil {
-		return nil, fmt.Errorf("create websocket config: %w", err)
-	}
-
-	ws, err := config.DialContext(ctx)
+	conn, _, err := websocket.Dial(ctx, wsURL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("dial websocket: %w", err)
 	}
 
-	if err := sendSubscribeRequest(ctx, ws); err != nil {
-		_ = ws.Close()
+	if err := sendSubscribeRequest(ctx, conn); err != nil {
+		conn.CloseNow()
 		return nil, err
 	}
 
-	sub := &websocketHeadSubscription{ws: ws}
+	sub := &websocketHeadSubscription{conn: conn}
 	if err := waitForSubscriptionAck(ctx, sub); err != nil {
 		_ = sub.Close()
 		return nil, err
@@ -55,7 +46,7 @@ func newWebSocketHeadSubscription(ctx context.Context, wsURL string) (headSubscr
 	return sub, nil
 }
 
-func sendSubscribeRequest(ctx context.Context, ws *websocket.Conn) error {
+func sendSubscribeRequest(ctx context.Context, conn *websocket.Conn) error {
 	payload, err := json.Marshal(rpcRequest{
 		JSONRPC: jsonRPCVersion,
 		ID:      1,
@@ -66,7 +57,7 @@ func sendSubscribeRequest(ctx context.Context, ws *websocket.Conn) error {
 		return fmt.Errorf("marshal subscribe request: %w", err)
 	}
 
-	if err := writeWebSocketMessage(ctx, ws, payload); err != nil {
+	if err := conn.Write(ctx, websocket.MessageText, payload); err != nil {
 		return fmt.Errorf("send subscribe request: %w", err)
 	}
 
@@ -134,7 +125,7 @@ func (s *websocketHeadSubscription) Next(ctx context.Context) error {
 func (s *websocketHeadSubscription) Close() error {
 	var closeErr error
 	s.closeOnce.Do(func() {
-		closeErr = s.ws.Close()
+		closeErr = s.conn.Close(websocket.StatusNormalClosure, "")
 	})
 
 	return closeErr
@@ -144,53 +135,15 @@ func (s *websocketHeadSubscription) read(ctx context.Context) ([]byte, error) {
 	s.nextMu.Lock()
 	defer s.nextMu.Unlock()
 
-	for {
-		if err := ctx.Err(); err != nil {
-			return nil, err
-		}
-
-		readDeadline := time.Now().Add(subscriptionIODeadline)
-		if err := s.ws.SetReadDeadline(readDeadline); err != nil {
-			return nil, fmt.Errorf("set read deadline: %w", err)
-		}
-
-		var message []byte
-		err := websocket.Message.Receive(s.ws, &message)
-		if err == nil {
-			if len(message) == 0 {
-				continue
-			}
-			return message, nil
-		}
-
-		if ne, ok := err.(net.Error); ok && ne.Timeout() {
-			continue
-		}
-
+	_, message, err := s.conn.Read(ctx)
+	if err != nil {
 		return nil, err
 	}
-}
-
-func writeWebSocketMessage(ctx context.Context, ws *websocket.Conn, payload []byte) error {
-	if err := ctx.Err(); err != nil {
-		return err
+	if len(message) == 0 {
+		return s.read(ctx)
 	}
 
-	writeDeadline := time.Now().Add(subscriptionIODeadline)
-	if err := ws.SetWriteDeadline(writeDeadline); err != nil {
-		return fmt.Errorf("set write deadline: %w", err)
-	}
-
-	err := websocket.Message.Send(ws, payload)
-	if err == nil {
-		return nil
-	}
-
-	if ne, ok := err.(net.Error); ok && ne.Timeout() {
-		return fmt.Errorf("websocket write timeout: %w", err)
-	}
-
-	return err
+	return message, nil
 }
 
 type rpcSubscriptionNotification struct {
@@ -203,24 +156,6 @@ type rpcSubscriptionNotification struct {
 
 type rpcSubscriptionHead struct {
 	Number string `json:"number"`
-}
-
-func originForWebSocketURL(wsURL string) string {
-	parsed, err := url.Parse(wsURL)
-	if err == nil && parsed.Host != "" {
-		scheme := "http"
-		if strings.EqualFold(parsed.Scheme, "wss") {
-			scheme = "https"
-		}
-
-		return scheme + "://" + parsed.Host
-	}
-
-	if strings.HasPrefix(strings.ToLower(wsURL), "wss://") {
-		return "https://bastion.local"
-	}
-
-	return "http://bastion.local"
 }
 
 func decodeRPCError(message []byte) error {

--- a/indexer/internal/indexer/subscription.go
+++ b/indexer/internal/indexer/subscription.go
@@ -135,15 +135,15 @@ func (s *websocketHeadSubscription) read(ctx context.Context) ([]byte, error) {
 	s.nextMu.Lock()
 	defer s.nextMu.Unlock()
 
-	_, message, err := s.conn.Read(ctx)
-	if err != nil {
-		return nil, err
+	for {
+		_, message, err := s.conn.Read(ctx)
+		if err != nil {
+			return nil, err
+		}
+		if len(message) > 0 {
+			return message, nil
+		}
 	}
-	if len(message) == 0 {
-		return s.read(ctx)
-	}
-
-	return message, nil
 }
 
 type rpcSubscriptionNotification struct {

--- a/indexer/internal/indexer/subscription_test.go
+++ b/indexer/internal/indexer/subscription_test.go
@@ -206,15 +206,3 @@ func TestSubscriptionConnectTimeoutUsesRequestTimeout(t *testing.T) {
 		t.Fatalf("expected request timeout %s, got %s", 7*time.Second, got)
 	}
 }
-
-func TestOriginForWebSocketURL_DerivesHostBasedOrigin(t *testing.T) {
-	t.Parallel()
-
-	if got := originForWebSocketURL("wss://rpc.example/ws?key=secret"); got != "https://rpc.example" {
-		t.Fatalf("expected https origin, got %q", got)
-	}
-
-	if got := originForWebSocketURL("ws://localhost:8546/path"); got != "http://localhost:8546" {
-		t.Fatalf("expected http origin with port, got %q", got)
-	}
-}


### PR DESCRIPTION
## What

Add a WebSocket endpoint at `/ws` that streams newly indexed
`UserOperationEvent` data to connected frontend clients in real time.

## Why

The frontend dashboard needs a live feed of user operations as they are
indexed. Polling the REST API is wasteful — a push-based WebSocket feed
gives instant updates with no wasted requests.

Also migrates the existing WebSocket code (`subscription.go`) from the
legacy `golang.org/x/net/websocket` to `github.com/coder/websocket` for
consistency and better context support.

## Scope

- [x] Backend

## How to verify

1. Run the indexer with a live RPC endpoint and database.
2. Connect to `ws://localhost:3001/ws` (e.g. with `websocat`).
3. Trigger a UserOperation on-chain — the operation should appear as a
   JSON message on the WebSocket within one poll interval.
4. Run `cd indexer && go test ./... -count=1` — all tests pass.

## Related issues

Closes #13