### PR TITLE
Stats panel

### DIFF
--- a/frontend/src/lib/components/StatsPanel.svelte
+++ b/frontend/src/lib/components/StatsPanel.svelte
@@ -35,28 +35,28 @@
 				>
 					{pct(stats.successRate)}
 				</span>
-		{:else}
-			{'\u2014'}
-		{/if}
-	</p>
-	{#if stats && stats.totalOps > 0}
-		<p class="mt-0.5 text-xs text-zinc-500">
-			{stats.successCount} / {stats.totalOps}
+			{:else}
+				{'\u2014'}
+			{/if}
 		</p>
-	{/if}
-</div>
-
-<!-- Sponsored -->
-<div class="rounded-lg border border-zinc-800 bg-zinc-800/50 px-4 py-4">
-	<p class="text-xs tracking-wider text-zinc-400 uppercase">Sponsored</p>
-	<p class="mt-1 text-2xl font-semibold tabular-nums">
-		{#if stats}
-			<span class={stats.sponsoredRate > 0 ? 'text-emerald-400' : ''}>
-				{pct(stats.sponsoredRate)}
-			</span>
-		{:else}
-			{'\u2014'}
+		{#if stats && stats.totalOps > 0}
+			<p class="mt-0.5 text-xs text-zinc-500">
+				{stats.successCount} / {stats.totalOps}
+			</p>
 		{/if}
+	</div>
+
+	<!-- Sponsored -->
+	<div class="rounded-lg border border-zinc-800 bg-zinc-800/50 px-4 py-4">
+		<p class="text-xs tracking-wider text-zinc-400 uppercase">Sponsored</p>
+		<p class="mt-1 text-2xl font-semibold tabular-nums">
+			{#if stats}
+				<span class={stats.sponsoredRate > 0 ? 'text-emerald-400' : ''}>
+					{pct(stats.sponsoredRate)}
+				</span>
+			{:else}
+				{'\u2014'}
+			{/if}
 		</p>
 		{#if stats && stats.totalOps > 0}
 			<p class="mt-0.5 text-xs text-zinc-500">

--- a/frontend/src/lib/components/StatsPanel.svelte
+++ b/frontend/src/lib/components/StatsPanel.svelte
@@ -1,0 +1,75 @@
+<script lang="ts">
+	import type { IndexerStats } from '$lib/indexer.svelte';
+
+	interface Props {
+		stats: IndexerStats | null;
+	}
+
+	let { stats }: Props = $props();
+
+	function pct(rate: number): string {
+		return (rate * 100).toFixed(1) + '%';
+	}
+</script>
+
+<div class="mb-6 grid grid-cols-2 gap-4 sm:grid-cols-4">
+	<!-- Total UserOps -->
+	<div class="rounded-lg border border-zinc-800 bg-zinc-800/50 px-4 py-4">
+		<p class="text-xs tracking-wider text-zinc-400 uppercase">Total UserOps</p>
+		<p class="mt-1 text-2xl font-semibold tabular-nums">
+			{stats ? stats.totalOps.toLocaleString() : '\u2014'}
+		</p>
+	</div>
+
+	<!-- Success Rate -->
+	<div class="rounded-lg border border-zinc-800 bg-zinc-800/50 px-4 py-4">
+		<p class="text-xs tracking-wider text-zinc-400 uppercase">Success Rate</p>
+		<p class="mt-1 text-2xl font-semibold tabular-nums">
+			{#if stats}
+				<span
+					class={stats.successRate >= 0.9
+						? 'text-green-400'
+						: stats.successRate >= 0.5
+							? 'text-yellow-400'
+							: 'text-red-400'}
+				>
+					{pct(stats.successRate)}
+				</span>
+			{:else}
+				&mdash;
+			{/if}
+		</p>
+		{#if stats && stats.totalOps > 0}
+			<p class="mt-0.5 text-xs text-zinc-500">
+				{stats.successCount} / {stats.totalOps}
+			</p>
+		{/if}
+	</div>
+
+	<!-- Sponsored -->
+	<div class="rounded-lg border border-zinc-800 bg-zinc-800/50 px-4 py-4">
+		<p class="text-xs tracking-wider text-zinc-400 uppercase">Sponsored</p>
+		<p class="mt-1 text-2xl font-semibold tabular-nums">
+			{#if stats}
+				<span class={stats.sponsoredRate > 0 ? 'text-emerald-400' : ''}>
+					{pct(stats.sponsoredRate)}
+				</span>
+			{:else}
+				&mdash;
+			{/if}
+		</p>
+		{#if stats && stats.totalOps > 0}
+			<p class="mt-0.5 text-xs text-zinc-500">
+				{stats.sponsoredCount} paymaster-funded
+			</p>
+		{/if}
+	</div>
+
+	<!-- Unique Senders -->
+	<div class="rounded-lg border border-zinc-800 bg-zinc-800/50 px-4 py-4">
+		<p class="text-xs tracking-wider text-zinc-400 uppercase">Unique Senders</p>
+		<p class="mt-1 text-2xl font-semibold tabular-nums">
+			{stats ? stats.uniqueSenders.toLocaleString() : '\u2014'}
+		</p>
+	</div>
+</div>

--- a/frontend/src/lib/components/StatsPanel.svelte
+++ b/frontend/src/lib/components/StatsPanel.svelte
@@ -35,28 +35,28 @@
 				>
 					{pct(stats.successRate)}
 				</span>
-			{:else}
-				&mdash;
-			{/if}
-		</p>
-		{#if stats && stats.totalOps > 0}
-			<p class="mt-0.5 text-xs text-zinc-500">
-				{stats.successCount} / {stats.totalOps}
-			</p>
+		{:else}
+			{'\u2014'}
 		{/if}
-	</div>
+	</p>
+	{#if stats && stats.totalOps > 0}
+		<p class="mt-0.5 text-xs text-zinc-500">
+			{stats.successCount} / {stats.totalOps}
+		</p>
+	{/if}
+</div>
 
-	<!-- Sponsored -->
-	<div class="rounded-lg border border-zinc-800 bg-zinc-800/50 px-4 py-4">
-		<p class="text-xs tracking-wider text-zinc-400 uppercase">Sponsored</p>
-		<p class="mt-1 text-2xl font-semibold tabular-nums">
-			{#if stats}
-				<span class={stats.sponsoredRate > 0 ? 'text-emerald-400' : ''}>
-					{pct(stats.sponsoredRate)}
-				</span>
-			{:else}
-				&mdash;
-			{/if}
+<!-- Sponsored -->
+<div class="rounded-lg border border-zinc-800 bg-zinc-800/50 px-4 py-4">
+	<p class="text-xs tracking-wider text-zinc-400 uppercase">Sponsored</p>
+	<p class="mt-1 text-2xl font-semibold tabular-nums">
+		{#if stats}
+			<span class={stats.sponsoredRate > 0 ? 'text-emerald-400' : ''}>
+				{pct(stats.sponsoredRate)}
+			</span>
+		{:else}
+			{'\u2014'}
+		{/if}
 		</p>
 		{#if stats && stats.totalOps > 0}
 			<p class="mt-0.5 text-xs text-zinc-500">

--- a/frontend/src/lib/indexer.svelte.ts
+++ b/frontend/src/lib/indexer.svelte.ts
@@ -17,6 +17,7 @@ const RECONNECT_DELAY = 3_000;
 const MAX_RECONNECT_DELAY = 30_000;
 const MAX_OPERATIONS = 200;
 const MAX_POLL_FAILURES = 3;
+const STATS_REFRESH_INTERVAL = 30_000;
 
 /** Shape returned by the indexer REST API and WebSocket feed. */
 export interface UserOperation {
@@ -37,6 +38,16 @@ export interface UserOperation {
 
 export type FeedStatus = 'disconnected' | 'connecting' | 'connected' | 'polling';
 
+/** Aggregate statistics returned by GET /api/stats. */
+export interface IndexerStats {
+	totalOps: number;
+	successCount: number;
+	successRate: number;
+	sponsoredCount: number;
+	sponsoredRate: number;
+	uniqueSenders: number;
+}
+
 /**
  * Reactive indexer feed that connects to the WebSocket live feed and falls
  * back to REST API polling when the WebSocket is unavailable.
@@ -47,11 +58,13 @@ export type FeedStatus = 'disconnected' | 'connecting' | 'connected' | 'polling'
  */
 class IndexerFeed {
 	operations = $state<UserOperation[]>([]);
+	stats = $state<IndexerStats | null>(null);
 	status = $state<FeedStatus>('disconnected');
 
 	private ws: WebSocket | null = null;
 	private pollTimer: ReturnType<typeof setInterval> | null = null;
 	private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+	private statsTimer: ReturnType<typeof setInterval> | null = null;
 	private seenHashes = new Set<string>();
 	private abort: AbortController | null = null;
 	private pollFailures = 0;
@@ -65,12 +78,14 @@ class IndexerFeed {
 		this.status = 'connecting';
 		this.loadInitial();
 		this.openWS();
+		this.startStatsRefresh();
 	}
 
 	/** Tear down all connections and timers. */
 	disconnect() {
 		this.stopReconnect();
 		this.stopPolling();
+		this.stopStatsRefresh();
 		this.abort?.abort();
 		this.abort = null;
 		if (this.ws) {
@@ -204,6 +219,31 @@ class IndexerFeed {
 			}
 		} catch {
 			// Will be populated by WS or polling.
+		}
+	}
+
+	// --- stats ---
+
+	private startStatsRefresh() {
+		this.fetchStats();
+		this.statsTimer = setInterval(() => this.fetchStats(), STATS_REFRESH_INTERVAL);
+	}
+
+	private stopStatsRefresh() {
+		if (this.statsTimer !== null) {
+			clearInterval(this.statsTimer);
+			this.statsTimer = null;
+		}
+	}
+
+	private async fetchStats() {
+		const signal = this.abort?.signal;
+		try {
+			const res = await fetch(indexerUrl() + '/api/stats', { signal });
+			if (!res.ok) return;
+			this.stats = (await res.json()) as IndexerStats;
+		} catch {
+			// Silently ignore — stats are non-critical.
 		}
 	}
 

--- a/frontend/src/lib/indexer.svelte.ts
+++ b/frontend/src/lib/indexer.svelte.ts
@@ -68,6 +68,7 @@ class IndexerFeed {
 	private seenHashes = new Set<string>();
 	private abort: AbortController | null = null;
 	private pollFailures = 0;
+	private statsFailures = 0;
 	private reconnectDelay = RECONNECT_DELAY;
 
 	/** Open the WebSocket connection and load initial data from REST. */
@@ -108,6 +109,7 @@ class IndexerFeed {
 				this.status = 'connected';
 				this.reconnectDelay = RECONNECT_DELAY;
 				this.stopPolling();
+				this.startStatsRefresh(); // Restart stats if stopped during outage.
 			};
 
 			ws.onmessage = (e: MessageEvent) => {
@@ -225,6 +227,8 @@ class IndexerFeed {
 	// --- stats ---
 
 	private startStatsRefresh() {
+		if (this.statsTimer !== null) return; // Already running.
+		this.statsFailures = 0;
 		this.fetchStats();
 		this.statsTimer = setInterval(() => this.fetchStats(), STATS_REFRESH_INTERVAL);
 	}
@@ -241,16 +245,24 @@ class IndexerFeed {
 		try {
 			const res = await fetch(indexerUrl() + '/api/stats', { signal });
 			if (!res.ok) {
-				this.stats = null;
+				this.trackStatsFailure();
 				return;
 			}
+			this.statsFailures = 0;
 			this.stats = (await res.json()) as IndexerStats;
 		} catch {
-			// Null out on real failures so the UI shows em-dashes;
-			// ignore AbortError from disconnect().
+			// Ignore AbortError from disconnect(); track real failures.
 			if (!signal?.aborted) {
-				this.stats = null;
+				this.trackStatsFailure();
 			}
+		}
+	}
+
+	private trackStatsFailure() {
+		this.stats = null;
+		this.statsFailures++;
+		if (this.statsFailures >= MAX_POLL_FAILURES) {
+			this.stopStatsRefresh();
 		}
 	}
 

--- a/frontend/src/lib/indexer.svelte.ts
+++ b/frontend/src/lib/indexer.svelte.ts
@@ -240,10 +240,17 @@ class IndexerFeed {
 		const signal = this.abort?.signal;
 		try {
 			const res = await fetch(indexerUrl() + '/api/stats', { signal });
-			if (!res.ok) return;
+			if (!res.ok) {
+				this.stats = null;
+				return;
+			}
 			this.stats = (await res.json()) as IndexerStats;
 		} catch {
-			// Silently ignore — stats are non-critical.
+			// Null out on real failures so the UI shows em-dashes;
+			// ignore AbortError from disconnect().
+			if (!signal?.aborted) {
+				this.stats = null;
+			}
 		}
 	}
 

--- a/frontend/src/lib/indexer.svelte.ts
+++ b/frontend/src/lib/indexer.svelte.ts
@@ -182,6 +182,7 @@ class IndexerFeed {
 				return;
 			}
 			this.pollFailures = 0;
+			this.startStatsRefresh(); // REST is alive — restart stats if stopped.
 			const body: { data: UserOperation[] } = await res.json();
 			// REST returns newest first; reverse so addOperation prepends correctly.
 			for (const op of body.data.reverse()) {

--- a/frontend/src/routes/indexer/+page.svelte
+++ b/frontend/src/routes/indexer/+page.svelte
@@ -8,6 +8,7 @@
 		truncateHex,
 		type FeedStatus
 	} from '$lib/indexer.svelte';
+	import StatsPanel from '$lib/components/StatsPanel.svelte';
 
 	$effect(() => {
 		feed.connect();
@@ -64,6 +65,9 @@
 			{statusLabel[feed.status]}
 		</div>
 	</div>
+
+	<!-- Stats -->
+	<StatsPanel stats={feed.stats} />
 
 	{#if feed.operations.length === 0}
 		<div class="rounded-lg border border-zinc-800 bg-zinc-800/50 py-16 text-center">

--- a/indexer/internal/api/handler.go
+++ b/indexer/internal/api/handler.go
@@ -122,16 +122,19 @@ func (h *Handler) GetStats(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var rate float64
+	var successRate, sponsoredRate float64
 	if s.TotalOps > 0 {
-		rate = float64(s.SuccessCount) / float64(s.TotalOps)
+		successRate = float64(s.SuccessCount) / float64(s.TotalOps)
+		sponsoredRate = float64(s.SponsoredCount) / float64(s.TotalOps)
 	}
 
 	writeJSON(w, http.StatusOK, statsResponse{
-		TotalOps:      s.TotalOps,
-		SuccessCount:  s.SuccessCount,
-		SuccessRate:   rate,
-		UniqueSenders: s.UniqueSenders,
+		TotalOps:       s.TotalOps,
+		SuccessCount:   s.SuccessCount,
+		SuccessRate:    successRate,
+		SponsoredCount: s.SponsoredCount,
+		SponsoredRate:  sponsoredRate,
+		UniqueSenders:  s.UniqueSenders,
 	})
 }
 
@@ -161,10 +164,12 @@ type listResponse struct {
 }
 
 type statsResponse struct {
-	TotalOps      int64   `json:"totalOps"`
-	SuccessCount  int64   `json:"successCount"`
-	SuccessRate   float64 `json:"successRate"`
-	UniqueSenders int64   `json:"uniqueSenders"`
+	TotalOps       int64   `json:"totalOps"`
+	SuccessCount   int64   `json:"successCount"`
+	SuccessRate    float64 `json:"successRate"`
+	SponsoredCount int64   `json:"sponsoredCount"`
+	SponsoredRate  float64 `json:"sponsoredRate"`
+	UniqueSenders  int64   `json:"uniqueSenders"`
 }
 
 func toResponse(op db.UserOperation) operationResponse {

--- a/indexer/internal/api/handler_test.go
+++ b/indexer/internal/api/handler_test.go
@@ -560,9 +560,10 @@ func TestGetStatsHappyPath(t *testing.T) {
 
 	store := &stubStore{
 		stats: db.Stats{
-			TotalOps:      100,
-			SuccessCount:  75,
-			UniqueSenders: 10,
+			TotalOps:       100,
+			SuccessCount:   75,
+			SponsoredCount: 40,
+			UniqueSenders:  10,
 		},
 	}
 	mux := newTestMux(store)
@@ -588,12 +589,19 @@ func TestGetStatsHappyPath(t *testing.T) {
 	if got.SuccessCount != 75 {
 		t.Fatalf("successCount = %d, want 75", got.SuccessCount)
 	}
+	if got.SponsoredCount != 40 {
+		t.Fatalf("sponsoredCount = %d, want 40", got.SponsoredCount)
+	}
 	if got.UniqueSenders != 10 {
 		t.Fatalf("uniqueSenders = %d, want 10", got.UniqueSenders)
 	}
-	wantRate := 0.75
-	if got.SuccessRate != wantRate {
-		t.Fatalf("successRate = %f, want %f", got.SuccessRate, wantRate)
+	wantSuccessRate := 0.75
+	if got.SuccessRate != wantSuccessRate {
+		t.Fatalf("successRate = %f, want %f", got.SuccessRate, wantSuccessRate)
+	}
+	wantSponsoredRate := 0.4
+	if got.SponsoredRate != wantSponsoredRate {
+		t.Fatalf("sponsoredRate = %f, want %f", got.SponsoredRate, wantSponsoredRate)
 	}
 }
 
@@ -620,6 +628,12 @@ func TestGetStatsZeroOps(t *testing.T) {
 	}
 	if got.SuccessRate != 0 {
 		t.Fatalf("successRate = %f, want 0 (avoid division by zero)", got.SuccessRate)
+	}
+	if got.SponsoredCount != 0 {
+		t.Fatalf("sponsoredCount = %d, want 0", got.SponsoredCount)
+	}
+	if got.SponsoredRate != 0 {
+		t.Fatalf("sponsoredRate = %f, want 0 (avoid division by zero)", got.SponsoredRate)
 	}
 }
 

--- a/indexer/internal/api/handler_test.go
+++ b/indexer/internal/api/handler_test.go
@@ -4,12 +4,19 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/flwrenn/bastion/indexer/internal/db"
 )
+
+const floatEps = 1e-9
+
+func approxEqual(a, b float64) bool {
+	return math.Abs(a-b) < floatEps
+}
 
 func TestEncodeHex(t *testing.T) {
 	t.Parallel()
@@ -595,13 +602,11 @@ func TestGetStatsHappyPath(t *testing.T) {
 	if got.UniqueSenders != 10 {
 		t.Fatalf("uniqueSenders = %d, want 10", got.UniqueSenders)
 	}
-	wantSuccessRate := 0.75
-	if got.SuccessRate != wantSuccessRate {
-		t.Fatalf("successRate = %f, want %f", got.SuccessRate, wantSuccessRate)
+	if !approxEqual(got.SuccessRate, 0.75) {
+		t.Fatalf("successRate = %f, want ~0.75", got.SuccessRate)
 	}
-	wantSponsoredRate := 0.4
-	if got.SponsoredRate != wantSponsoredRate {
-		t.Fatalf("sponsoredRate = %f, want %f", got.SponsoredRate, wantSponsoredRate)
+	if !approxEqual(got.SponsoredRate, 0.4) {
+		t.Fatalf("sponsoredRate = %f, want ~0.4", got.SponsoredRate)
 	}
 }
 
@@ -626,13 +631,13 @@ func TestGetStatsZeroOps(t *testing.T) {
 	if got.TotalOps != 0 {
 		t.Fatalf("totalOps = %d, want 0", got.TotalOps)
 	}
-	if got.SuccessRate != 0 {
+	if !approxEqual(got.SuccessRate, 0) {
 		t.Fatalf("successRate = %f, want 0 (avoid division by zero)", got.SuccessRate)
 	}
 	if got.SponsoredCount != 0 {
 		t.Fatalf("sponsoredCount = %d, want 0", got.SponsoredCount)
 	}
-	if got.SponsoredRate != 0 {
+	if !approxEqual(got.SponsoredRate, 0) {
 		t.Fatalf("sponsoredRate = %f, want 0 (avoid division by zero)", got.SponsoredRate)
 	}
 }

--- a/indexer/internal/db/queries.go
+++ b/indexer/internal/db/queries.go
@@ -169,7 +169,8 @@ type Stats struct {
 
 // zeroPaymaster is the 20-byte zero address used to identify self-funded
 // (non-sponsored) operations. Any other paymaster value is considered sponsored.
-// Fixed-size array prevents accidental mutation of the sentinel value.
+// Declared as a fixed-size array so each [:] call produces a fresh slice header
+// without risk of append or reslice changing the underlying length.
 var zeroPaymaster = [20]byte{}
 
 // GetStats returns aggregate statistics across all indexed operations.

--- a/indexer/internal/db/queries.go
+++ b/indexer/internal/db/queries.go
@@ -169,7 +169,8 @@ type Stats struct {
 
 // zeroPaymaster is the 20-byte zero address used to identify self-funded
 // (non-sponsored) operations. Any other paymaster value is considered sponsored.
-var zeroPaymaster = make([]byte, 20)
+// Fixed-size array prevents accidental mutation of the sentinel value.
+var zeroPaymaster = [20]byte{}
 
 // GetStats returns aggregate statistics across all indexed operations.
 func GetStats(ctx context.Context, pool *pgxpool.Pool) (Stats, error) {
@@ -183,7 +184,7 @@ func GetStats(ctx context.Context, pool *pgxpool.Pool) (Stats, error) {
 		       count(*) FILTER (WHERE paymaster != $1),
 		       count(DISTINCT sender)
 		FROM user_operations`,
-		zeroPaymaster,
+		zeroPaymaster[:],
 	).Scan(&s.TotalOps, &s.SuccessCount, &s.SponsoredCount, &s.UniqueSenders)
 	if err != nil {
 		return Stats{}, fmt.Errorf("query stats: %w", err)

--- a/indexer/internal/db/queries.go
+++ b/indexer/internal/db/queries.go
@@ -161,10 +161,15 @@ func GetOperationByHash(ctx context.Context, pool *pgxpool.Pool, hash []byte) (*
 
 // Stats holds aggregate statistics for indexed user operations.
 type Stats struct {
-	TotalOps      int64
-	SuccessCount  int64
-	UniqueSenders int64
+	TotalOps       int64
+	SuccessCount   int64
+	SponsoredCount int64
+	UniqueSenders  int64
 }
+
+// zeroPaymaster is the 20-byte zero address used to identify self-funded
+// (non-sponsored) operations. Any other paymaster value is considered sponsored.
+var zeroPaymaster = make([]byte, 20)
 
 // GetStats returns aggregate statistics across all indexed operations.
 func GetStats(ctx context.Context, pool *pgxpool.Pool) (Stats, error) {
@@ -175,9 +180,11 @@ func GetStats(ctx context.Context, pool *pgxpool.Pool) (Stats, error) {
 	err := pool.QueryRow(ctx, `
 		SELECT count(*),
 		       count(*) FILTER (WHERE success),
+		       count(*) FILTER (WHERE paymaster != $1),
 		       count(DISTINCT sender)
 		FROM user_operations`,
-	).Scan(&s.TotalOps, &s.SuccessCount, &s.UniqueSenders)
+		zeroPaymaster,
+	).Scan(&s.TotalOps, &s.SuccessCount, &s.SponsoredCount, &s.UniqueSenders)
 	if err != nil {
 		return Stats{}, fmt.Errorf("query stats: %w", err)
 	}

--- a/indexer/internal/db/queries_integration_test.go
+++ b/indexer/internal/db/queries_integration_test.go
@@ -13,13 +13,14 @@ import (
 // testPool creates an isolated Postgres schema for the test, runs migrations
 // inside it, and returns a pool with search_path pinned to that schema.
 // The schema is dropped on test cleanup, so no shared data is touched.
-// Skips the test when DATABASE_URL is not set.
+// Skips the test when TEST_DATABASE_URL is not set; uses a dedicated env var
+// to avoid accidentally running against a dev/production database.
 func testPool(t *testing.T) *pgxpool.Pool {
 	t.Helper()
 
-	dsn := os.Getenv("DATABASE_URL")
+	dsn := os.Getenv("TEST_DATABASE_URL")
 	if dsn == "" {
-		t.Skip("DATABASE_URL not set — skipping integration test")
+		t.Skip("TEST_DATABASE_URL not set — skipping integration test")
 	}
 
 	ctx := context.Background()

--- a/indexer/internal/db/queries_integration_test.go
+++ b/indexer/internal/db/queries_integration_test.go
@@ -2,14 +2,18 @@ package db
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
-// testPool connects to a real Postgres and runs migrations.
-// It skips the test when DATABASE_URL is not set.
+// testPool creates an isolated Postgres schema for the test, runs migrations
+// inside it, and returns a pool with search_path pinned to that schema.
+// The schema is dropped on test cleanup, so no shared data is touched.
+// Skips the test when DATABASE_URL is not set.
 func testPool(t *testing.T) *pgxpool.Pool {
 	t.Helper()
 
@@ -19,15 +23,45 @@ func testPool(t *testing.T) *pgxpool.Pool {
 	}
 
 	ctx := context.Background()
-	pool, err := pgxpool.New(ctx, dsn)
+	schema := fmt.Sprintf("test_%d", time.Now().UnixNano())
+
+	// Bootstrap: connect with default search_path to create the schema.
+	bootstrap, err := pgxpool.New(ctx, dsn)
 	if err != nil {
-		t.Fatalf("connect to test database: %v", err)
+		t.Fatalf("bootstrap connection: %v", err)
 	}
-	t.Cleanup(pool.Close)
+	if _, err := bootstrap.Exec(ctx, fmt.Sprintf("CREATE SCHEMA %q", schema)); err != nil {
+		bootstrap.Close()
+		t.Fatalf("create test schema: %v", err)
+	}
+	bootstrap.Close()
+
+	// Create a pool with search_path pinned to the isolated schema.
+	config, err := pgxpool.ParseConfig(dsn)
+	if err != nil {
+		t.Fatalf("parse DSN: %v", err)
+	}
+	config.ConnConfig.RuntimeParams["search_path"] = schema
+
+	pool, err := pgxpool.NewWithConfig(ctx, config)
+	if err != nil {
+		t.Fatalf("create pool with test schema: %v", err)
+	}
 
 	if err := Migrate(ctx, pool); err != nil {
+		pool.Close()
 		t.Fatalf("run migrations: %v", err)
 	}
+
+	t.Cleanup(func() {
+		pool.Close()
+		// Drop the test schema using a fresh connection.
+		cleanup, err := pgxpool.New(context.Background(), dsn)
+		if err == nil {
+			cleanup.Exec(context.Background(), fmt.Sprintf("DROP SCHEMA %q CASCADE", schema))
+			cleanup.Close()
+		}
+	})
 
 	return pool
 }
@@ -35,14 +69,6 @@ func testPool(t *testing.T) *pgxpool.Pool {
 func TestGetStatsIntegration(t *testing.T) {
 	pool := testPool(t)
 	ctx := context.Background()
-
-	// Clean slate — delete all existing operations so counts are deterministic.
-	if _, err := pool.Exec(ctx, "DELETE FROM user_operations"); err != nil {
-		t.Fatalf("clean user_operations: %v", err)
-	}
-	t.Cleanup(func() {
-		pool.Exec(context.Background(), "DELETE FROM user_operations WHERE block_number BETWEEN 900000 AND 900001")
-	})
 
 	// Distinct senders and paymasters.
 	senderA := make([]byte, 20)

--- a/indexer/internal/db/queries_integration_test.go
+++ b/indexer/internal/db/queries_integration_test.go
@@ -1,0 +1,126 @@
+package db
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// testPool connects to a real Postgres and runs migrations.
+// It skips the test when DATABASE_URL is not set.
+func testPool(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+
+	dsn := os.Getenv("DATABASE_URL")
+	if dsn == "" {
+		t.Skip("DATABASE_URL not set — skipping integration test")
+	}
+
+	ctx := context.Background()
+	pool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		t.Fatalf("connect to test database: %v", err)
+	}
+	t.Cleanup(pool.Close)
+
+	if err := Migrate(ctx, pool); err != nil {
+		t.Fatalf("run migrations: %v", err)
+	}
+
+	return pool
+}
+
+func TestGetStatsIntegration(t *testing.T) {
+	pool := testPool(t)
+	ctx := context.Background()
+
+	// Clean slate — delete all existing operations so counts are deterministic.
+	if _, err := pool.Exec(ctx, "DELETE FROM user_operations"); err != nil {
+		t.Fatalf("clean user_operations: %v", err)
+	}
+	t.Cleanup(func() {
+		pool.Exec(context.Background(), "DELETE FROM user_operations WHERE block_number BETWEEN 900000 AND 900001")
+	})
+
+	// Distinct senders and paymasters.
+	senderA := make([]byte, 20)
+	senderA[19] = 0x0A
+	senderB := make([]byte, 20)
+	senderB[19] = 0x0B
+	senderC := make([]byte, 20)
+	senderC[19] = 0x0C
+
+	noPaymaster := make([]byte, 20) // all zeros = self-funded
+	paymaster1 := make([]byte, 20)
+	paymaster1[19] = 0xFF
+
+	// Insert 5 operations with mixed paymaster and success values:
+	//
+	//  #  | success | paymaster    | sender
+	//  ---|---------|--------------|-------
+	//  1  | true    | zero         | A
+	//  2  | true    | zero         | A
+	//  3  | true    | paymaster1   | B        <- sponsored
+	//  4  | false   | zero         | C
+	//  5  | false   | paymaster1   | B        <- sponsored
+	//
+	// Expected: total=5, success=3, sponsored=2, unique_senders=3
+	ops := []UserOperation{
+		testIntOp(senderA, noPaymaster, true, 900000, 0),
+		testIntOp(senderA, noPaymaster, true, 900000, 1),
+		testIntOp(senderB, paymaster1, true, 900001, 0),
+		testIntOp(senderC, noPaymaster, false, 900001, 1),
+		testIntOp(senderB, paymaster1, false, 900001, 2),
+	}
+
+	err := ReplaceOperationsAndSetCursor(ctx, pool, "test_cursor", 900000, 900001, 900001, ops)
+	if err != nil {
+		t.Fatalf("insert test operations: %v", err)
+	}
+
+	got, err := GetStats(ctx, pool)
+	if err != nil {
+		t.Fatalf("GetStats: %v", err)
+	}
+
+	if got.TotalOps != 5 {
+		t.Errorf("TotalOps = %d, want 5", got.TotalOps)
+	}
+	if got.SuccessCount != 3 {
+		t.Errorf("SuccessCount = %d, want 3", got.SuccessCount)
+	}
+	if got.SponsoredCount != 2 {
+		t.Errorf("SponsoredCount = %d, want 2", got.SponsoredCount)
+	}
+	if got.UniqueSenders != 3 {
+		t.Errorf("UniqueSenders = %d, want 3", got.UniqueSenders)
+	}
+}
+
+// testIntOp builds a minimal UserOperation for integration testing.
+func testIntOp(sender, paymaster []byte, success bool, block int64, logIdx int32) UserOperation {
+	hash := make([]byte, 32)
+	hash[0] = byte(block)
+	hash[1] = byte(logIdx)
+
+	txHash := make([]byte, 32)
+	txHash[0] = byte(block >> 8)
+	txHash[1] = byte(block)
+	txHash[2] = byte(logIdx)
+
+	return UserOperation{
+		UserOpHash:     hash,
+		Sender:         sender,
+		Paymaster:      paymaster,
+		Nonce:          "0",
+		Success:        success,
+		ActualGasCost:  "21000",
+		ActualGasUsed:  "21000",
+		TxHash:         txHash,
+		BlockNumber:    block,
+		BlockTimestamp: 1700000000 + block,
+		LogIndex:       logIdx,
+	}
+}


### PR DESCRIPTION
## What

Add a stats panel to the indexer dashboard showing aggregate statistics fetched from `GET /api/stats`, auto-refreshed every 30 seconds.

## Why

Exam requirement: the frontend must include a basic stats panel showing total UserOps indexed, success rate, and % sponsored by a paymaster.

## Scope

- [x] Backend
- [x] Frontend

## How to verify

1. Run the indexer with a populated database
2. Navigate to `/indexer`
3. Verify the 4-card stats panel renders above the live feed: Total UserOps, Success Rate, Sponsored %, Unique Senders
4. Confirm stats auto-refresh (30s interval) and show em-dashes when the indexer is unreachable

## Related issues

Closes #21