### PR TITLE
fix(frontend): replace toSimpleSmartAccount with custom Bastion adapter

### DIFF
--- a/frontend/src/lib/account.svelte.ts
+++ b/frontend/src/lib/account.svelte.ts
@@ -1,11 +1,11 @@
 import { env } from '$env/dynamic/public';
 import { http, isAddress } from 'viem';
 import { sepolia } from 'viem/chains';
-import { createPaymasterClient, entryPoint07Address } from 'viem/account-abstraction';
-import { toSimpleSmartAccount } from 'permissionless/accounts';
+import { createPaymasterClient } from 'viem/account-abstraction';
 import { createSmartAccountClient } from 'permissionless';
 import { publicClient, wallet } from '$lib/wallet.svelte';
 import { SmartAccountFactoryAbi } from '$lib/contracts/SmartAccountFactory';
+import { toBastionSmartAccount } from '$lib/smartAccount';
 
 /** Resolve factory address lazily so $env/dynamic/public is read at call time. */
 function factoryAddress(): `0x${string}` {
@@ -89,7 +89,8 @@ class AccountState {
 			return;
 		}
 
-		if (!this.smartAccountAddress) {
+		const accountAddr = this.smartAccountAddress;
+		if (!accountAddr) {
 			this.error = 'Load account address first';
 			return;
 		}
@@ -100,15 +101,12 @@ class AccountState {
 		this.deployUserOpHash = null;
 
 		try {
-			const smartAccount = await toSimpleSmartAccount({
+			const smartAccount = await toBastionSmartAccount({
 				client: publicClient,
 				owner: walletClient,
 				factoryAddress: factoryAddress(),
-				index: 0n,
-				entryPoint: {
-					address: entryPoint07Address,
-					version: '0.7'
-				}
+				salt: 0n,
+				accountAddress: accountAddr
 			});
 
 			if (id !== this.deployId) return;
@@ -126,7 +124,7 @@ class AccountState {
 
 			// Send a no-op call to self — the first UserOp auto-deploys via initCode.
 			const hash = await bundlerClient.sendUserOperation({
-				calls: [{ to: this.smartAccountAddress, value: 0n, data: '0x' }]
+				calls: [{ to: accountAddr, value: 0n, data: '0x' }]
 			});
 
 			if (id !== this.deployId) return;
@@ -145,7 +143,7 @@ class AccountState {
 			}
 
 			// Verify deployment by checking bytecode.
-			const code = await publicClient.getCode({ address: this.smartAccountAddress });
+			const code = await publicClient.getCode({ address: accountAddr });
 
 			if (id !== this.deployId) return;
 

--- a/frontend/src/lib/smartAccount.ts
+++ b/frontend/src/lib/smartAccount.ts
@@ -1,0 +1,141 @@
+/**
+ * Custom smart account adapter for the Bastion SmartAccount contract.
+ *
+ * Replaces permissionless.js's generic `toSimpleSmartAccount` with an adapter
+ * built on viem's `toSmartAccount` that uses the project's own SmartAccount and
+ * SmartAccountFactory ABIs for call encoding, factory initCode, and UserOp signing.
+ */
+
+import type { Address, Chain, Client, Transport, WalletClient, Account } from 'viem';
+import { encodeFunctionData } from 'viem';
+import {
+	type SmartAccount,
+	type UserOperation,
+	entryPoint07Abi,
+	entryPoint07Address,
+	getUserOperationHash,
+	toSmartAccount
+} from 'viem/account-abstraction';
+import { getChainId } from 'viem/actions';
+import { SmartAccountAbi } from '$lib/contracts/SmartAccount';
+import { SmartAccountFactoryAbi } from '$lib/contracts/SmartAccountFactory';
+
+export type ToBastionSmartAccountParameters = {
+	/** Public client for on-chain reads and chain ID resolution. */
+	client: Client<Transport, Chain | undefined>;
+	/** Owner wallet client — signs UserOps via the connected wallet (e.g. MetaMask). */
+	owner: WalletClient<Transport, Chain | undefined, Account>;
+	/** Deployed SmartAccountFactory address. */
+	factoryAddress: Address;
+	/** CREATE2 salt (default 0). */
+	salt?: bigint;
+	/** Pre-computed counterfactual address (from factory.getAddress). */
+	accountAddress: Address;
+};
+
+/**
+ * Create a viem `SmartAccount` adapter for the Bastion SmartAccount contract.
+ *
+ * - Encodes `execute` / `executeBatch` calls using the SmartAccount ABI.
+ * - Generates factory initCode using the SmartAccountFactory ABI.
+ * - Signs UserOperations with ECDSA via the owner's wallet.
+ * - Targets EntryPoint v0.7.
+ */
+export async function toBastionSmartAccount(
+	parameters: ToBastionSmartAccountParameters
+): Promise<SmartAccount> {
+	const { client, owner, factoryAddress, salt = 0n, accountAddress } = parameters;
+
+	const ownerAddress = owner.account.address;
+
+	const entryPoint = {
+		address: entryPoint07Address,
+		abi: entryPoint07Abi,
+		version: '0.7' as const
+	};
+
+	// Memoised chain ID — resolved once, reused for all subsequent UserOp signatures.
+	let resolvedChainId: number | undefined;
+
+	const getResolvedChainId = async (): Promise<number> => {
+		if (resolvedChainId) return resolvedChainId;
+		resolvedChainId = client.chain?.id ?? (await getChainId(client));
+		return resolvedChainId;
+	};
+
+	return toSmartAccount({
+		client,
+		entryPoint,
+
+		async getAddress() {
+			return accountAddress;
+		},
+
+		async getFactoryArgs() {
+			return {
+				factory: factoryAddress,
+				factoryData: encodeFunctionData({
+					abi: SmartAccountFactoryAbi,
+					functionName: 'createAccount',
+					args: [ownerAddress, salt]
+				})
+			};
+		},
+
+		async encodeCalls(calls) {
+			if (calls.length > 1) {
+				return encodeFunctionData({
+					abi: SmartAccountAbi,
+					functionName: 'executeBatch',
+					args: [
+						calls.map((c) => c.to),
+						calls.map((c) => c.value ?? 0n),
+						calls.map((c) => c.data ?? '0x')
+					]
+				});
+			}
+
+			const call = calls[0];
+			if (!call) throw new Error('No calls to encode');
+
+			return encodeFunctionData({
+				abi: SmartAccountAbi,
+				functionName: 'execute',
+				args: [call.to, call.value ?? 0n, call.data ?? '0x']
+			});
+		},
+
+		async getStubSignature() {
+			// 65-byte dummy ECDSA signature used for gas estimation.
+			return '0xfffffffffffffffffffffffffffffff0000000000000000000000000000000007aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1c';
+		},
+
+		async signMessage(_) {
+			throw new Error('Bastion SmartAccount is not ERC-1271 compliant');
+		},
+
+		async signTypedData(_) {
+			throw new Error('Bastion SmartAccount is not ERC-1271 compliant');
+		},
+
+		async signUserOperation(parameters) {
+			const { chainId: chainIdOverride, ...userOperation } = parameters;
+			const chainId = chainIdOverride ?? (await getResolvedChainId());
+
+			const hash = getUserOperationHash({
+				userOperation: {
+					...userOperation,
+					sender: userOperation.sender ?? accountAddress,
+					signature: '0x'
+				} as UserOperation<'0.7'>,
+				entryPointAddress: entryPoint.address,
+				entryPointVersion: '0.7',
+				chainId
+			});
+
+			return owner.signMessage({
+				message: { raw: hash }
+			});
+		}
+	});
+}

--- a/frontend/src/lib/smartAccount.ts
+++ b/frontend/src/lib/smartAccount.ts
@@ -58,7 +58,7 @@ export async function toBastionSmartAccount(
 	let resolvedChainId: number | undefined;
 
 	const getResolvedChainId = async (): Promise<number> => {
-		if (resolvedChainId) return resolvedChainId;
+		if (resolvedChainId !== undefined) return resolvedChainId;
 		resolvedChainId = client.chain?.id ?? (await getChainId(client));
 		return resolvedChainId;
 	};


### PR DESCRIPTION
## What

Replace the generic `toSimpleSmartAccount` from permissionless.js with a project-specific `toBastionSmartAccount` adapter built on viem's `toSmartAccount`.

## Why

The frontend was using `toSimpleSmartAccount` which is designed for eth-infinitism's SimpleAccount contract, not our custom SmartAccount. While the function signatures happen to match (same `execute` selector, same `createAccount` factory signature), this is the wrong abstraction:

- It hardcodes SimpleAccount's internal ABI, which could diverge on a permissionless.js update
- It has no awareness of `executeBatch`, `registerSessionKey`, or `revokeSessionKey`
- It cannot support session key signing (only owner ECDSA)

The new adapter uses our SmartAccount and SmartAccountFactory ABIs directly, encodes `execute`/`executeBatch` correctly, and sets up the foundation for session key signing.

## Scope

- [x] Frontend

## How to verify

```sh
cd frontend && pnpm build
```

Build should complete with no type errors. The deployment flow is functionally equivalent — same factory initCode, same execute encoding, same ECDSA signing.

## Related issues

Groundwork for #17, #18, #19 (owner interaction, session key management, session key interaction).