### PR TITLE
Deploy smart account flow

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,11 @@
+# Frontend environment variables
+# Copy to .env and fill in values.
+
+# Indexer REST/WebSocket base URL (used by indexer.svelte.ts)
+PUBLIC_INDEXER_URL=http://localhost:3001
+
+# SmartAccountFactory contract address on Sepolia (used by account.svelte.ts)
+PUBLIC_FACTORY_ADDRESS=0xYOUR_FACTORY_ADDRESS_HERE
+
+# Pimlico bundler/paymaster API key (used by account.svelte.ts)
+PUBLIC_PIMLICO_API_KEY=your_pimlico_api_key_here

--- a/frontend/src/lib/account.svelte.ts
+++ b/frontend/src/lib/account.svelte.ts
@@ -30,14 +30,19 @@ class AccountState {
 	smartAccountAddress = $state<`0x${string}` | null>(null);
 	deployed = $state<boolean>(false);
 	deploying = $state<boolean>(false);
-	deployTxHash = $state<`0x${string}` | null>(null);
+	deployUserOpHash = $state<`0x${string}` | null>(null);
 	error = $state<string | null>(null);
+
+	/** Monotonically increasing ID to discard results from stale load() calls. */
+	private loadId = 0;
 
 	/** Compute the counterfactual address and check if already deployed. */
 	async load(ownerAddress: `0x${string}`) {
+		const id = ++this.loadId;
+
 		this.error = null;
 		this.deploying = false;
-		this.deployTxHash = null;
+		this.deployUserOpHash = null;
 		this.smartAccountAddress = null;
 		this.deployed = false;
 
@@ -49,11 +54,17 @@ class AccountState {
 				args: [ownerAddress, 0n]
 			});
 
+			if (id !== this.loadId) return;
+
 			this.smartAccountAddress = address;
 
 			const code = await publicClient.getCode({ address });
+
+			if (id !== this.loadId) return;
+
 			this.deployed = !!code && code !== '0x';
 		} catch (e: unknown) {
+			if (id !== this.loadId) return;
 			const err = e as { shortMessage?: string; message?: string };
 			this.error = err.shortMessage ?? err.message ?? 'Failed to load smart account';
 		}
@@ -80,7 +91,7 @@ class AccountState {
 
 		this.deploying = true;
 		this.error = null;
-		this.deployTxHash = null;
+		this.deployUserOpHash = null;
 
 		try {
 			const smartAccount = await toSimpleSmartAccount({
@@ -110,7 +121,7 @@ class AccountState {
 				calls: [{ to: this.smartAccountAddress, value: 0n, data: '0x' }]
 			});
 
-			this.deployTxHash = hash;
+			this.deployUserOpHash = hash;
 
 			// Wait for the UserOp to be included on-chain.
 			const receipt = await bundlerClient.waitForUserOperationReceipt({ hash });
@@ -138,10 +149,11 @@ class AccountState {
 
 	/** Clear all state (called on wallet disconnect). */
 	reset() {
+		++this.loadId;
 		this.smartAccountAddress = null;
 		this.deployed = false;
 		this.deploying = false;
-		this.deployTxHash = null;
+		this.deployUserOpHash = null;
 		this.error = null;
 	}
 }

--- a/frontend/src/lib/account.svelte.ts
+++ b/frontend/src/lib/account.svelte.ts
@@ -23,7 +23,7 @@ function pimlicoApiKey(): string {
 
 /** Build the Pimlico RPC URL for Sepolia. */
 function pimlicoUrl(): string {
-	return `https://api.pimlico.io/v2/sepolia/rpc?apikey=${pimlicoApiKey()}`;
+	return `https://api.pimlico.io/v2/sepolia/rpc?apikey=${encodeURIComponent(pimlicoApiKey())}`;
 }
 
 class AccountState {
@@ -36,6 +36,10 @@ class AccountState {
 	/** Compute the counterfactual address and check if already deployed. */
 	async load(ownerAddress: `0x${string}`) {
 		this.error = null;
+		this.deploying = false;
+		this.deployTxHash = null;
+		this.smartAccountAddress = null;
+		this.deployed = false;
 
 		try {
 			const address = await publicClient.readContract({
@@ -58,9 +62,8 @@ class AccountState {
 	/** Deploy the smart account by sending a no-op UserOp (first UserOp auto-includes initCode). */
 	async deploy() {
 		const walletClient = wallet.client;
-		const walletAddress = wallet.address;
 
-		if (!walletClient || !walletAddress) {
+		if (!walletClient || !wallet.address) {
 			this.error = 'Wallet not connected';
 			return;
 		}

--- a/frontend/src/lib/account.svelte.ts
+++ b/frontend/src/lib/account.svelte.ts
@@ -1,0 +1,146 @@
+import { env } from '$env/dynamic/public';
+import { http } from 'viem';
+import { sepolia } from 'viem/chains';
+import { createPaymasterClient, entryPoint07Address } from 'viem/account-abstraction';
+import { toSimpleSmartAccount } from 'permissionless/accounts';
+import { createSmartAccountClient } from 'permissionless';
+import { publicClient, wallet } from '$lib/wallet.svelte';
+import { SmartAccountFactoryAbi } from '$lib/contracts/SmartAccountFactory';
+
+/** Resolve factory address lazily so $env/dynamic/public is read at call time. */
+function factoryAddress(): `0x${string}` {
+	const addr = env.PUBLIC_FACTORY_ADDRESS;
+	if (!addr) throw new Error('PUBLIC_FACTORY_ADDRESS is not set');
+	return addr as `0x${string}`;
+}
+
+/** Resolve Pimlico API key lazily. */
+function pimlicoApiKey(): string {
+	const key = env.PUBLIC_PIMLICO_API_KEY;
+	if (!key) throw new Error('PUBLIC_PIMLICO_API_KEY is not set');
+	return key;
+}
+
+/** Build the Pimlico RPC URL for Sepolia. */
+function pimlicoUrl(): string {
+	return `https://api.pimlico.io/v2/sepolia/rpc?apikey=${pimlicoApiKey()}`;
+}
+
+class AccountState {
+	smartAccountAddress = $state<`0x${string}` | null>(null);
+	deployed = $state<boolean>(false);
+	deploying = $state<boolean>(false);
+	deployTxHash = $state<`0x${string}` | null>(null);
+	error = $state<string | null>(null);
+
+	/** Compute the counterfactual address and check if already deployed. */
+	async load(ownerAddress: `0x${string}`) {
+		this.error = null;
+
+		try {
+			const address = await publicClient.readContract({
+				address: factoryAddress(),
+				abi: SmartAccountFactoryAbi,
+				functionName: 'getAddress',
+				args: [ownerAddress, 0n]
+			});
+
+			this.smartAccountAddress = address;
+
+			const code = await publicClient.getCode({ address });
+			this.deployed = !!code && code !== '0x';
+		} catch (e: unknown) {
+			const err = e as { shortMessage?: string; message?: string };
+			this.error = err.shortMessage ?? err.message ?? 'Failed to load smart account';
+		}
+	}
+
+	/** Deploy the smart account by sending a no-op UserOp (first UserOp auto-includes initCode). */
+	async deploy() {
+		const walletClient = wallet.client;
+		const walletAddress = wallet.address;
+
+		if (!walletClient || !walletAddress) {
+			this.error = 'Wallet not connected';
+			return;
+		}
+
+		if (this.deployed) {
+			this.error = 'Account already deployed';
+			return;
+		}
+
+		if (!this.smartAccountAddress) {
+			this.error = 'Load account address first';
+			return;
+		}
+
+		this.deploying = true;
+		this.error = null;
+		this.deployTxHash = null;
+
+		try {
+			const smartAccount = await toSimpleSmartAccount({
+				client: publicClient,
+				owner: walletClient,
+				factoryAddress: factoryAddress(),
+				index: 0n,
+				entryPoint: {
+					address: entryPoint07Address,
+					version: '0.7'
+				}
+			});
+
+			const paymaster = createPaymasterClient({
+				transport: http(pimlicoUrl())
+			});
+
+			const bundlerClient = createSmartAccountClient({
+				account: smartAccount,
+				paymaster,
+				chain: sepolia,
+				bundlerTransport: http(pimlicoUrl())
+			});
+
+			// Send a no-op call to self — the first UserOp auto-deploys via initCode.
+			const hash = await bundlerClient.sendUserOperation({
+				calls: [{ to: this.smartAccountAddress, value: 0n, data: '0x' }]
+			});
+
+			this.deployTxHash = hash;
+
+			// Wait for the UserOp to be included on-chain.
+			const receipt = await bundlerClient.waitForUserOperationReceipt({ hash });
+
+			if (!receipt.success) {
+				this.error = 'UserOperation reverted on-chain';
+				this.deploying = false;
+				return;
+			}
+
+			// Verify deployment by checking bytecode.
+			const code = await publicClient.getCode({ address: this.smartAccountAddress });
+			this.deployed = !!code && code !== '0x';
+
+			if (!this.deployed) {
+				this.error = 'Deployment transaction succeeded but no bytecode found';
+			}
+		} catch (e: unknown) {
+			const err = e as { shortMessage?: string; message?: string };
+			this.error = err.shortMessage ?? err.message ?? 'Deployment failed';
+		} finally {
+			this.deploying = false;
+		}
+	}
+
+	/** Clear all state (called on wallet disconnect). */
+	reset() {
+		this.smartAccountAddress = null;
+		this.deployed = false;
+		this.deploying = false;
+		this.deployTxHash = null;
+		this.error = null;
+	}
+}
+
+export const account = new AccountState();

--- a/frontend/src/lib/account.svelte.ts
+++ b/frontend/src/lib/account.svelte.ts
@@ -1,5 +1,5 @@
 import { env } from '$env/dynamic/public';
-import { http } from 'viem';
+import { http, isAddress } from 'viem';
 import { sepolia } from 'viem/chains';
 import { createPaymasterClient, entryPoint07Address } from 'viem/account-abstraction';
 import { toSimpleSmartAccount } from 'permissionless/accounts';
@@ -11,7 +11,8 @@ import { SmartAccountFactoryAbi } from '$lib/contracts/SmartAccountFactory';
 function factoryAddress(): `0x${string}` {
 	const addr = env.PUBLIC_FACTORY_ADDRESS;
 	if (!addr) throw new Error('PUBLIC_FACTORY_ADDRESS is not set');
-	return addr as `0x${string}`;
+	if (!isAddress(addr)) throw new Error(`PUBLIC_FACTORY_ADDRESS is not a valid address: ${addr}`);
+	return addr;
 }
 
 /** Resolve Pimlico API key lazily. */
@@ -35,6 +36,8 @@ class AccountState {
 
 	/** Monotonically increasing ID to discard results from stale load() calls. */
 	private loadId = 0;
+	/** Monotonically increasing ID to discard results from stale deploy() calls. */
+	private deployId = 0;
 
 	/** Compute the counterfactual address and check if already deployed. */
 	async load(ownerAddress: `0x${string}`) {
@@ -72,6 +75,8 @@ class AccountState {
 
 	/** Deploy the smart account by sending a no-op UserOp (first UserOp auto-includes initCode). */
 	async deploy() {
+		if (this.deploying) return;
+
 		const walletClient = wallet.client;
 
 		if (!walletClient || !wallet.address) {
@@ -89,6 +94,7 @@ class AccountState {
 			return;
 		}
 
+		const id = ++this.deployId;
 		this.deploying = true;
 		this.error = null;
 		this.deployUserOpHash = null;
@@ -104,6 +110,8 @@ class AccountState {
 					version: '0.7'
 				}
 			});
+
+			if (id !== this.deployId) return;
 
 			const paymaster = createPaymasterClient({
 				transport: http(pimlicoUrl())
@@ -121,10 +129,14 @@ class AccountState {
 				calls: [{ to: this.smartAccountAddress, value: 0n, data: '0x' }]
 			});
 
+			if (id !== this.deployId) return;
+
 			this.deployUserOpHash = hash;
 
 			// Wait for the UserOp to be included on-chain.
 			const receipt = await bundlerClient.waitForUserOperationReceipt({ hash });
+
+			if (id !== this.deployId) return;
 
 			if (!receipt.success) {
 				this.error = 'UserOperation reverted on-chain';
@@ -134,22 +146,27 @@ class AccountState {
 
 			// Verify deployment by checking bytecode.
 			const code = await publicClient.getCode({ address: this.smartAccountAddress });
+
+			if (id !== this.deployId) return;
+
 			this.deployed = !!code && code !== '0x';
 
 			if (!this.deployed) {
 				this.error = 'Deployment transaction succeeded but no bytecode found';
 			}
 		} catch (e: unknown) {
+			if (id !== this.deployId) return;
 			const err = e as { shortMessage?: string; message?: string };
 			this.error = err.shortMessage ?? err.message ?? 'Deployment failed';
 		} finally {
-			this.deploying = false;
+			if (id === this.deployId) this.deploying = false;
 		}
 	}
 
 	/** Clear all state (called on wallet disconnect). */
 	reset() {
 		++this.loadId;
+		++this.deployId;
 		this.smartAccountAddress = null;
 		this.deployed = false;
 		this.deploying = false;

--- a/frontend/src/lib/explorer.ts
+++ b/frontend/src/lib/explorer.ts
@@ -1,0 +1,35 @@
+import { formatEther } from 'viem';
+
+const ETHERSCAN_BASE = 'https://sepolia.etherscan.io';
+
+/** Returns a Sepolia Etherscan link for a transaction hash. */
+export function etherscanTx(txHash: string): string {
+	return `${ETHERSCAN_BASE}/tx/${txHash}`;
+}
+
+/** Returns a Sepolia Etherscan link for a block number. */
+export function etherscanBlock(blockNumber: number): string {
+	return `${ETHERSCAN_BASE}/block/${blockNumber}`;
+}
+
+/** Returns a Sepolia Etherscan link for an address. */
+export function etherscanAddress(address: string): string {
+	return `${ETHERSCAN_BASE}/address/${address}`;
+}
+
+/** Formats a wei string as a human-readable ETH value (up to 6 decimals). */
+export function formatGasCost(wei: string): string {
+	if (!wei || wei === '0') return '0 ETH';
+	const eth = formatEther(BigInt(wei));
+	// Trim trailing zeros but keep at least one decimal for clarity.
+	const [whole, frac] = eth.split('.');
+	if (!frac) return `${whole} ETH`;
+	const trimmed = frac.slice(0, 6).replace(/0+$/, '');
+	return trimmed ? `${whole}.${trimmed} ETH` : `${whole} ETH`;
+}
+
+/** Truncates a hex string: 0xabcd…ef12 */
+export function truncateHex(hex: string, head = 6, tail = 4): string {
+	if (hex.length <= head + tail + 1) return hex;
+	return hex.slice(0, head) + '\u2026' + hex.slice(-tail);
+}

--- a/frontend/src/lib/indexer.svelte.ts
+++ b/frontend/src/lib/indexer.svelte.ts
@@ -1,5 +1,11 @@
 import { env } from '$env/dynamic/public';
-import { formatEther } from 'viem';
+export {
+	etherscanTx,
+	etherscanBlock,
+	etherscanAddress,
+	formatGasCost,
+	truncateHex
+} from '$lib/explorer';
 
 /** Resolve the indexer base URL lazily so $env/dynamic/public is read at call time. */
 function indexerUrl(): string {
@@ -30,40 +36,6 @@ export interface UserOperation {
 }
 
 export type FeedStatus = 'disconnected' | 'connecting' | 'connected' | 'polling';
-
-const ETHERSCAN_BASE = 'https://sepolia.etherscan.io';
-
-/** Returns a Sepolia Etherscan link for a transaction hash. */
-export function etherscanTx(txHash: string): string {
-	return `${ETHERSCAN_BASE}/tx/${txHash}`;
-}
-
-/** Returns a Sepolia Etherscan link for a block number. */
-export function etherscanBlock(blockNumber: number): string {
-	return `${ETHERSCAN_BASE}/block/${blockNumber}`;
-}
-
-/** Returns a Sepolia Etherscan link for an address. */
-export function etherscanAddress(address: string): string {
-	return `${ETHERSCAN_BASE}/address/${address}`;
-}
-
-/** Formats a wei string as a human-readable ETH value (up to 6 decimals). */
-export function formatGasCost(wei: string): string {
-	if (!wei || wei === '0') return '0 ETH';
-	const eth = formatEther(BigInt(wei));
-	// Trim trailing zeros but keep at least one decimal for clarity.
-	const [whole, frac] = eth.split('.');
-	if (!frac) return `${whole} ETH`;
-	const trimmed = frac.slice(0, 6).replace(/0+$/, '');
-	return trimmed ? `${whole}.${trimmed} ETH` : `${whole} ETH`;
-}
-
-/** Truncates a hex string: 0xabcd…ef12 */
-export function truncateHex(hex: string, head = 6, tail = 4): string {
-	if (hex.length <= head + tail + 1) return hex;
-	return hex.slice(0, head) + '\u2026' + hex.slice(-tail);
-}
 
 /**
  * Reactive indexer feed that connects to the WebSocket live feed and falls

--- a/frontend/src/lib/wallet.svelte.ts
+++ b/frontend/src/lib/wallet.svelte.ts
@@ -1,4 +1,13 @@
-import { createPublicClient, createWalletClient, custom, http, type WalletClient } from 'viem';
+import {
+	createPublicClient,
+	createWalletClient,
+	custom,
+	http,
+	type Account,
+	type Chain,
+	type Transport,
+	type WalletClient
+} from 'viem';
 import { sepolia } from 'viem/chains';
 
 const SEPOLIA_CHAIN_ID = sepolia.id;
@@ -11,7 +20,7 @@ export const publicClient = createPublicClient({
 class WalletState {
 	address = $state<`0x${string}` | null>(null);
 	chainId = $state<number | null>(null);
-	client = $state<WalletClient | null>(null);
+	client = $state<WalletClient<Transport, Chain, Account> | null>(null);
 	error = $state<string | null>(null);
 
 	get connected() {

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -59,24 +59,27 @@
 							</dd>
 						</div>
 					{:else if !account.error}
-						<div class="text-zinc-400">Loading account...</div>
+						<div class="flex justify-between">
+							<dt class="text-zinc-400">Account Address</dt>
+							<dd class="text-zinc-400">Loading...</dd>
+						</div>
 					{/if}
 
-				{#if account.deployUserOpHash}
-					<div class="flex justify-between">
-						<dt class="text-zinc-400">UserOp Hash</dt>
-						<dd class="font-mono text-sm">
-							<a
-								href="https://jiffyscan.xyz/userOpHash/{account.deployUserOpHash}?network=sepolia"
-								target="_blank"
-								rel="noopener noreferrer"
-								class="text-indigo-400 hover:text-indigo-300"
-							>
-								{truncateHex(account.deployUserOpHash)}
-							</a>
-						</dd>
-					</div>
-				{/if}
+					{#if account.deployUserOpHash}
+						<div class="flex justify-between">
+							<dt class="text-zinc-400">UserOp Hash</dt>
+							<dd class="font-mono text-sm">
+								<a
+									href="https://jiffyscan.xyz/userOpHash/{account.deployUserOpHash}?network=sepolia"
+									target="_blank"
+									rel="noopener noreferrer"
+									class="text-indigo-400 hover:text-indigo-300"
+								>
+									{truncateHex(account.deployUserOpHash)}
+								</a>
+							</dd>
+						</div>
+					{/if}
 				</dl>
 
 				{#if account.error}

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -1,5 +1,20 @@
 <script lang="ts">
 	import { wallet } from '$lib/wallet.svelte';
+	import { account } from '$lib/account.svelte';
+	import { etherscanAddress } from '$lib/indexer.svelte';
+
+	function truncate(hex: string, head = 6, tail = 4): string {
+		if (hex.length <= head + tail + 1) return hex;
+		return hex.slice(0, head) + '\u2026' + hex.slice(-tail);
+	}
+
+	$effect(() => {
+		if (wallet.address && wallet.correctChain) {
+			account.load(wallet.address);
+		} else {
+			account.reset();
+		}
+	});
 </script>
 
 <div class="mx-auto max-w-xl">
@@ -17,6 +32,73 @@
 				</div>
 			</dl>
 		</div>
+
+		{#if wallet.correctChain}
+			<h2 class="mt-8 mb-4 text-xl font-bold">Smart Account</h2>
+			<div class="rounded-lg border border-zinc-800 bg-zinc-800/50 p-6">
+				<dl class="space-y-3">
+					{#if account.smartAccountAddress}
+						<div class="flex justify-between">
+							<dt class="text-zinc-400">Account Address</dt>
+							<dd class="font-mono text-sm">
+								<a
+									href={etherscanAddress(account.smartAccountAddress)}
+									target="_blank"
+									rel="noopener noreferrer"
+									class="text-indigo-400 hover:text-indigo-300"
+								>
+									{truncate(account.smartAccountAddress)}
+								</a>
+							</dd>
+						</div>
+						<div class="flex justify-between">
+							<dt class="text-zinc-400">Status</dt>
+							<dd>
+								{#if account.deploying}
+									<span class="text-yellow-400">Deploying...</span>
+								{:else if account.deployed}
+									<span class="text-green-400">Deployed</span>
+								{:else}
+									<span class="text-zinc-400">Not deployed</span>
+								{/if}
+							</dd>
+						</div>
+					{:else if !account.error}
+						<div class="text-zinc-400">Loading account...</div>
+					{/if}
+
+					{#if account.deployTxHash}
+						<div class="flex justify-between">
+							<dt class="text-zinc-400">UserOp Hash</dt>
+							<dd class="font-mono text-sm">
+								<a
+									href="https://jiffyscan.xyz/userOpHash/{account.deployTxHash}?network=sepolia"
+									target="_blank"
+									rel="noopener noreferrer"
+									class="text-indigo-400 hover:text-indigo-300"
+								>
+									{truncate(account.deployTxHash)}
+								</a>
+							</dd>
+						</div>
+					{/if}
+				</dl>
+
+				{#if account.error}
+					<p class="mt-4 text-sm text-red-400">{account.error}</p>
+				{/if}
+
+				{#if account.smartAccountAddress && !account.deployed && !account.deploying}
+					<button
+						type="button"
+						class="mt-4 w-full cursor-pointer rounded bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-50"
+						onclick={() => account.deploy()}
+					>
+						Deploy Account
+					</button>
+				{/if}
+			</div>
+		{/if}
 	{:else}
 		<div class="py-24 text-center">
 			<h1 class="mb-3 text-2xl font-bold">Bastion</h1>

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -1,12 +1,7 @@
 <script lang="ts">
 	import { wallet } from '$lib/wallet.svelte';
 	import { account } from '$lib/account.svelte';
-	import { etherscanAddress } from '$lib/indexer.svelte';
-
-	function truncate(hex: string, head = 6, tail = 4): string {
-		if (hex.length <= head + tail + 1) return hex;
-		return hex.slice(0, head) + '\u2026' + hex.slice(-tail);
-	}
+	import { etherscanAddress, truncateHex } from '$lib/explorer';
 
 	$effect(() => {
 		if (wallet.address && wallet.correctChain) {
@@ -47,7 +42,7 @@
 									rel="noopener noreferrer"
 									class="text-indigo-400 hover:text-indigo-300"
 								>
-									{truncate(account.smartAccountAddress)}
+									{truncateHex(account.smartAccountAddress)}
 								</a>
 							</dd>
 						</div>
@@ -77,7 +72,7 @@
 									rel="noopener noreferrer"
 									class="text-indigo-400 hover:text-indigo-300"
 								>
-									{truncate(account.deployTxHash)}
+									{truncateHex(account.deployTxHash)}
 								</a>
 							</dd>
 						</div>

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -62,21 +62,21 @@
 						<div class="text-zinc-400">Loading account...</div>
 					{/if}
 
-					{#if account.deployTxHash}
-						<div class="flex justify-between">
-							<dt class="text-zinc-400">UserOp Hash</dt>
-							<dd class="font-mono text-sm">
-								<a
-									href="https://jiffyscan.xyz/userOpHash/{account.deployTxHash}?network=sepolia"
-									target="_blank"
-									rel="noopener noreferrer"
-									class="text-indigo-400 hover:text-indigo-300"
-								>
-									{truncateHex(account.deployTxHash)}
-								</a>
-							</dd>
-						</div>
-					{/if}
+				{#if account.deployUserOpHash}
+					<div class="flex justify-between">
+						<dt class="text-zinc-400">UserOp Hash</dt>
+						<dd class="font-mono text-sm">
+							<a
+								href="https://jiffyscan.xyz/userOpHash/{account.deployUserOpHash}?network=sepolia"
+								target="_blank"
+								rel="noopener noreferrer"
+								class="text-indigo-400 hover:text-indigo-300"
+							>
+								{truncateHex(account.deployUserOpHash)}
+							</a>
+						</dd>
+					</div>
+				{/if}
 				</dl>
 
 				{#if account.error}


### PR DESCRIPTION
## What

Add a deploy smart account flow to the frontend home page. Users can see their counterfactual smart account address, check deployment status, and deploy via a single button click that submits an ERC-4337 UserOperation through the Pimlico bundler.

## Why

This is the first real ERC-4337 interaction in the frontend (issue #16). It enables users to deploy their SmartAccount proxy via the factory using permissionless.js, which is the prerequisite for all subsequent owner and session key flows.

## Scope

- [x] Frontend

## How to verify

1. Copy `frontend/.env.example` to `frontend/.env` and fill in `PUBLIC_FACTORY_ADDRESS` (deployed SmartAccountFactory on Sepolia) and `PUBLIC_PIMLICO_API_KEY`.
2. `cd frontend && pnpm dev`
3. Connect MetaMask on Sepolia — the dashboard should show the counterfactual smart account address and "Not deployed" status.
4. Click "Deploy Account" — a UserOp is submitted via Pimlico. Status changes to "Deploying..." then "Deployed" with a Jiffyscan link to the UserOp hash.
5. Refresh the page — status should still show "Deployed" (bytecode check).

## Related issues

Closes #16