### PR TITLE
feat(frontend): add owner interaction flow for Counter and FaucetToken

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -7,5 +7,11 @@ PUBLIC_INDEXER_URL=http://localhost:3001
 # SmartAccountFactory contract address on Sepolia (used by account.svelte.ts)
 PUBLIC_FACTORY_ADDRESS=0xYOUR_FACTORY_ADDRESS_HERE
 
-# Pimlico bundler/paymaster API key (used by account.svelte.ts)
+# Counter contract address on Sepolia (used by CounterCard)
+PUBLIC_COUNTER_ADDRESS=0xYOUR_COUNTER_ADDRESS_HERE
+
+# FaucetToken (BFT) contract address on Sepolia (used by FaucetTokenCard)
+PUBLIC_FAUCET_TOKEN_ADDRESS=0xYOUR_FAUCET_TOKEN_ADDRESS_HERE
+
+# Pimlico bundler/paymaster API key (used by account.svelte.ts, userOp.ts)
 PUBLIC_PIMLICO_API_KEY=your_pimlico_api_key_here

--- a/frontend/src/lib/account.svelte.ts
+++ b/frontend/src/lib/account.svelte.ts
@@ -1,31 +1,11 @@
-import { env } from '$env/dynamic/public';
-import { http, isAddress } from 'viem';
+import { http } from 'viem';
 import { sepolia } from 'viem/chains';
 import { createPaymasterClient } from 'viem/account-abstraction';
 import { createSmartAccountClient } from 'permissionless';
 import { publicClient, wallet } from '$lib/wallet.svelte';
 import { SmartAccountFactoryAbi } from '$lib/contracts/SmartAccountFactory';
 import { toBastionSmartAccount } from '$lib/smartAccount';
-
-/** Resolve factory address lazily so $env/dynamic/public is read at call time. */
-function factoryAddress(): `0x${string}` {
-	const addr = env.PUBLIC_FACTORY_ADDRESS;
-	if (!addr) throw new Error('PUBLIC_FACTORY_ADDRESS is not set');
-	if (!isAddress(addr)) throw new Error(`PUBLIC_FACTORY_ADDRESS is not a valid address: ${addr}`);
-	return addr;
-}
-
-/** Resolve Pimlico API key lazily. */
-function pimlicoApiKey(): string {
-	const key = env.PUBLIC_PIMLICO_API_KEY;
-	if (!key) throw new Error('PUBLIC_PIMLICO_API_KEY is not set');
-	return key;
-}
-
-/** Build the Pimlico RPC URL for Sepolia. */
-function pimlicoUrl(): string {
-	return `https://api.pimlico.io/v2/sepolia/rpc?apikey=${encodeURIComponent(pimlicoApiKey())}`;
-}
+import { factoryAddress, pimlicoUrl } from '$lib/config';
 
 class AccountState {
 	smartAccountAddress = $state<`0x${string}` | null>(null);
@@ -111,15 +91,17 @@ class AccountState {
 
 			if (id !== this.deployId) return;
 
+			const pimlico = pimlicoUrl();
+
 			const paymaster = createPaymasterClient({
-				transport: http(pimlicoUrl())
+				transport: http(pimlico)
 			});
 
 			const bundlerClient = createSmartAccountClient({
 				account: smartAccount,
 				paymaster,
 				chain: sepolia,
-				bundlerTransport: http(pimlicoUrl())
+				bundlerTransport: http(pimlico)
 			});
 
 			// Send a no-op call to self — the first UserOp auto-deploys via initCode.

--- a/frontend/src/lib/components/CounterCard.svelte
+++ b/frontend/src/lib/components/CounterCard.svelte
@@ -134,6 +134,7 @@
 	{/if}
 
 	<button
+		type="button"
 		onclick={increment}
 		disabled={sending}
 		class="mt-4 w-full cursor-pointer rounded bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-50"

--- a/frontend/src/lib/components/CounterCard.svelte
+++ b/frontend/src/lib/components/CounterCard.svelte
@@ -1,0 +1,123 @@
+<script lang="ts">
+	import { encodeFunctionData, formatUnits } from 'viem';
+	import { publicClient, wallet } from '$lib/wallet.svelte';
+	import { CounterAbi } from '$lib/contracts/Counter';
+	import { counterAddress } from '$lib/config';
+	import { sendUserOp } from '$lib/userOp';
+	import { etherscanTx } from '$lib/explorer';
+
+	let { accountAddress }: { accountAddress: `0x${string}` } = $props();
+
+	let count = $state<bigint | null>(null);
+	let loading = $state(false);
+	let sending = $state(false);
+	let error = $state<string | null>(null);
+	let lastOpHash = $state<`0x${string}` | null>(null);
+
+	async function loadCount() {
+		loading = true;
+		error = null;
+		try {
+			count = await publicClient.readContract({
+				address: counterAddress(),
+				abi: CounterAbi,
+				functionName: 'getCount',
+				args: [accountAddress]
+			});
+		} catch (e: unknown) {
+			const err = e as { shortMessage?: string; message?: string };
+			error = err.shortMessage ?? err.message ?? 'Failed to read counter';
+		} finally {
+			loading = false;
+		}
+	}
+
+	async function increment() {
+		const walletClient = wallet.client;
+		if (!walletClient) {
+			error = 'Wallet not connected';
+			return;
+		}
+
+		sending = true;
+		error = null;
+		lastOpHash = null;
+
+		try {
+			const result = await sendUserOp(walletClient, accountAddress, [
+				{
+					to: counterAddress(),
+					data: encodeFunctionData({
+						abi: CounterAbi,
+						functionName: 'increment'
+					})
+				}
+			]);
+
+			lastOpHash = result.userOpHash;
+
+			if (!result.success) {
+				error = 'UserOperation reverted on-chain';
+				return;
+			}
+
+			await loadCount();
+		} catch (e: unknown) {
+			const err = e as { shortMessage?: string; message?: string };
+			error = err.shortMessage ?? err.message ?? 'Increment failed';
+		} finally {
+			sending = false;
+		}
+	}
+
+	$effect(() => {
+		// Reload when accountAddress changes.
+		accountAddress;
+		loadCount();
+	});
+</script>
+
+<div class="rounded-lg border border-zinc-800 bg-zinc-800/50 p-6">
+	<h3 class="text-lg font-semibold">Counter</h3>
+
+	<dl class="mt-4 space-y-3">
+		<div class="flex justify-between">
+			<dt class="text-zinc-400">Count</dt>
+			<dd class="font-mono text-sm">
+				{#if loading && count === null}
+					<span class="text-zinc-500">Loading…</span>
+				{:else if count !== null}
+					{count.toString()}
+				{:else}
+					<span class="text-zinc-500">—</span>
+				{/if}
+			</dd>
+		</div>
+	</dl>
+
+	{#if lastOpHash}
+		<p class="mt-3 text-xs text-zinc-500">
+			Last op:
+			<a
+				href={etherscanTx(lastOpHash)}
+				target="_blank"
+				rel="noopener noreferrer"
+				class="text-indigo-400 hover:text-indigo-300"
+			>
+				{lastOpHash.slice(0, 10)}…{lastOpHash.slice(-6)}
+			</a>
+		</p>
+	{/if}
+
+	{#if error}
+		<p class="mt-3 text-sm text-red-400">{error}</p>
+	{/if}
+
+	<button
+		onclick={increment}
+		disabled={sending}
+		class="mt-4 w-full cursor-pointer rounded bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-50"
+	>
+		{sending ? 'Sending UserOp…' : 'Increment'}
+	</button>
+</div>

--- a/frontend/src/lib/components/CounterCard.svelte
+++ b/frontend/src/lib/components/CounterCard.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
-	import { encodeFunctionData, formatUnits } from 'viem';
+	import { encodeFunctionData } from 'viem';
 	import { publicClient, wallet } from '$lib/wallet.svelte';
 	import { CounterAbi } from '$lib/contracts/Counter';
 	import { counterAddress } from '$lib/config';
 	import { sendUserOp } from '$lib/userOp';
-	import { etherscanTx } from '$lib/explorer';
+	import { etherscanTx, truncateHex } from '$lib/explorer';
 
 	let { accountAddress }: { accountAddress: `0x${string}` } = $props();
 
@@ -12,7 +12,8 @@
 	let loading = $state(false);
 	let sending = $state(false);
 	let error = $state<string | null>(null);
-	let lastOpHash = $state<`0x${string}` | null>(null);
+	let lastUserOpHash = $state<`0x${string}` | null>(null);
+	let lastTxHash = $state<`0x${string}` | null>(null);
 
 	async function loadCount() {
 		loading = true;
@@ -41,7 +42,8 @@
 
 		sending = true;
 		error = null;
-		lastOpHash = null;
+		lastUserOpHash = null;
+		lastTxHash = null;
 
 		try {
 			const result = await sendUserOp(walletClient, accountAddress, [
@@ -54,7 +56,8 @@
 				}
 			]);
 
-			lastOpHash = result.userOpHash;
+			lastUserOpHash = result.userOpHash;
+			lastTxHash = result.txHash;
 
 			if (!result.success) {
 				error = 'UserOperation reverted on-chain';
@@ -95,18 +98,35 @@
 		</div>
 	</dl>
 
-	{#if lastOpHash}
-		<p class="mt-3 text-xs text-zinc-500">
-			Last op:
-			<a
-				href={etherscanTx(lastOpHash)}
-				target="_blank"
-				rel="noopener noreferrer"
-				class="text-indigo-400 hover:text-indigo-300"
-			>
-				{lastOpHash.slice(0, 10)}…{lastOpHash.slice(-6)}
-			</a>
-		</p>
+	{#if lastUserOpHash || lastTxHash}
+		<div class="mt-3 space-y-1 text-xs text-zinc-500">
+			{#if lastUserOpHash}
+				<p>
+					UserOp:
+					<a
+						href="https://jiffyscan.xyz/userOpHash/{lastUserOpHash}?network=sepolia"
+						target="_blank"
+						rel="noopener noreferrer"
+						class="text-indigo-400 hover:text-indigo-300"
+					>
+						{truncateHex(lastUserOpHash)}
+					</a>
+				</p>
+			{/if}
+			{#if lastTxHash}
+				<p>
+					Tx:
+					<a
+						href={etherscanTx(lastTxHash)}
+						target="_blank"
+						rel="noopener noreferrer"
+						class="text-indigo-400 hover:text-indigo-300"
+					>
+						{truncateHex(lastTxHash)}
+					</a>
+				</p>
+			{/if}
+		</div>
 	{/if}
 
 	{#if error}

--- a/frontend/src/lib/components/FaucetTokenCard.svelte
+++ b/frontend/src/lib/components/FaucetTokenCard.svelte
@@ -1,0 +1,150 @@
+<script lang="ts">
+	import { encodeFunctionData, formatUnits } from 'viem';
+	import { publicClient, wallet } from '$lib/wallet.svelte';
+	import { FaucetTokenAbi } from '$lib/contracts/FaucetToken';
+	import { faucetTokenAddress } from '$lib/config';
+	import { sendUserOp } from '$lib/userOp';
+	import { etherscanTx } from '$lib/explorer';
+
+	let { accountAddress }: { accountAddress: `0x${string}` } = $props();
+
+	let balance = $state<bigint | null>(null);
+	let decimals = $state<number>(18);
+	let symbol = $state<string>('BFT');
+	let loading = $state(false);
+	let claiming = $state(false);
+	let error = $state<string | null>(null);
+	let lastOpHash = $state<`0x${string}` | null>(null);
+
+	async function loadBalance() {
+		loading = true;
+		error = null;
+		try {
+			const tokenAddr = faucetTokenAddress();
+
+			const [bal, dec, sym] = await Promise.all([
+				publicClient.readContract({
+					address: tokenAddr,
+					abi: FaucetTokenAbi,
+					functionName: 'balanceOf',
+					args: [accountAddress]
+				}),
+				publicClient.readContract({
+					address: tokenAddr,
+					abi: FaucetTokenAbi,
+					functionName: 'decimals'
+				}),
+				publicClient.readContract({
+					address: tokenAddr,
+					abi: FaucetTokenAbi,
+					functionName: 'symbol'
+				})
+			]);
+
+			balance = bal;
+			decimals = dec;
+			symbol = sym;
+		} catch (e: unknown) {
+			const err = e as { shortMessage?: string; message?: string };
+			error = err.shortMessage ?? err.message ?? 'Failed to read token balance';
+		} finally {
+			loading = false;
+		}
+	}
+
+	async function claim() {
+		const walletClient = wallet.client;
+		if (!walletClient) {
+			error = 'Wallet not connected';
+			return;
+		}
+
+		claiming = true;
+		error = null;
+		lastOpHash = null;
+
+		try {
+			const result = await sendUserOp(walletClient, accountAddress, [
+				{
+					to: faucetTokenAddress(),
+					data: encodeFunctionData({
+						abi: FaucetTokenAbi,
+						functionName: 'claim'
+					})
+				}
+			]);
+
+			lastOpHash = result.userOpHash;
+
+			if (!result.success) {
+				error = 'UserOperation reverted on-chain';
+				return;
+			}
+
+			await loadBalance();
+		} catch (e: unknown) {
+			const err = e as { shortMessage?: string; message?: string };
+			error = err.shortMessage ?? err.message ?? 'Claim failed';
+		} finally {
+			claiming = false;
+		}
+	}
+
+	function formatBalance(raw: bigint, dec: number): string {
+		const formatted = formatUnits(raw, dec);
+		// Drop unnecessary trailing decimals but keep at least 2.
+		const num = Number(formatted);
+		return num % 1 === 0 ? num.toFixed(0) : num.toFixed(2);
+	}
+
+	$effect(() => {
+		accountAddress;
+		loadBalance();
+	});
+</script>
+
+<div class="rounded-lg border border-zinc-800 bg-zinc-800/50 p-6">
+	<h3 class="text-lg font-semibold">Faucet Token</h3>
+
+	<dl class="mt-4 space-y-3">
+		<div class="flex justify-between">
+			<dt class="text-zinc-400">Balance</dt>
+			<dd class="font-mono text-sm">
+				{#if loading && balance === null}
+					<span class="text-zinc-500">Loading…</span>
+				{:else if balance !== null}
+					{formatBalance(balance, decimals)}
+					<span class="text-zinc-400">{symbol}</span>
+				{:else}
+					<span class="text-zinc-500">—</span>
+				{/if}
+			</dd>
+		</div>
+	</dl>
+
+	{#if lastOpHash}
+		<p class="mt-3 text-xs text-zinc-500">
+			Last op:
+			<a
+				href={etherscanTx(lastOpHash)}
+				target="_blank"
+				rel="noopener noreferrer"
+				class="text-indigo-400 hover:text-indigo-300"
+			>
+				{lastOpHash.slice(0, 10)}…{lastOpHash.slice(-6)}
+			</a>
+		</p>
+	{/if}
+
+	{#if error}
+		<p class="mt-3 text-sm text-red-400">{error}</p>
+	{/if}
+
+	<button
+		onclick={claim}
+		disabled={claiming}
+		class="mt-4 w-full cursor-pointer rounded bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-50"
+	>
+		{claiming ? 'Sending UserOp…' : 'Claim Tokens'}
+	</button>
+</div>

--- a/frontend/src/lib/components/FaucetTokenCard.svelte
+++ b/frontend/src/lib/components/FaucetTokenCard.svelte
@@ -4,7 +4,7 @@
 	import { FaucetTokenAbi } from '$lib/contracts/FaucetToken';
 	import { faucetTokenAddress } from '$lib/config';
 	import { sendUserOp } from '$lib/userOp';
-	import { etherscanTx } from '$lib/explorer';
+	import { etherscanTx, truncateHex } from '$lib/explorer';
 
 	let { accountAddress }: { accountAddress: `0x${string}` } = $props();
 
@@ -14,7 +14,8 @@
 	let loading = $state(false);
 	let claiming = $state(false);
 	let error = $state<string | null>(null);
-	let lastOpHash = $state<`0x${string}` | null>(null);
+	let lastUserOpHash = $state<`0x${string}` | null>(null);
+	let lastTxHash = $state<`0x${string}` | null>(null);
 
 	async function loadBalance() {
 		loading = true;
@@ -61,7 +62,8 @@
 
 		claiming = true;
 		error = null;
-		lastOpHash = null;
+		lastUserOpHash = null;
+		lastTxHash = null;
 
 		try {
 			const result = await sendUserOp(walletClient, accountAddress, [
@@ -74,7 +76,8 @@
 				}
 			]);
 
-			lastOpHash = result.userOpHash;
+			lastUserOpHash = result.userOpHash;
+			lastTxHash = result.txHash;
 
 			if (!result.success) {
 				error = 'UserOperation reverted on-chain';
@@ -90,11 +93,14 @@
 		}
 	}
 
+	/** Format a token balance string-based to avoid Number precision loss. */
 	function formatBalance(raw: bigint, dec: number): string {
-		const formatted = formatUnits(raw, dec);
-		// Drop unnecessary trailing decimals but keep at least 2.
-		const num = Number(formatted);
-		return num % 1 === 0 ? num.toFixed(0) : num.toFixed(2);
+		const str = formatUnits(raw, dec);
+		const dot = str.indexOf('.');
+		if (dot === -1) return str;
+		// Keep up to 2 decimal places, strip trailing zeros.
+		const trimmed = str.slice(0, dot + 3).replace(/\.?0+$/, '');
+		return trimmed || '0';
 	}
 
 	$effect(() => {
@@ -122,18 +128,35 @@
 		</div>
 	</dl>
 
-	{#if lastOpHash}
-		<p class="mt-3 text-xs text-zinc-500">
-			Last op:
-			<a
-				href={etherscanTx(lastOpHash)}
-				target="_blank"
-				rel="noopener noreferrer"
-				class="text-indigo-400 hover:text-indigo-300"
-			>
-				{lastOpHash.slice(0, 10)}…{lastOpHash.slice(-6)}
-			</a>
-		</p>
+	{#if lastUserOpHash || lastTxHash}
+		<div class="mt-3 space-y-1 text-xs text-zinc-500">
+			{#if lastUserOpHash}
+				<p>
+					UserOp:
+					<a
+						href="https://jiffyscan.xyz/userOpHash/{lastUserOpHash}?network=sepolia"
+						target="_blank"
+						rel="noopener noreferrer"
+						class="text-indigo-400 hover:text-indigo-300"
+					>
+						{truncateHex(lastUserOpHash)}
+					</a>
+				</p>
+			{/if}
+			{#if lastTxHash}
+				<p>
+					Tx:
+					<a
+						href={etherscanTx(lastTxHash)}
+						target="_blank"
+						rel="noopener noreferrer"
+						class="text-indigo-400 hover:text-indigo-300"
+					>
+						{truncateHex(lastTxHash)}
+					</a>
+				</p>
+			{/if}
+		</div>
 	{/if}
 
 	{#if error}

--- a/frontend/src/lib/components/FaucetTokenCard.svelte
+++ b/frontend/src/lib/components/FaucetTokenCard.svelte
@@ -164,6 +164,7 @@
 	{/if}
 
 	<button
+		type="button"
 		onclick={claim}
 		disabled={claiming}
 		class="mt-4 w-full cursor-pointer rounded bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-50"

--- a/frontend/src/lib/config.ts
+++ b/frontend/src/lib/config.ts
@@ -1,0 +1,43 @@
+/**
+ * Centralised environment configuration for contract addresses and Pimlico.
+ *
+ * All helpers read from SvelteKit's $env/dynamic/public at call time so they
+ * pick up runtime values (e.g. from .env or the hosting platform).
+ */
+
+import { env } from '$env/dynamic/public';
+import { isAddress } from 'viem';
+
+function requireAddress(name: string): `0x${string}` {
+	const raw = env[name];
+	if (!raw) throw new Error(`${name} is not set`);
+	if (!isAddress(raw)) throw new Error(`${name} is not a valid address: ${raw}`);
+	return raw;
+}
+
+function requireString(name: string): string {
+	const val = env[name];
+	if (!val) throw new Error(`${name} is not set`);
+	return val;
+}
+
+/** SmartAccountFactory deployment address. */
+export function factoryAddress(): `0x${string}` {
+	return requireAddress('PUBLIC_FACTORY_ADDRESS');
+}
+
+/** Counter contract address. */
+export function counterAddress(): `0x${string}` {
+	return requireAddress('PUBLIC_COUNTER_ADDRESS');
+}
+
+/** FaucetToken (BFT) contract address. */
+export function faucetTokenAddress(): `0x${string}` {
+	return requireAddress('PUBLIC_FAUCET_TOKEN_ADDRESS');
+}
+
+/** Pimlico bundler/paymaster RPC URL for Sepolia. */
+export function pimlicoUrl(): string {
+	const key = requireString('PUBLIC_PIMLICO_API_KEY');
+	return `https://api.pimlico.io/v2/sepolia/rpc?apikey=${encodeURIComponent(key)}`;
+}

--- a/frontend/src/lib/userOp.ts
+++ b/frontend/src/lib/userOp.ts
@@ -22,6 +22,7 @@ export type UserOpCall = {
 
 export type UserOpResult = {
 	userOpHash: `0x${string}`;
+	txHash: `0x${string}`;
 	success: boolean;
 };
 
@@ -31,7 +32,7 @@ export type UserOpResult = {
  * @param owner       Connected wallet client (signs the UserOp).
  * @param accountAddress  Deployed SmartAccount address.
  * @param calls       One or more calls to execute.
- * @returns           The UserOp hash and whether it succeeded on-chain.
+ * @returns           The UserOp hash, on-chain tx hash, and whether it succeeded.
  */
 export async function sendUserOp(
 	owner: WalletClient<Transport, Chain, Account>,
@@ -61,5 +62,9 @@ export async function sendUserOp(
 	const hash = await bundlerClient.sendUserOperation({ calls });
 	const receipt = await bundlerClient.waitForUserOperationReceipt({ hash });
 
-	return { userOpHash: hash, success: receipt.success };
+	return {
+		userOpHash: hash,
+		txHash: receipt.receipt.transactionHash,
+		success: receipt.success
+	};
 }

--- a/frontend/src/lib/userOp.ts
+++ b/frontend/src/lib/userOp.ts
@@ -1,0 +1,65 @@
+/**
+ * Shared utility for submitting UserOperations through the Bastion SmartAccount.
+ *
+ * Creates a fresh SmartAccount adapter + Pimlico bundler client per call,
+ * sends the UserOp, and waits for the on-chain receipt.
+ */
+
+import type { Account, Chain, Transport, WalletClient } from 'viem';
+import { http } from 'viem';
+import { sepolia } from 'viem/chains';
+import { createPaymasterClient } from 'viem/account-abstraction';
+import { createSmartAccountClient } from 'permissionless';
+import { publicClient } from '$lib/wallet.svelte';
+import { toBastionSmartAccount } from '$lib/smartAccount';
+import { factoryAddress, pimlicoUrl } from '$lib/config';
+
+export type UserOpCall = {
+	to: `0x${string}`;
+	value?: bigint;
+	data?: `0x${string}`;
+};
+
+export type UserOpResult = {
+	userOpHash: `0x${string}`;
+	success: boolean;
+};
+
+/**
+ * Send a UserOperation with one or more calls via the owner's SmartAccount.
+ *
+ * @param owner       Connected wallet client (signs the UserOp).
+ * @param accountAddress  Deployed SmartAccount address.
+ * @param calls       One or more calls to execute.
+ * @returns           The UserOp hash and whether it succeeded on-chain.
+ */
+export async function sendUserOp(
+	owner: WalletClient<Transport, Chain, Account>,
+	accountAddress: `0x${string}`,
+	calls: UserOpCall[]
+): Promise<UserOpResult> {
+	const smartAccount = await toBastionSmartAccount({
+		client: publicClient,
+		owner,
+		factoryAddress: factoryAddress(),
+		accountAddress
+	});
+
+	const pimlico = pimlicoUrl();
+
+	const paymaster = createPaymasterClient({
+		transport: http(pimlico)
+	});
+
+	const bundlerClient = createSmartAccountClient({
+		account: smartAccount,
+		paymaster,
+		chain: sepolia,
+		bundlerTransport: http(pimlico)
+	});
+
+	const hash = await bundlerClient.sendUserOperation({ calls });
+	const receipt = await bundlerClient.waitForUserOperationReceipt({ hash });
+
+	return { userOpHash: hash, success: receipt.success };
+}

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -2,6 +2,8 @@
 	import { wallet } from '$lib/wallet.svelte';
 	import { account } from '$lib/account.svelte';
 	import { etherscanAddress, truncateHex } from '$lib/explorer';
+	import CounterCard from '$lib/components/CounterCard.svelte';
+	import FaucetTokenCard from '$lib/components/FaucetTokenCard.svelte';
 
 	$effect(() => {
 		if (wallet.address && wallet.correctChain) {
@@ -96,6 +98,14 @@
 					</button>
 				{/if}
 			</div>
+
+			{#if account.deployed && account.smartAccountAddress}
+				<h2 class="mt-8 mb-4 text-xl font-bold">Interact</h2>
+				<div class="space-y-4">
+					<CounterCard accountAddress={account.smartAccountAddress} />
+					<FaucetTokenCard accountAddress={account.smartAccountAddress} />
+				</div>
+			{/if}
 		{/if}
 	{:else}
 		<div class="py-24 text-center">


### PR DESCRIPTION
## What

Add the owner interaction flow — the owner can now submit UserOperations to interact with the Counter and FaucetToken demo contracts through their SmartAccount.

**New files:**
- `config.ts` — centralised contract address + Pimlico URL resolution (extracted from `account.svelte.ts`)
- `userOp.ts` — shared utility for creating a SmartAccount adapter + bundler client and submitting UserOps
- `CounterCard.svelte` — reads counter value via `getCount(address)`, increments via UserOp
- `FaucetTokenCard.svelte` — reads BFT balance/symbol/decimals, claims via UserOp

**Modified files:**
- `account.svelte.ts` — uses shared `config.ts` instead of inline env helpers
- `+page.svelte` — shows "Interact" section with Counter and FaucetToken cards when account is deployed
- `.env.example` — adds `PUBLIC_COUNTER_ADDRESS` and `PUBLIC_FAUCET_TOKEN_ADDRESS`

## Why

The exam requires the owner to sign and submit UserOps to interact with demo contracts (Counter, FaucetToken) through the frontend. This was listed as a critical missing piece (#17, #22).

## Scope

- [x] Frontend

## How to verify

```sh
cd frontend && pnpm build
```

Build should complete with no type errors. Full E2E testing requires deployed contracts on Sepolia (issue #7) and the env vars populated.

## Related issues

Closes #17, closes #22.