### PR TITLE
feat(frontend): indexer live feed page

### DIFF
--- a/frontend/src/lib/indexer.svelte.ts
+++ b/frontend/src/lib/indexer.svelte.ts
@@ -184,9 +184,10 @@ class IndexerFeed {
 	}
 
 	private async poll() {
+		const signal = this.abort?.signal;
 		try {
 			const apiUrl = indexerUrl() + '/api/operations';
-			const res = await fetch(`${apiUrl}?limit=20`, { signal: this.abort?.signal });
+			const res = await fetch(`${apiUrl}?limit=20`, { signal });
 			if (!res.ok) {
 				this.trackPollFailure();
 				return;
@@ -199,7 +200,9 @@ class IndexerFeed {
 			}
 		} catch {
 			// Ignore AbortError from disconnect(); track real failures.
-			if (!this.abort?.signal.aborted) {
+			// Check the captured signal, not this.abort, to avoid races with
+			// rapid disconnect/connect replacing the controller.
+			if (!signal?.aborted) {
 				this.trackPollFailure();
 			}
 		}
@@ -217,9 +220,10 @@ class IndexerFeed {
 
 	/** Load the most recent operations from the REST API (initial page load). */
 	private async loadInitial() {
+		const signal = this.abort?.signal;
 		try {
 			const apiUrl = indexerUrl() + '/api/operations';
-			const res = await fetch(`${apiUrl}?limit=50`, { signal: this.abort?.signal });
+			const res = await fetch(`${apiUrl}?limit=50`, { signal });
 			if (!res.ok) return;
 			const body: { data: UserOperation[] } = await res.json();
 			// REST returns newest first — add in reverse so newest ends up at index 0.

--- a/frontend/src/lib/indexer.svelte.ts
+++ b/frontend/src/lib/indexer.svelte.ts
@@ -3,7 +3,7 @@ import { formatEther } from 'viem';
 
 /** Resolve the indexer base URL lazily so $env/dynamic/public is read at call time. */
 function indexerUrl(): string {
-	return env.PUBLIC_INDEXER_URL ?? 'http://localhost:3001';
+	return (env.PUBLIC_INDEXER_URL ?? 'http://localhost:3001').replace(/\/+$/, '');
 }
 
 const POLL_INTERVAL = 5_000;

--- a/frontend/src/lib/indexer.svelte.ts
+++ b/frontend/src/lib/indexer.svelte.ts
@@ -1,0 +1,207 @@
+import { formatEther } from 'viem';
+
+const INDEXER_URL = import.meta.env.PUBLIC_INDEXER_URL ?? 'http://localhost:3001';
+const WS_URL = INDEXER_URL.replace(/^http/, 'ws') + '/ws';
+const API_URL = INDEXER_URL + '/api/operations';
+
+const POLL_INTERVAL = 5_000;
+const RECONNECT_DELAY = 3_000;
+const MAX_OPERATIONS = 200;
+
+/** Shape returned by the indexer REST API and WebSocket feed. */
+export interface UserOperation {
+	userOpHash: string;
+	sender: string;
+	paymaster: string;
+	target?: string;
+	calldata?: string;
+	nonce: string;
+	success: boolean;
+	actualGasCost: string;
+	actualGasUsed: string;
+	txHash: string;
+	blockNumber: number;
+	blockTimestamp: number;
+	logIndex: number;
+}
+
+export type FeedStatus = 'disconnected' | 'connecting' | 'connected' | 'polling';
+
+const ETHERSCAN_BASE = 'https://sepolia.etherscan.io';
+
+/** Returns a Sepolia Etherscan link for a transaction hash. */
+export function etherscanTx(txHash: string): string {
+	return `${ETHERSCAN_BASE}/tx/${txHash}`;
+}
+
+/** Returns a Sepolia Etherscan link for an address. */
+export function etherscanAddress(address: string): string {
+	return `${ETHERSCAN_BASE}/address/${address}`;
+}
+
+/** Formats a wei string as a human-readable ETH value (up to 6 decimals). */
+export function formatGasCost(wei: string): string {
+	if (!wei || wei === '0') return '0 ETH';
+	const eth = formatEther(BigInt(wei));
+	// Trim trailing zeros but keep at least one decimal for clarity.
+	const [whole, frac] = eth.split('.');
+	if (!frac) return `${whole} ETH`;
+	const trimmed = frac.slice(0, 6).replace(/0+$/, '');
+	return trimmed ? `${whole}.${trimmed} ETH` : `${whole} ETH`;
+}
+
+/** Truncates a hex string: 0xabcd…ef12 */
+export function truncateHex(hex: string, head = 6, tail = 4): string {
+	if (hex.length <= head + tail + 1) return hex;
+	return hex.slice(0, head) + '\u2026' + hex.slice(-tail);
+}
+
+/**
+ * Reactive indexer feed that connects to the WebSocket live feed and falls
+ * back to REST API polling when the WebSocket is unavailable.
+ *
+ * Usage (in a Svelte component):
+ *   const feed = new IndexerFeed();
+ *   $effect(() => { feed.connect(); return () => feed.disconnect(); });
+ */
+class IndexerFeed {
+	operations = $state<UserOperation[]>([]);
+	status = $state<FeedStatus>('disconnected');
+
+	private ws: WebSocket | null = null;
+	private pollTimer: ReturnType<typeof setInterval> | null = null;
+	private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+	private seenHashes = new Set<string>();
+
+	/** Open the WebSocket connection and load initial data from REST. */
+	connect() {
+		this.status = 'connecting';
+		this.loadInitial();
+		this.openWS();
+	}
+
+	/** Tear down all connections and timers. */
+	disconnect() {
+		this.stopReconnect();
+		this.stopPolling();
+		if (this.ws) {
+			this.ws.onclose = null; // Prevent reconnect on intentional close.
+			this.ws.close();
+			this.ws = null;
+		}
+		this.status = 'disconnected';
+	}
+
+	// --- WebSocket ---
+
+	private openWS() {
+		try {
+			const ws = new WebSocket(WS_URL);
+
+			ws.onopen = () => {
+				this.status = 'connected';
+				this.stopPolling();
+			};
+
+			ws.onmessage = (e: MessageEvent) => {
+				try {
+					const op: UserOperation = JSON.parse(e.data as string);
+					this.addOperation(op);
+				} catch {
+					// Ignore malformed messages.
+				}
+			};
+
+			ws.onclose = () => {
+				this.ws = null;
+				this.startPolling();
+				this.scheduleReconnect();
+			};
+
+			ws.onerror = () => {
+				// onerror is always followed by onclose; just let onclose handle it.
+			};
+
+			this.ws = ws;
+		} catch {
+			// WebSocket constructor can throw if the URL is invalid.
+			this.startPolling();
+		}
+	}
+
+	private scheduleReconnect() {
+		this.stopReconnect();
+		this.reconnectTimer = setTimeout(() => {
+			if (this.status !== 'disconnected') {
+				this.openWS();
+			}
+		}, RECONNECT_DELAY);
+	}
+
+	private stopReconnect() {
+		if (this.reconnectTimer !== null) {
+			clearTimeout(this.reconnectTimer);
+			this.reconnectTimer = null;
+		}
+	}
+
+	// --- REST polling fallback ---
+
+	private startPolling() {
+		if (this.pollTimer !== null) return;
+		this.status = 'polling';
+		this.poll();
+		this.pollTimer = setInterval(() => this.poll(), POLL_INTERVAL);
+	}
+
+	private stopPolling() {
+		if (this.pollTimer !== null) {
+			clearInterval(this.pollTimer);
+			this.pollTimer = null;
+		}
+	}
+
+	private async poll() {
+		try {
+			const res = await fetch(`${API_URL}?limit=20`);
+			if (!res.ok) return;
+			const body: { data: UserOperation[] } = await res.json();
+			// REST returns newest first; reverse so addOperation prepends correctly.
+			for (const op of body.data.reverse()) {
+				this.addOperation(op);
+			}
+		} catch {
+			// Network error — will retry on next interval.
+		}
+	}
+
+	/** Load the most recent operations from the REST API (initial page load). */
+	private async loadInitial() {
+		try {
+			const res = await fetch(`${API_URL}?limit=50`);
+			if (!res.ok) return;
+			const body: { data: UserOperation[] } = await res.json();
+			// REST returns newest first — add in reverse so newest ends up at index 0.
+			for (const op of body.data.reverse()) {
+				this.addOperation(op);
+			}
+		} catch {
+			// Will be populated by WS or polling.
+		}
+	}
+
+	// --- shared ---
+
+	private addOperation(op: UserOperation) {
+		if (this.seenHashes.has(op.userOpHash)) return;
+		this.seenHashes.add(op.userOpHash);
+		this.operations = [op, ...this.operations].slice(0, MAX_OPERATIONS);
+		// Trim the dedup set to avoid unbounded growth.
+		if (this.seenHashes.size > MAX_OPERATIONS * 2) {
+			const keep = this.operations.map((o) => o.userOpHash);
+			this.seenHashes = new Set(keep);
+		}
+	}
+}
+
+export const feed = new IndexerFeed();

--- a/frontend/src/lib/indexer.svelte.ts
+++ b/frontend/src/lib/indexer.svelte.ts
@@ -8,6 +8,7 @@ function indexerUrl(): string {
 
 const POLL_INTERVAL = 5_000;
 const RECONNECT_DELAY = 3_000;
+const MAX_RECONNECT_DELAY = 30_000;
 const MAX_OPERATIONS = 200;
 const MAX_POLL_FAILURES = 3;
 
@@ -82,11 +83,13 @@ class IndexerFeed {
 	private seenHashes = new Set<string>();
 	private abort: AbortController | null = null;
 	private pollFailures = 0;
+	private reconnectDelay = RECONNECT_DELAY;
 
 	/** Open the WebSocket connection and load initial data from REST. */
 	connect() {
 		this.disconnect(); // Idempotent — tear down any previous session first.
 		this.abort = new AbortController();
+		this.reconnectDelay = RECONNECT_DELAY;
 		this.status = 'connecting';
 		this.loadInitial();
 		this.openWS();
@@ -116,6 +119,7 @@ class IndexerFeed {
 
 			ws.onopen = () => {
 				this.status = 'connected';
+				this.reconnectDelay = RECONNECT_DELAY;
 				this.stopPolling();
 			};
 
@@ -142,16 +146,17 @@ class IndexerFeed {
 		} catch {
 			// WebSocket constructor can throw if the URL is invalid.
 			this.startPolling();
+			this.scheduleReconnect();
 		}
 	}
 
 	private scheduleReconnect() {
 		this.stopReconnect();
+		const delay = this.reconnectDelay;
+		this.reconnectDelay = Math.min(this.reconnectDelay * 2, MAX_RECONNECT_DELAY);
 		this.reconnectTimer = setTimeout(() => {
-			if (this.status !== 'disconnected') {
-				this.openWS();
-			}
-		}, RECONNECT_DELAY);
+			this.openWS();
+		}, delay);
 	}
 
 	private stopReconnect() {
@@ -165,6 +170,7 @@ class IndexerFeed {
 
 	private startPolling() {
 		if (this.pollTimer !== null) return;
+		this.pollFailures = 0;
 		this.status = 'polling';
 		this.poll();
 		this.pollTimer = setInterval(() => this.poll(), POLL_INTERVAL);
@@ -202,8 +208,9 @@ class IndexerFeed {
 	private trackPollFailure() {
 		this.pollFailures++;
 		if (this.pollFailures >= MAX_POLL_FAILURES) {
+			// Stop hammering a dead REST API, but keep the WS reconnect loop
+			// running so recovery happens automatically when the indexer restarts.
 			this.stopPolling();
-			this.stopReconnect();
 			this.status = 'disconnected';
 		}
 	}

--- a/frontend/src/lib/indexer.svelte.ts
+++ b/frontend/src/lib/indexer.svelte.ts
@@ -1,12 +1,15 @@
+import { env } from '$env/dynamic/public';
 import { formatEther } from 'viem';
 
-const INDEXER_URL = import.meta.env.PUBLIC_INDEXER_URL ?? 'http://localhost:3001';
-const WS_URL = INDEXER_URL.replace(/^http/, 'ws') + '/ws';
-const API_URL = INDEXER_URL + '/api/operations';
+/** Resolve the indexer base URL lazily so $env/dynamic/public is read at call time. */
+function indexerUrl(): string {
+	return env.PUBLIC_INDEXER_URL ?? 'http://localhost:3001';
+}
 
 const POLL_INTERVAL = 5_000;
 const RECONNECT_DELAY = 3_000;
 const MAX_OPERATIONS = 200;
+const MAX_POLL_FAILURES = 3;
 
 /** Shape returned by the indexer REST API and WebSocket feed. */
 export interface UserOperation {
@@ -32,6 +35,11 @@ const ETHERSCAN_BASE = 'https://sepolia.etherscan.io';
 /** Returns a Sepolia Etherscan link for a transaction hash. */
 export function etherscanTx(txHash: string): string {
 	return `${ETHERSCAN_BASE}/tx/${txHash}`;
+}
+
+/** Returns a Sepolia Etherscan link for a block number. */
+export function etherscanBlock(blockNumber: number): string {
+	return `${ETHERSCAN_BASE}/block/${blockNumber}`;
 }
 
 /** Returns a Sepolia Etherscan link for an address. */
@@ -72,9 +80,13 @@ class IndexerFeed {
 	private pollTimer: ReturnType<typeof setInterval> | null = null;
 	private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 	private seenHashes = new Set<string>();
+	private abort: AbortController | null = null;
+	private pollFailures = 0;
 
 	/** Open the WebSocket connection and load initial data from REST. */
 	connect() {
+		this.disconnect(); // Idempotent — tear down any previous session first.
+		this.abort = new AbortController();
 		this.status = 'connecting';
 		this.loadInitial();
 		this.openWS();
@@ -84,11 +96,14 @@ class IndexerFeed {
 	disconnect() {
 		this.stopReconnect();
 		this.stopPolling();
+		this.abort?.abort();
+		this.abort = null;
 		if (this.ws) {
 			this.ws.onclose = null; // Prevent reconnect on intentional close.
 			this.ws.close();
 			this.ws = null;
 		}
+		this.pollFailures = 0;
 		this.status = 'disconnected';
 	}
 
@@ -96,7 +111,8 @@ class IndexerFeed {
 
 	private openWS() {
 		try {
-			const ws = new WebSocket(WS_URL);
+			const wsUrl = indexerUrl().replace(/^http/, 'ws') + '/ws';
+			const ws = new WebSocket(wsUrl);
 
 			ws.onopen = () => {
 				this.status = 'connected';
@@ -163,22 +179,40 @@ class IndexerFeed {
 
 	private async poll() {
 		try {
-			const res = await fetch(`${API_URL}?limit=20`);
-			if (!res.ok) return;
+			const apiUrl = indexerUrl() + '/api/operations';
+			const res = await fetch(`${apiUrl}?limit=20`, { signal: this.abort?.signal });
+			if (!res.ok) {
+				this.trackPollFailure();
+				return;
+			}
+			this.pollFailures = 0;
 			const body: { data: UserOperation[] } = await res.json();
 			// REST returns newest first; reverse so addOperation prepends correctly.
 			for (const op of body.data.reverse()) {
 				this.addOperation(op);
 			}
 		} catch {
-			// Network error — will retry on next interval.
+			// Ignore AbortError from disconnect(); track real failures.
+			if (!this.abort?.signal.aborted) {
+				this.trackPollFailure();
+			}
+		}
+	}
+
+	private trackPollFailure() {
+		this.pollFailures++;
+		if (this.pollFailures >= MAX_POLL_FAILURES) {
+			this.stopPolling();
+			this.stopReconnect();
+			this.status = 'disconnected';
 		}
 	}
 
 	/** Load the most recent operations from the REST API (initial page load). */
 	private async loadInitial() {
 		try {
-			const res = await fetch(`${API_URL}?limit=50`);
+			const apiUrl = indexerUrl() + '/api/operations';
+			const res = await fetch(`${apiUrl}?limit=50`, { signal: this.abort?.signal });
 			if (!res.ok) return;
 			const body: { data: UserOperation[] } = await res.json();
 			// REST returns newest first — add in reverse so newest ends up at index 0.

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -10,7 +10,10 @@
 
 <div class="flex min-h-screen flex-col bg-zinc-900 text-zinc-100">
 	<header class="flex items-center justify-between border-b border-zinc-800 px-6 py-4">
-		<a href="/" class="text-lg font-semibold tracking-tight">Bastion</a>
+		<nav class="flex items-center gap-6">
+			<a href="/" class="text-lg font-semibold tracking-tight">Bastion</a>
+			<a href="/indexer" class="text-sm text-zinc-400 hover:text-zinc-200">Indexer</a>
+		</nav>
 		<ConnectButton />
 	</header>
 	<main class="flex-1 px-6 py-8">

--- a/frontend/src/routes/indexer/+page.svelte
+++ b/frontend/src/routes/indexer/+page.svelte
@@ -38,16 +38,15 @@
 		return !!paymaster && paymaster !== '0x' && paymaster !== '0x' + '0'.repeat(40);
 	}
 
-	/** Auto-scroll: keep the table scrolled to top when new ops arrive (if user is near top). */
-	let tableContainer: HTMLDivElement | undefined = $state();
+	/** Auto-scroll: keep the page scrolled to top when new ops arrive (if user is near top). */
 	let prevCount = 0;
 
 	$effect(() => {
 		const count = feed.operations.length;
-		if (count > prevCount && tableContainer) {
+		if (count > prevCount) {
 			// Only auto-scroll if the user hasn't scrolled down more than 100px.
-			if (tableContainer.scrollTop < 100) {
-				tableContainer.scrollTo({ top: 0, behavior: 'smooth' });
+			if (window.scrollY < 100) {
+				window.scrollTo({ top: 0, behavior: 'smooth' });
 			}
 		}
 		prevCount = count;
@@ -79,7 +78,7 @@
 			</p>
 		</div>
 	{:else}
-		<div bind:this={tableContainer} class="overflow-x-auto rounded-lg border border-zinc-800">
+		<div class="overflow-x-auto rounded-lg border border-zinc-800">
 			<table class="w-full text-left text-sm">
 				<thead
 					class="border-b border-zinc-700 bg-zinc-800/80 text-xs tracking-wider text-zinc-400 uppercase"

--- a/frontend/src/routes/indexer/+page.svelte
+++ b/frontend/src/routes/indexer/+page.svelte
@@ -2,6 +2,7 @@
 	import {
 		feed,
 		etherscanTx,
+		etherscanBlock,
 		etherscanAddress,
 		formatGasCost,
 		truncateHex,
@@ -36,6 +37,21 @@
 	function isSponsored(paymaster: string): boolean {
 		return !!paymaster && paymaster !== '0x' && paymaster !== '0x' + '0'.repeat(40);
 	}
+
+	/** Auto-scroll: keep the table scrolled to top when new ops arrive (if user is near top). */
+	let tableContainer: HTMLDivElement | undefined = $state();
+	let prevCount = 0;
+
+	$effect(() => {
+		const count = feed.operations.length;
+		if (count > prevCount && tableContainer) {
+			// Only auto-scroll if the user hasn't scrolled down more than 100px.
+			if (tableContainer.scrollTop < 100) {
+				tableContainer.scrollTo({ top: 0, behavior: 'smooth' });
+			}
+		}
+		prevCount = count;
+	});
 </script>
 
 <svelte:head><title>Indexer Live Feed | Bastion</title></svelte:head>
@@ -63,7 +79,7 @@
 			</p>
 		</div>
 	{:else}
-		<div class="overflow-x-auto rounded-lg border border-zinc-800">
+		<div bind:this={tableContainer} class="overflow-x-auto rounded-lg border border-zinc-800">
 			<table class="w-full text-left text-sm">
 				<thead
 					class="border-b border-zinc-700 bg-zinc-800/80 text-xs tracking-wider text-zinc-400 uppercase"
@@ -92,7 +108,7 @@
 								<a
 									href={etherscanAddress(op.sender)}
 									target="_blank"
-									rel="noopener"
+									rel="noopener noreferrer"
 									class="text-indigo-400 hover:text-indigo-300"
 								>
 									{truncateHex(op.sender)}
@@ -105,7 +121,7 @@
 									<a
 										href={etherscanAddress(op.paymaster)}
 										target="_blank"
-										rel="noopener"
+										rel="noopener noreferrer"
 										class="text-indigo-400 hover:text-indigo-300"
 									>
 										{truncateHex(op.paymaster)}
@@ -145,9 +161,9 @@
 							<!-- Block -->
 							<td class="px-4 py-3 text-right font-mono text-xs">
 								<a
-									href="{etherscanTx(op.txHash).replace(/\/tx\/.*/, '')}/block/{op.blockNumber}"
+									href={etherscanBlock(op.blockNumber)}
 									target="_blank"
-									rel="noopener"
+									rel="noopener noreferrer"
 									class="text-indigo-400 hover:text-indigo-300"
 								>
 									{op.blockNumber}
@@ -164,7 +180,7 @@
 								<a
 									href={etherscanTx(op.txHash)}
 									target="_blank"
-									rel="noopener"
+									rel="noopener noreferrer"
 									class="text-indigo-400 hover:text-indigo-300"
 									title={op.txHash}
 								>

--- a/frontend/src/routes/indexer/+page.svelte
+++ b/frontend/src/routes/indexer/+page.svelte
@@ -1,0 +1,183 @@
+<script lang="ts">
+	import {
+		feed,
+		etherscanTx,
+		etherscanAddress,
+		formatGasCost,
+		truncateHex,
+		type FeedStatus
+	} from '$lib/indexer.svelte';
+
+	$effect(() => {
+		feed.connect();
+		return () => feed.disconnect();
+	});
+
+	const statusLabel: Record<FeedStatus, string> = {
+		disconnected: 'Disconnected',
+		connecting: 'Connecting\u2026',
+		connected: 'Live',
+		polling: 'Polling (REST)'
+	};
+
+	const statusColor: Record<FeedStatus, string> = {
+		disconnected: 'bg-zinc-500',
+		connecting: 'bg-yellow-500',
+		connected: 'bg-green-500',
+		polling: 'bg-yellow-500'
+	};
+
+	function formatTimestamp(unix: number): string {
+		if (!unix) return '\u2014';
+		return new Date(unix * 1000).toLocaleString();
+	}
+
+	/** True when the paymaster field indicates a sponsored (non-zero) paymaster. */
+	function isSponsored(paymaster: string): boolean {
+		return !!paymaster && paymaster !== '0x' && paymaster !== '0x' + '0'.repeat(40);
+	}
+</script>
+
+<svelte:head><title>Indexer Live Feed | Bastion</title></svelte:head>
+
+<div class="mx-auto max-w-7xl">
+	<!-- Header -->
+	<div class="mb-6 flex items-center justify-between">
+		<h1 class="text-2xl font-bold">Indexer Live Feed</h1>
+		<div class="flex items-center gap-2 text-sm text-zinc-400">
+			<span class="inline-block h-2 w-2 rounded-full {statusColor[feed.status]}"></span>
+			{statusLabel[feed.status]}
+		</div>
+	</div>
+
+	{#if feed.operations.length === 0}
+		<div class="rounded-lg border border-zinc-800 bg-zinc-800/50 py-16 text-center">
+			<p class="text-zinc-400">
+				{#if feed.status === 'connected' || feed.status === 'polling'}
+					Waiting for new UserOperations&hellip;
+				{:else if feed.status === 'connecting'}
+					Connecting to indexer&hellip;
+				{:else}
+					Not connected to indexer.
+				{/if}
+			</p>
+		</div>
+	{:else}
+		<div class="overflow-x-auto rounded-lg border border-zinc-800">
+			<table class="w-full text-left text-sm">
+				<thead
+					class="border-b border-zinc-700 bg-zinc-800/80 text-xs tracking-wider text-zinc-400 uppercase"
+				>
+					<tr>
+						<th class="px-4 py-3">UserOp Hash</th>
+						<th class="px-4 py-3">Sender</th>
+						<th class="px-4 py-3">Paymaster</th>
+						<th class="px-4 py-3">Status</th>
+						<th class="px-4 py-3 text-right">Gas Cost</th>
+						<th class="px-4 py-3 text-right">Block</th>
+						<th class="px-4 py-3">Time</th>
+						<th class="px-4 py-3">Tx</th>
+					</tr>
+				</thead>
+				<tbody class="divide-y divide-zinc-800">
+					{#each feed.operations as op (op.userOpHash)}
+						<tr class="hover:bg-zinc-800/40">
+							<!-- UserOp Hash -->
+							<td class="px-4 py-3 font-mono text-xs text-zinc-300">
+								{truncateHex(op.userOpHash, 10, 6)}
+							</td>
+
+							<!-- Sender -->
+							<td class="px-4 py-3 font-mono text-xs">
+								<a
+									href={etherscanAddress(op.sender)}
+									target="_blank"
+									rel="noopener"
+									class="text-indigo-400 hover:text-indigo-300"
+								>
+									{truncateHex(op.sender)}
+								</a>
+							</td>
+
+							<!-- Paymaster -->
+							<td class="px-4 py-3 font-mono text-xs">
+								{#if isSponsored(op.paymaster)}
+									<a
+										href={etherscanAddress(op.paymaster)}
+										target="_blank"
+										rel="noopener"
+										class="text-indigo-400 hover:text-indigo-300"
+									>
+										{truncateHex(op.paymaster)}
+									</a>
+									<span
+										class="ml-1.5 inline-block rounded bg-emerald-900/60 px-1.5 py-0.5 text-[10px] font-medium text-emerald-300"
+									>
+										Sponsored
+									</span>
+								{:else}
+									<span class="text-zinc-500">&mdash;</span>
+								{/if}
+							</td>
+
+							<!-- Success -->
+							<td class="px-4 py-3">
+								{#if op.success}
+									<span
+										class="inline-block rounded bg-green-900/60 px-2 py-0.5 text-xs font-medium text-green-300"
+									>
+										Success
+									</span>
+								{:else}
+									<span
+										class="inline-block rounded bg-red-900/60 px-2 py-0.5 text-xs font-medium text-red-300"
+									>
+										Reverted
+									</span>
+								{/if}
+							</td>
+
+							<!-- Gas Cost -->
+							<td class="px-4 py-3 text-right font-mono text-xs text-zinc-300">
+								{formatGasCost(op.actualGasCost)}
+							</td>
+
+							<!-- Block -->
+							<td class="px-4 py-3 text-right font-mono text-xs">
+								<a
+									href="{etherscanTx(op.txHash).replace(/\/tx\/.*/, '')}/block/{op.blockNumber}"
+									target="_blank"
+									rel="noopener"
+									class="text-indigo-400 hover:text-indigo-300"
+								>
+									{op.blockNumber}
+								</a>
+							</td>
+
+							<!-- Timestamp -->
+							<td class="px-4 py-3 text-xs text-zinc-400">
+								{formatTimestamp(op.blockTimestamp)}
+							</td>
+
+							<!-- Tx Link -->
+							<td class="px-4 py-3">
+								<a
+									href={etherscanTx(op.txHash)}
+									target="_blank"
+									rel="noopener"
+									class="text-indigo-400 hover:text-indigo-300"
+									title={op.txHash}
+								>
+									{truncateHex(op.txHash)}
+								</a>
+							</td>
+						</tr>
+					{/each}
+				</tbody>
+			</table>
+		</div>
+		<p class="mt-3 text-right text-xs text-zinc-500">
+			Showing {feed.operations.length} operation{feed.operations.length === 1 ? '' : 's'}
+		</p>
+	{/if}
+</div>


### PR DESCRIPTION
## What

Add an `/indexer` page showing indexed UserOperations in real time via WebSocket, with REST API polling fallback.

## Why

Bridges Part 1 (contracts) and Part 2 (indexer) by giving users a live view of UserOperations as they're indexed. Satisfies the exam requirement for an indexer dashboard with Etherscan links.

## Scope

- [x] Frontend

## How to verify

1. Start the indexer (`cd indexer && go run ./cmd/indexer`)
2. Start the frontend (`cd frontend && pnpm dev`)
3. Navigate to `http://localhost:5173/indexer`
4. Verify connection status shows "Live" (WebSocket) or "Polling (REST)" if indexer WS is unavailable
5. Confirm operations table renders with: UserOp Hash, Sender, Paymaster (with "Sponsored" badge), Status, Gas Cost (ETH), Block, Time, Tx
6. Confirm all address/tx/block links open Sepolia Etherscan
7. Stop the indexer — verify status falls back to "Polling" then shows empty state
8. `pnpm check` and `pnpm build` pass with zero errors

## Related issues

Closes #20