### PR TITLE
feat(frontend): add session key management UI

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -4,14 +4,14 @@
 # Indexer REST/WebSocket base URL (used by indexer.svelte.ts)
 PUBLIC_INDEXER_URL=http://localhost:3001
 
-# SmartAccountFactory contract address on Sepolia (used by account.svelte.ts)
+# SmartAccountFactory contract address on Sepolia (used by config.ts)
 PUBLIC_FACTORY_ADDRESS=0xYOUR_FACTORY_ADDRESS_HERE
 
-# Counter contract address on Sepolia (used by CounterCard)
+# Counter contract address on Sepolia (used by config.ts)
 PUBLIC_COUNTER_ADDRESS=0xYOUR_COUNTER_ADDRESS_HERE
 
-# FaucetToken (BFT) contract address on Sepolia (used by FaucetTokenCard)
+# FaucetToken (BFT) contract address on Sepolia (used by config.ts)
 PUBLIC_FAUCET_TOKEN_ADDRESS=0xYOUR_FAUCET_TOKEN_ADDRESS_HERE
 
-# Pimlico bundler/paymaster API key (used by account.svelte.ts, userOp.ts)
+# Pimlico bundler/paymaster API key (used by config.ts)
 PUBLIC_PIMLICO_API_KEY=your_pimlico_api_key_here

--- a/frontend/src/lib/components/SessionKeyManager.svelte
+++ b/frontend/src/lib/components/SessionKeyManager.svelte
@@ -327,6 +327,9 @@
 	{#if keys.length > 0}
 		<div class="rounded-lg border border-zinc-800 bg-zinc-800/50 p-6">
 			<h3 class="text-lg font-semibold">Registered Keys</h3>
+			<p class="mt-1 text-xs text-zinc-500">
+				Keys shown are from this session only. Refreshing the page will clear this list.
+			</p>
 
 			<div class="mt-4 space-y-3">
 				{#each keys as entry, i}

--- a/frontend/src/lib/components/SessionKeyManager.svelte
+++ b/frontend/src/lib/components/SessionKeyManager.svelte
@@ -1,0 +1,343 @@
+<script lang="ts">
+	import { encodeFunctionData, toFunctionSelector } from 'viem';
+	import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts';
+	import { publicClient, wallet } from '$lib/wallet.svelte';
+	import { SmartAccountAbi } from '$lib/contracts/SmartAccount';
+	import { counterAddress, faucetTokenAddress } from '$lib/config';
+	import { sendRawUserOp } from '$lib/userOp';
+	import { truncateHex } from '$lib/explorer';
+
+	let { accountAddress }: { accountAddress: `0x${string}` } = $props();
+
+	// ── Targets & selectors ─────────────────────────────────────────────
+
+	const TARGETS = [
+		{
+			id: 'counter',
+			label: 'Counter',
+			address: () => counterAddress(),
+			functions: [{ label: 'increment()', selector: toFunctionSelector('function increment()') }]
+		},
+		{
+			id: 'faucet',
+			label: 'FaucetToken',
+			address: () => faucetTokenAddress(),
+			functions: [
+				{ label: 'claim()', selector: toFunctionSelector('function claim()') },
+				{
+					label: 'transfer(address,uint256)',
+					selector: toFunctionSelector('function transfer(address,uint256)')
+				}
+			]
+		}
+	];
+
+	// ── Registration form state ─────────────────────────────────────────
+
+	let keyAddress = $state('');
+	let generatedPrivateKey = $state<string | null>(null);
+	let selectedTargetId = $state(TARGETS[0].id);
+	let selectedFnIndex = $state(0);
+	let validMinutes = $state(60);
+	let registering = $state(false);
+	let registerError = $state<string | null>(null);
+
+	// ── Registered keys ─────────────────────────────────────────────────
+
+	type SessionKeyEntry = {
+		address: `0x${string}`;
+		privateKey: string | null;
+		targetName: string;
+		functionName: string;
+		validAfter: number;
+		validUntil: number;
+		revoking: boolean;
+	};
+
+	let keys = $state<SessionKeyEntry[]>([]);
+	let revokeError = $state<string | null>(null);
+
+	// ── Derived ─────────────────────────────────────────────────────────
+
+	const selectedTarget = $derived(TARGETS.find((t) => t.id === selectedTargetId) ?? TARGETS[0]);
+	const selectedFn = $derived(
+		selectedTarget.functions[selectedFnIndex] ?? selectedTarget.functions[0]
+	);
+
+	// Reset function index when target changes.
+	$effect(() => {
+		selectedTargetId;
+		selectedFnIndex = 0;
+	});
+
+	// ── Actions ─────────────────────────────────────────────────────────
+
+	function generateKey() {
+		const pk = generatePrivateKey();
+		const account = privateKeyToAccount(pk);
+		keyAddress = account.address;
+		generatedPrivateKey = pk;
+	}
+
+	async function register() {
+		const walletClient = wallet.client;
+		if (!walletClient) {
+			registerError = 'Wallet not connected';
+			return;
+		}
+		if (!keyAddress || !keyAddress.startsWith('0x') || keyAddress.length !== 42) {
+			registerError = 'Enter a valid address or generate a key';
+			return;
+		}
+
+		registering = true;
+		registerError = null;
+
+		const now = Math.floor(Date.now() / 1000);
+		const validAfter = now;
+		const validUntil = now + validMinutes * 60;
+
+		try {
+			const callData = encodeFunctionData({
+				abi: SmartAccountAbi,
+				functionName: 'registerSessionKey',
+				args: [
+					keyAddress as `0x${string}`,
+					selectedTarget.address(),
+					selectedFn.selector as `0x${string}`,
+					validAfter,
+					validUntil
+				]
+			});
+
+			const result = await sendRawUserOp(walletClient, accountAddress, callData);
+
+			if (!result.success) {
+				registerError = 'UserOperation reverted on-chain';
+				return;
+			}
+
+			keys = [
+				...keys,
+				{
+					address: keyAddress as `0x${string}`,
+					privateKey: generatedPrivateKey,
+					targetName: selectedTarget.label,
+					functionName: selectedFn.label,
+					validAfter,
+					validUntil,
+					revoking: false
+				}
+			];
+
+			// Reset form.
+			keyAddress = '';
+			generatedPrivateKey = null;
+		} catch (e: unknown) {
+			const err = e as { shortMessage?: string; message?: string };
+			registerError = err.shortMessage ?? err.message ?? 'Registration failed';
+		} finally {
+			registering = false;
+		}
+	}
+
+	async function revoke(index: number) {
+		const walletClient = wallet.client;
+		if (!walletClient) return;
+
+		const entry = keys[index];
+		if (!entry) return;
+
+		keys[index].revoking = true;
+		revokeError = null;
+
+		try {
+			const callData = encodeFunctionData({
+				abi: SmartAccountAbi,
+				functionName: 'revokeSessionKey',
+				args: [entry.address]
+			});
+
+			const result = await sendRawUserOp(walletClient, accountAddress, callData);
+
+			if (!result.success) {
+				revokeError = `Failed to revoke ${truncateHex(entry.address)}`;
+				keys[index].revoking = false;
+				return;
+			}
+
+			keys = keys.filter((_, i) => i !== index);
+		} catch (e: unknown) {
+			const err = e as { shortMessage?: string; message?: string };
+			revokeError = err.shortMessage ?? err.message ?? 'Revoke failed';
+			keys[index].revoking = false;
+		}
+	}
+
+	function formatTime(unix: number): string {
+		return new Date(unix * 1000).toLocaleString();
+	}
+
+	function isExpired(entry: SessionKeyEntry): boolean {
+		return Date.now() / 1000 > entry.validUntil;
+	}
+
+	function copyToClipboard(text: string) {
+		navigator.clipboard.writeText(text);
+	}
+</script>
+
+<div class="space-y-6">
+	<!-- Register form -->
+	<div class="rounded-lg border border-zinc-800 bg-zinc-800/50 p-6">
+		<h3 class="text-lg font-semibold">Register Session Key</h3>
+
+		<div class="mt-4 space-y-4">
+			<!-- Key address -->
+			<div>
+				<label for="sk-address" class="mb-1 block text-sm text-zinc-400">Key Address</label>
+				<div class="flex gap-2">
+					<input
+						id="sk-address"
+						type="text"
+						bind:value={keyAddress}
+						placeholder="0x…"
+						class="flex-1 rounded border border-zinc-700 bg-zinc-900 px-3 py-2 font-mono text-sm text-zinc-100 placeholder-zinc-600 focus:border-indigo-500 focus:outline-none"
+					/>
+					<button
+						type="button"
+						onclick={generateKey}
+						class="cursor-pointer rounded bg-zinc-700 px-3 py-2 text-sm whitespace-nowrap text-zinc-200 hover:bg-zinc-600"
+					>
+						Generate
+					</button>
+				</div>
+				{#if generatedPrivateKey}
+					<div class="mt-2 rounded border border-yellow-800/50 bg-yellow-900/20 p-2">
+						<p class="text-xs text-yellow-400">Private key (save for session key demo):</p>
+						<div class="mt-1 flex items-center gap-2">
+							<code class="flex-1 font-mono text-xs break-all text-yellow-300">
+								{generatedPrivateKey}
+							</code>
+							<button
+								type="button"
+								onclick={() => copyToClipboard(generatedPrivateKey!)}
+								class="cursor-pointer rounded bg-zinc-700 px-2 py-1 text-xs text-zinc-300 hover:bg-zinc-600"
+							>
+								Copy
+							</button>
+						</div>
+					</div>
+				{/if}
+			</div>
+
+			<!-- Target contract -->
+			<div>
+				<label for="sk-target" class="mb-1 block text-sm text-zinc-400">Target Contract</label>
+				<select
+					id="sk-target"
+					bind:value={selectedTargetId}
+					class="w-full rounded border border-zinc-700 bg-zinc-900 px-3 py-2 text-sm text-zinc-100 focus:border-indigo-500 focus:outline-none"
+				>
+					{#each TARGETS as target}
+						<option value={target.id}>{target.label}</option>
+					{/each}
+				</select>
+			</div>
+
+			<!-- Allowed function -->
+			<div>
+				<label for="sk-fn" class="mb-1 block text-sm text-zinc-400">Allowed Function</label>
+				<select
+					id="sk-fn"
+					bind:value={selectedFnIndex}
+					class="w-full rounded border border-zinc-700 bg-zinc-900 px-3 py-2 font-mono text-sm text-zinc-100 focus:border-indigo-500 focus:outline-none"
+				>
+					{#each selectedTarget.functions as fn, i}
+						<option value={i}>{fn.label}</option>
+					{/each}
+				</select>
+			</div>
+
+			<!-- Validity duration -->
+			<div>
+				<label for="sk-duration" class="mb-1 block text-sm text-zinc-400">Valid for (minutes)</label
+				>
+				<input
+					id="sk-duration"
+					type="number"
+					min="1"
+					max="10080"
+					bind:value={validMinutes}
+					class="w-full rounded border border-zinc-700 bg-zinc-900 px-3 py-2 text-sm text-zinc-100 focus:border-indigo-500 focus:outline-none"
+				/>
+			</div>
+
+			{#if registerError}
+				<p class="text-sm text-red-400">{registerError}</p>
+			{/if}
+
+			<button
+				type="button"
+				onclick={register}
+				disabled={registering}
+				class="w-full cursor-pointer rounded bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-50"
+			>
+				{registering ? 'Sending UserOp…' : 'Register Key'}
+			</button>
+		</div>
+	</div>
+
+	<!-- Registered keys list -->
+	{#if keys.length > 0}
+		<div class="rounded-lg border border-zinc-800 bg-zinc-800/50 p-6">
+			<h3 class="text-lg font-semibold">Registered Keys</h3>
+
+			<div class="mt-4 space-y-3">
+				{#each keys as entry, i}
+					<div class="rounded border border-zinc-700 p-3">
+						<div class="flex items-start justify-between gap-2">
+							<div class="min-w-0 flex-1">
+								<p class="font-mono text-sm text-zinc-200">
+									{truncateHex(entry.address)}
+								</p>
+								<p class="mt-1 text-xs text-zinc-400">
+									{entry.targetName} · <code>{entry.functionName}</code>
+								</p>
+								<p class="mt-1 text-xs text-zinc-500">
+									{formatTime(entry.validAfter)} → {formatTime(entry.validUntil)}
+									{#if isExpired(entry)}
+										<span class="ml-1 text-red-400">Expired</span>
+									{:else}
+										<span class="ml-1 text-green-400">Active</span>
+									{/if}
+								</p>
+								{#if entry.privateKey}
+									<button
+										type="button"
+										onclick={() => copyToClipboard(entry.privateKey!)}
+										class="mt-1 cursor-pointer text-xs text-indigo-400 hover:text-indigo-300"
+									>
+										Copy private key
+									</button>
+								{/if}
+							</div>
+							<button
+								type="button"
+								onclick={() => revoke(i)}
+								disabled={entry.revoking}
+								class="cursor-pointer rounded bg-red-900/60 px-2.5 py-1 text-xs font-medium text-red-300 hover:bg-red-900/80 disabled:cursor-not-allowed disabled:opacity-50"
+							>
+								{entry.revoking ? 'Revoking…' : 'Revoke'}
+							</button>
+						</div>
+					</div>
+				{/each}
+			</div>
+
+			{#if revokeError}
+				<p class="mt-3 text-sm text-red-400">{revokeError}</p>
+			{/if}
+		</div>
+	{/if}
+</div>

--- a/frontend/src/lib/components/SessionKeyManager.svelte
+++ b/frontend/src/lib/components/SessionKeyManager.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-	import { encodeFunctionData, toFunctionSelector } from 'viem';
+	import { encodeFunctionData, isAddress, toFunctionSelector } from 'viem';
 	import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts';
-	import { publicClient, wallet } from '$lib/wallet.svelte';
+	import { wallet } from '$lib/wallet.svelte';
 	import { SmartAccountAbi } from '$lib/contracts/SmartAccount';
 	import { counterAddress, faucetTokenAddress } from '$lib/config';
 	import { sendRawUserOp } from '$lib/userOp';
@@ -36,6 +36,8 @@
 
 	let keyAddress = $state('');
 	let generatedPrivateKey = $state<string | null>(null);
+	/** The address that was generated — used to detect manual edits. */
+	let generatedAddress = $state<string | null>(null);
 	let selectedTargetId = $state(TARGETS[0].id);
 	let selectedFnIndex = $state(0);
 	let validMinutes = $state(60);
@@ -43,6 +45,8 @@
 	let registerError = $state<string | null>(null);
 
 	// ── Registered keys ─────────────────────────────────────────────────
+	// NOTE: Keys are tracked in-memory only (the contract's sessionKeys mapping
+	// is not enumerable). Refreshing the page will clear this list.
 
 	type SessionKeyEntry = {
 		address: `0x${string}`;
@@ -51,6 +55,7 @@
 		functionName: string;
 		validAfter: number;
 		validUntil: number;
+		revoked: boolean;
 		revoking: boolean;
 	};
 
@@ -70,12 +75,21 @@
 		selectedFnIndex = 0;
 	});
 
+	// Clear generated private key if the user manually edits the address.
+	$effect(() => {
+		if (generatedAddress && keyAddress !== generatedAddress) {
+			generatedPrivateKey = null;
+			generatedAddress = null;
+		}
+	});
+
 	// ── Actions ─────────────────────────────────────────────────────────
 
 	function generateKey() {
 		const pk = generatePrivateKey();
 		const account = privateKeyToAccount(pk);
 		keyAddress = account.address;
+		generatedAddress = account.address;
 		generatedPrivateKey = pk;
 	}
 
@@ -85,8 +99,12 @@
 			registerError = 'Wallet not connected';
 			return;
 		}
-		if (!keyAddress || !keyAddress.startsWith('0x') || keyAddress.length !== 42) {
-			registerError = 'Enter a valid address or generate a key';
+		if (!isAddress(keyAddress)) {
+			registerError = 'Enter a valid Ethereum address or generate a key';
+			return;
+		}
+		if (!Number.isFinite(validMinutes) || validMinutes < 1) {
+			registerError = 'Duration must be at least 1 minute';
 			return;
 		}
 
@@ -95,7 +113,7 @@
 
 		const now = Math.floor(Date.now() / 1000);
 		const validAfter = now;
-		const validUntil = now + validMinutes * 60;
+		const validUntil = now + Math.floor(validMinutes) * 60;
 
 		try {
 			const callData = encodeFunctionData({
@@ -126,6 +144,7 @@
 					functionName: selectedFn.label,
 					validAfter,
 					validUntil,
+					revoked: false,
 					revoking: false
 				}
 			];
@@ -133,6 +152,7 @@
 			// Reset form.
 			keyAddress = '';
 			generatedPrivateKey = null;
+			generatedAddress = null;
 		} catch (e: unknown) {
 			const err = e as { shortMessage?: string; message?: string };
 			registerError = err.shortMessage ?? err.message ?? 'Registration failed';
@@ -146,7 +166,7 @@
 		if (!walletClient) return;
 
 		const entry = keys[index];
-		if (!entry) return;
+		if (!entry || entry.revoked) return;
 
 		keys[index].revoking = true;
 		revokeError = null;
@@ -166,7 +186,8 @@
 				return;
 			}
 
-			keys = keys.filter((_, i) => i !== index);
+			keys[index].revoked = true;
+			keys[index].revoking = false;
 		} catch (e: unknown) {
 			const err = e as { shortMessage?: string; message?: string };
 			revokeError = err.shortMessage ?? err.message ?? 'Revoke failed';
@@ -178,12 +199,26 @@
 		return new Date(unix * 1000).toLocaleString();
 	}
 
-	function isExpired(entry: SessionKeyEntry): boolean {
-		return Date.now() / 1000 > entry.validUntil;
+	function keyStatus(entry: SessionKeyEntry): { label: string; color: string } {
+		if (entry.revoked) return { label: 'Revoked', color: 'text-zinc-400' };
+		if (Date.now() / 1000 > entry.validUntil) return { label: 'Expired', color: 'text-red-400' };
+		return { label: 'Active', color: 'text-green-400' };
 	}
 
-	function copyToClipboard(text: string) {
-		navigator.clipboard.writeText(text);
+	async function copyToClipboard(text: string) {
+		try {
+			await navigator.clipboard.writeText(text);
+		} catch {
+			// Fallback: select a temporary textarea (insecure context).
+			const el = document.createElement('textarea');
+			el.value = text;
+			el.style.position = 'fixed';
+			el.style.opacity = '0';
+			document.body.appendChild(el);
+			el.select();
+			document.execCommand('copy');
+			document.body.removeChild(el);
+		}
 	}
 </script>
 
@@ -295,7 +330,13 @@
 
 			<div class="mt-4 space-y-3">
 				{#each keys as entry, i}
-					<div class="rounded border border-zinc-700 p-3">
+					{@const status = keyStatus(entry)}
+					<div
+						class="rounded border p-3"
+						class:border-zinc-700={!entry.revoked}
+						class:border-zinc-800={entry.revoked}
+						class:opacity-60={entry.revoked}
+					>
 						<div class="flex items-start justify-between gap-2">
 							<div class="min-w-0 flex-1">
 								<p class="font-mono text-sm text-zinc-200">
@@ -306,13 +347,9 @@
 								</p>
 								<p class="mt-1 text-xs text-zinc-500">
 									{formatTime(entry.validAfter)} → {formatTime(entry.validUntil)}
-									{#if isExpired(entry)}
-										<span class="ml-1 text-red-400">Expired</span>
-									{:else}
-										<span class="ml-1 text-green-400">Active</span>
-									{/if}
+									<span class="ml-1 {status.color}">{status.label}</span>
 								</p>
-								{#if entry.privateKey}
+								{#if entry.privateKey && !entry.revoked}
 									<button
 										type="button"
 										onclick={() => copyToClipboard(entry.privateKey!)}
@@ -322,14 +359,16 @@
 									</button>
 								{/if}
 							</div>
-							<button
-								type="button"
-								onclick={() => revoke(i)}
-								disabled={entry.revoking}
-								class="cursor-pointer rounded bg-red-900/60 px-2.5 py-1 text-xs font-medium text-red-300 hover:bg-red-900/80 disabled:cursor-not-allowed disabled:opacity-50"
-							>
-								{entry.revoking ? 'Revoking…' : 'Revoke'}
-							</button>
+							{#if !entry.revoked}
+								<button
+									type="button"
+									onclick={() => revoke(i)}
+									disabled={entry.revoking}
+									class="cursor-pointer rounded bg-red-900/60 px-2.5 py-1 text-xs font-medium text-red-300 hover:bg-red-900/80 disabled:cursor-not-allowed disabled:opacity-50"
+								>
+									{entry.revoking ? 'Revoking…' : 'Revoke'}
+								</button>
+							{/if}
 						</div>
 					</div>
 				{/each}

--- a/frontend/src/lib/userOp.ts
+++ b/frontend/src/lib/userOp.ts
@@ -5,7 +5,7 @@
  * sends the UserOp, and waits for the on-chain receipt.
  */
 
-import type { Account, Chain, Transport, WalletClient } from 'viem';
+import type { Account, Chain, Hex, Transport, WalletClient } from 'viem';
 import { http } from 'viem';
 import { sepolia } from 'viem/chains';
 import { createPaymasterClient } from 'viem/account-abstraction';
@@ -26,19 +26,11 @@ export type UserOpResult = {
 	success: boolean;
 };
 
-/**
- * Send a UserOperation with one or more calls via the owner's SmartAccount.
- *
- * @param owner       Connected wallet client (signs the UserOp).
- * @param accountAddress  Deployed SmartAccount address.
- * @param calls       One or more calls to execute.
- * @returns           The UserOp hash, on-chain tx hash, and whether it succeeded.
- */
-export async function sendUserOp(
+/** Create a SmartAccountClient (bundler + paymaster) for the given owner. */
+async function createBundlerClient(
 	owner: WalletClient<Transport, Chain, Account>,
-	accountAddress: `0x${string}`,
-	calls: UserOpCall[]
-): Promise<UserOpResult> {
+	accountAddress: `0x${string}`
+) {
 	const smartAccount = await toBastionSmartAccount({
 		client: publicClient,
 		owner,
@@ -52,14 +44,58 @@ export async function sendUserOp(
 		transport: http(pimlico)
 	});
 
-	const bundlerClient = createSmartAccountClient({
+	return createSmartAccountClient({
 		account: smartAccount,
 		paymaster,
 		chain: sepolia,
 		bundlerTransport: http(pimlico)
 	});
+}
+
+/**
+ * Send a UserOperation with one or more calls via the owner's SmartAccount.
+ * Calls are encoded via `execute` / `executeBatch`.
+ *
+ * @param owner           Connected wallet client (signs the UserOp).
+ * @param accountAddress  Deployed SmartAccount address.
+ * @param calls           One or more calls to execute.
+ * @returns               The UserOp hash, on-chain tx hash, and whether it succeeded.
+ */
+export async function sendUserOp(
+	owner: WalletClient<Transport, Chain, Account>,
+	accountAddress: `0x${string}`,
+	calls: UserOpCall[]
+): Promise<UserOpResult> {
+	const bundlerClient = await createBundlerClient(owner, accountAddress);
 
 	const hash = await bundlerClient.sendUserOperation({ calls });
+	const receipt = await bundlerClient.waitForUserOperationReceipt({ hash });
+
+	return {
+		userOpHash: hash,
+		txHash: receipt.receipt.transactionHash,
+		success: receipt.success
+	};
+}
+
+/**
+ * Send a UserOperation with raw callData (bypasses `execute` encoding).
+ * Use this for SmartAccount self-calls like `registerSessionKey` / `revokeSessionKey`
+ * where the EntryPoint must call the function directly.
+ *
+ * @param owner           Connected wallet client (signs the UserOp).
+ * @param accountAddress  Deployed SmartAccount address.
+ * @param callData        Pre-encoded callData for the UserOp.
+ * @returns               The UserOp hash, on-chain tx hash, and whether it succeeded.
+ */
+export async function sendRawUserOp(
+	owner: WalletClient<Transport, Chain, Account>,
+	accountAddress: `0x${string}`,
+	callData: Hex
+): Promise<UserOpResult> {
+	const bundlerClient = await createBundlerClient(owner, accountAddress);
+
+	const hash = await bundlerClient.sendUserOperation({ callData });
 	const receipt = await bundlerClient.waitForUserOperationReceipt({ hash });
 
 	return {

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -4,6 +4,7 @@
 	import { etherscanAddress, truncateHex } from '$lib/explorer';
 	import CounterCard from '$lib/components/CounterCard.svelte';
 	import FaucetTokenCard from '$lib/components/FaucetTokenCard.svelte';
+	import SessionKeyManager from '$lib/components/SessionKeyManager.svelte';
 
 	$effect(() => {
 		if (wallet.address && wallet.correctChain) {
@@ -105,6 +106,9 @@
 					<CounterCard accountAddress={account.smartAccountAddress} />
 					<FaucetTokenCard accountAddress={account.smartAccountAddress} />
 				</div>
+
+				<h2 class="mt-8 mb-4 text-xl font-bold">Session Keys</h2>
+				<SessionKeyManager accountAddress={account.smartAccountAddress} />
 			{/if}
 		{/if}
 	{:else}


### PR DESCRIPTION
## What

Add the session key management UI — the owner can register, view, and revoke session keys for their SmartAccount through UserOperations.

**New files:**
- `SessionKeyManager.svelte` — register form (generate or enter key address, select target contract + allowed function, set validity window), registered keys list with active/expired status and revoke button, private key copy for the session key interaction demo

**Modified files:**
- `userOp.ts` — extracted shared `createBundlerClient`, added `sendRawUserOp` for direct callData UserOps (bypasses `execute` wrapper since `registerSessionKey`/`revokeSessionKey` use `onlyOwnerOrEntryPoint` and must be called directly by the EntryPoint)
- `+page.svelte` — "Session Keys" section below "Interact", visible when account is deployed

## Why

Session key management is the exam's core differentiator. The owner needs to register session keys with constraints (target contract, allowed function selector, time window) and revoke them — all through UserOperations.

Key technical insight: `registerSessionKey` has the `onlyOwnerOrEntryPoint` modifier, so the UserOp callData must encode the function directly (not wrapped in `execute`), because a self-call via `execute` would have `msg.sender = address(this)` which fails the modifier check.

## Scope

- [x] Frontend

## How to verify

```sh
cd frontend && pnpm build
```

Build should complete with no type errors. Full E2E testing requires deployed contracts on Sepolia and the env vars populated.

## Related issues

Closes #18. Depends on #48.