### PR TITLE
fix(contracts): align Counter.s.sol pragma with project standard

### DIFF
--- a/contracts/script/Counter.s.sol
+++ b/contracts/script/Counter.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.13;
+pragma solidity ^0.8.28;
 
 import {Script} from "forge-std/Script.sol";
 import {Counter} from "../src/Counter.sol";


### PR DESCRIPTION
## What

Align the Solidity pragma in `contracts/script/Counter.s.sol` from `^0.8.13` (Foundry init default) to `^0.8.28` to match the rest of the project and `foundry.toml`.

## Why

Consistency — every other file uses `^0.8.28`. This was a leftover from `forge init`.

## Scope

- [x] Contracts

## How to verify

```sh
cd contracts && forge build
```

## Related issues

None — caught during project audit.