### PR TITLE
feat(frontend): add session key interaction page

### DIFF
--- a/frontend/src/lib/smartAccount.ts
+++ b/frontend/src/lib/smartAccount.ts
@@ -1,12 +1,24 @@
 /**
- * Custom smart account adapter for the Bastion SmartAccount contract.
+ * Custom smart account adapters for the Bastion SmartAccount contract.
  *
- * Replaces permissionless.js's generic `toSimpleSmartAccount` with an adapter
- * built on viem's `toSmartAccount` that uses the project's own SmartAccount and
- * SmartAccountFactory ABIs for call encoding, factory initCode, and UserOp signing.
+ * Two variants:
+ * - `toBastionSmartAccount` — owner flow, signs via WalletClient (MetaMask)
+ * - `toSessionKeySmartAccount` — session key flow, signs via LocalAccount (private key)
+ *
+ * Both use the project's SmartAccount and SmartAccountFactory ABIs for call
+ * encoding, factory initCode, and UserOp signing against EntryPoint v0.7.
  */
 
-import type { Address, Chain, Client, Transport, WalletClient, Account } from 'viem';
+import type {
+	Address,
+	Chain,
+	Client,
+	Hex,
+	LocalAccount,
+	Transport,
+	WalletClient,
+	Account
+} from 'viem';
 import { encodeFunctionData } from 'viem';
 import {
 	type SmartAccount,
@@ -20,41 +32,27 @@ import { getChainId } from 'viem/actions';
 import { SmartAccountAbi } from '$lib/contracts/SmartAccount';
 import { SmartAccountFactoryAbi } from '$lib/contracts/SmartAccountFactory';
 
-export type ToBastionSmartAccountParameters = {
-	/** Public client for on-chain reads and chain ID resolution. */
-	client: Client<Transport, Chain | undefined>;
-	/** Owner wallet client — signs UserOps via the connected wallet (e.g. MetaMask). */
-	owner: WalletClient<Transport, Chain | undefined, Account>;
-	/** Deployed SmartAccountFactory address. */
-	factoryAddress: Address;
-	/** CREATE2 salt (default 0). */
-	salt?: bigint;
-	/** Pre-computed counterfactual address (from factory.getAddress). */
-	accountAddress: Address;
+// ── Shared internals ────────────────────────────────────────────────
+
+const entryPoint = {
+	address: entryPoint07Address,
+	abi: entryPoint07Abi,
+	version: '0.7' as const
 };
 
-/**
- * Create a viem `SmartAccount` adapter for the Bastion SmartAccount contract.
- *
- * - Encodes `execute` / `executeBatch` calls using the SmartAccount ABI.
- * - Generates factory initCode using the SmartAccountFactory ABI.
- * - Signs UserOperations with ECDSA via the owner's wallet.
- * - Targets EntryPoint v0.7.
- */
-export async function toBastionSmartAccount(
-	parameters: ToBastionSmartAccountParameters
-): Promise<SmartAccount> {
-	const { client, owner, factoryAddress, salt = 0n, accountAddress } = parameters;
+type SharedParams = {
+	client: Client<Transport, Chain | undefined>;
+	factoryAddress: Address;
+	ownerAddress: Address;
+	salt: bigint;
+	accountAddress: Address;
+	signHash: (hash: Hex) => Promise<Hex>;
+};
 
-	const ownerAddress = owner.account.address;
+/** Build the SmartAccount adapter with a generic signing function. */
+async function buildSmartAccount(params: SharedParams): Promise<SmartAccount> {
+	const { client, factoryAddress, ownerAddress, salt, accountAddress, signHash } = params;
 
-	const entryPoint = {
-		address: entryPoint07Address,
-		abi: entryPoint07Abi,
-		version: '0.7' as const
-	};
-
-	// Memoised chain ID — resolved once, reused for all subsequent UserOp signatures.
 	let resolvedChainId: number | undefined;
 
 	const getResolvedChainId = async (): Promise<number> => {
@@ -106,7 +104,6 @@ export async function toBastionSmartAccount(
 		},
 
 		async getStubSignature() {
-			// 65-byte dummy ECDSA signature used for gas estimation.
 			return '0xfffffffffffffffffffffffffffffff0000000000000000000000000000000007aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1c';
 		},
 
@@ -133,9 +130,75 @@ export async function toBastionSmartAccount(
 				chainId
 			});
 
-			return owner.signMessage({
-				message: { raw: hash }
-			});
+			return signHash(hash);
 		}
+	});
+}
+
+// ── Owner adapter (WalletClient) ────────────────────────────────────
+
+export type ToBastionSmartAccountParameters = {
+	/** Public client for on-chain reads and chain ID resolution. */
+	client: Client<Transport, Chain | undefined>;
+	/** Owner wallet client — signs UserOps via the connected wallet (e.g. MetaMask). */
+	owner: WalletClient<Transport, Chain | undefined, Account>;
+	/** Deployed SmartAccountFactory address. */
+	factoryAddress: Address;
+	/** CREATE2 salt (default 0). */
+	salt?: bigint;
+	/** Pre-computed counterfactual address (from factory.getAddress). */
+	accountAddress: Address;
+};
+
+/**
+ * Create a SmartAccount adapter for the owner flow.
+ * Signs UserOperations via the owner's connected wallet (e.g. MetaMask).
+ */
+export async function toBastionSmartAccount(
+	parameters: ToBastionSmartAccountParameters
+): Promise<SmartAccount> {
+	const { client, owner, factoryAddress, salt = 0n, accountAddress } = parameters;
+
+	return buildSmartAccount({
+		client,
+		factoryAddress,
+		ownerAddress: owner.account.address,
+		salt,
+		accountAddress,
+		signHash: (hash) => owner.signMessage({ message: { raw: hash } })
+	});
+}
+
+// ── Session key adapter (LocalAccount) ──────────────────────────────
+
+export type ToSessionKeySmartAccountParameters = {
+	/** Public client for on-chain reads and chain ID resolution. */
+	client: Client<Transport, Chain | undefined>;
+	/** Session key local account (signs UserOps with the private key). */
+	sessionKey: LocalAccount;
+	/** Deployed SmartAccountFactory address. */
+	factoryAddress: Address;
+	/** Owner address (needed for factory initCode, though account is already deployed). */
+	ownerAddress: Address;
+	/** Pre-computed SmartAccount address. */
+	accountAddress: Address;
+};
+
+/**
+ * Create a SmartAccount adapter for the session key flow.
+ * Signs UserOperations locally with the session key's private key.
+ */
+export async function toSessionKeySmartAccount(
+	parameters: ToSessionKeySmartAccountParameters
+): Promise<SmartAccount> {
+	const { client, sessionKey, factoryAddress, ownerAddress, accountAddress } = parameters;
+
+	return buildSmartAccount({
+		client,
+		factoryAddress,
+		ownerAddress,
+		salt: 0n,
+		accountAddress,
+		signHash: (hash) => sessionKey.signMessage({ message: { raw: hash } })
 	});
 }

--- a/frontend/src/lib/userOp.ts
+++ b/frontend/src/lib/userOp.ts
@@ -118,14 +118,14 @@ export async function sendRawUserOp(
  * @param sessionKey      Local account holding the session key private key.
  * @param ownerAddress    Owner of the SmartAccount (needed for factory args).
  * @param accountAddress  Deployed SmartAccount address.
- * @param calls           One or more calls to execute.
+ * @param call            Single call to execute (session key validation requires `execute`, not `executeBatch`).
  * @returns               The UserOp hash, on-chain tx hash, and whether it succeeded.
  */
 export async function sendSessionKeyUserOp(
 	sessionKey: LocalAccount,
 	ownerAddress: Address,
 	accountAddress: Address,
-	calls: UserOpCall[]
+	call: UserOpCall
 ): Promise<UserOpResult> {
 	const smartAccount = await toSessionKeySmartAccount({
 		client: publicClient,
@@ -137,7 +137,7 @@ export async function sendSessionKeyUserOp(
 
 	const bundlerClient = await createBundlerClientFor(smartAccount);
 
-	const hash = await bundlerClient.sendUserOperation({ calls });
+	const hash = await bundlerClient.sendUserOperation({ calls: [call] });
 	const receipt = await bundlerClient.waitForUserOperationReceipt({ hash });
 
 	return {

--- a/frontend/src/lib/userOp.ts
+++ b/frontend/src/lib/userOp.ts
@@ -5,13 +5,14 @@
  * sends the UserOp, and waits for the on-chain receipt.
  */
 
-import type { Account, Chain, Hex, Transport, WalletClient } from 'viem';
+import type { Account, Address, Chain, Hex, LocalAccount, Transport, WalletClient } from 'viem';
 import { http } from 'viem';
 import { sepolia } from 'viem/chains';
+import type { SmartAccount } from 'viem/account-abstraction';
 import { createPaymasterClient } from 'viem/account-abstraction';
 import { createSmartAccountClient } from 'permissionless';
 import { publicClient } from '$lib/wallet.svelte';
-import { toBastionSmartAccount } from '$lib/smartAccount';
+import { toBastionSmartAccount, toSessionKeySmartAccount } from '$lib/smartAccount';
 import { factoryAddress, pimlicoUrl } from '$lib/config';
 
 export type UserOpCall = {
@@ -26,10 +27,26 @@ export type UserOpResult = {
 	success: boolean;
 };
 
-/** Create a SmartAccountClient (bundler + paymaster) for the given owner. */
-async function createBundlerClient(
+/** Create a SmartAccountClient (bundler + paymaster) for a given SmartAccount adapter. */
+async function createBundlerClientFor(account: SmartAccount) {
+	const pimlico = pimlicoUrl();
+
+	const paymaster = createPaymasterClient({
+		transport: http(pimlico)
+	});
+
+	return createSmartAccountClient({
+		account,
+		paymaster,
+		chain: sepolia,
+		bundlerTransport: http(pimlico)
+	});
+}
+
+/** Create a SmartAccountClient for the owner flow (signs via WalletClient). */
+async function createOwnerBundlerClient(
 	owner: WalletClient<Transport, Chain, Account>,
-	accountAddress: `0x${string}`
+	accountAddress: Address
 ) {
 	const smartAccount = await toBastionSmartAccount({
 		client: publicClient,
@@ -38,18 +55,7 @@ async function createBundlerClient(
 		accountAddress
 	});
 
-	const pimlico = pimlicoUrl();
-
-	const paymaster = createPaymasterClient({
-		transport: http(pimlico)
-	});
-
-	return createSmartAccountClient({
-		account: smartAccount,
-		paymaster,
-		chain: sepolia,
-		bundlerTransport: http(pimlico)
-	});
+	return createBundlerClientFor(smartAccount);
 }
 
 /**
@@ -66,7 +72,7 @@ export async function sendUserOp(
 	accountAddress: `0x${string}`,
 	calls: UserOpCall[]
 ): Promise<UserOpResult> {
-	const bundlerClient = await createBundlerClient(owner, accountAddress);
+	const bundlerClient = await createOwnerBundlerClient(owner, accountAddress);
 
 	const hash = await bundlerClient.sendUserOperation({ calls });
 	const receipt = await bundlerClient.waitForUserOperationReceipt({ hash });
@@ -90,12 +96,48 @@ export async function sendUserOp(
  */
 export async function sendRawUserOp(
 	owner: WalletClient<Transport, Chain, Account>,
-	accountAddress: `0x${string}`,
+	accountAddress: Address,
 	callData: Hex
 ): Promise<UserOpResult> {
-	const bundlerClient = await createBundlerClient(owner, accountAddress);
+	const bundlerClient = await createOwnerBundlerClient(owner, accountAddress);
 
 	const hash = await bundlerClient.sendUserOperation({ callData });
+	const receipt = await bundlerClient.waitForUserOperationReceipt({ hash });
+
+	return {
+		userOpHash: hash,
+		txHash: receipt.receipt.transactionHash,
+		success: receipt.success
+	};
+}
+
+/**
+ * Send a UserOperation signed by a session key (LocalAccount).
+ * Calls are encoded via `execute` — session key validation requires this encoding.
+ *
+ * @param sessionKey      Local account holding the session key private key.
+ * @param ownerAddress    Owner of the SmartAccount (needed for factory args).
+ * @param accountAddress  Deployed SmartAccount address.
+ * @param calls           One or more calls to execute.
+ * @returns               The UserOp hash, on-chain tx hash, and whether it succeeded.
+ */
+export async function sendSessionKeyUserOp(
+	sessionKey: LocalAccount,
+	ownerAddress: Address,
+	accountAddress: Address,
+	calls: UserOpCall[]
+): Promise<UserOpResult> {
+	const smartAccount = await toSessionKeySmartAccount({
+		client: publicClient,
+		sessionKey,
+		factoryAddress: factoryAddress(),
+		ownerAddress,
+		accountAddress
+	});
+
+	const bundlerClient = await createBundlerClientFor(smartAccount);
+
+	const hash = await bundlerClient.sendUserOperation({ calls });
 	const receipt = await bundlerClient.waitForUserOperationReceipt({ hash });
 
 	return {

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -12,6 +12,7 @@
 	<header class="flex items-center justify-between border-b border-zinc-800 px-6 py-4">
 		<nav class="flex items-center gap-6">
 			<a href="/" class="text-lg font-semibold tracking-tight">Bastion</a>
+			<a href="/session" class="text-sm text-zinc-400 hover:text-zinc-200">Session</a>
 			<a href="/indexer" class="text-sm text-zinc-400 hover:text-zinc-200">Indexer</a>
 		</nav>
 		<ConnectButton />

--- a/frontend/src/routes/session/+page.svelte
+++ b/frontend/src/routes/session/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { onDestroy, onMount } from 'svelte';
 	import { isAddress, type Hex } from 'viem';
-	import { privateKeyToAccount } from 'viem/accounts';
+	import { type LocalAccount, privateKeyToAccount } from 'viem/accounts';
 	import { publicClient } from '$lib/wallet.svelte';
 	import { SmartAccountAbi } from '$lib/contracts/SmartAccount';
 	import { sendSessionKeyUserOp } from '$lib/userOp';
@@ -35,6 +35,8 @@
 
 	let keyInfo = $state<SessionKeyInfo | null>(null);
 	let ownerAddress = $state<`0x${string}` | null>(null);
+	/** LocalAccount derived at load time — reused for signing to prevent mismatch. */
+	let loadedAccount = $state<LocalAccount | null>(null);
 	let loading = $state(false);
 	let loadError = $state<string | null>(null);
 
@@ -90,6 +92,7 @@
 		loadError = null;
 		keyInfo = null;
 		ownerAddress = null;
+		loadedAccount = null;
 		lastUserOpHash = null;
 		lastTxHash = null;
 		sendError = null;
@@ -119,6 +122,7 @@
 			}
 
 			ownerAddress = owner;
+			loadedAccount = account;
 			keyInfo = {
 				address: account.address,
 				allowedTarget,
@@ -137,9 +141,7 @@
 	// ── Execute allowed action ──────────────────────────────────────────
 
 	async function execute() {
-		if (!keyInfo || !ownerAddress || !canExecute) return;
-
-		const account = privateKeyToAccount(privateKeyInput as `0x${string}`);
+		if (!keyInfo || !ownerAddress || !loadedAccount || !canExecute) return;
 
 		sending = true;
 		sendError = null;
@@ -148,7 +150,7 @@
 
 		try {
 			const result = await sendSessionKeyUserOp(
-				account,
+				loadedAccount,
 				ownerAddress,
 				accountAddress as `0x${string}`,
 				{

--- a/frontend/src/routes/session/+page.svelte
+++ b/frontend/src/routes/session/+page.svelte
@@ -1,12 +1,16 @@
 <script lang="ts">
-	import { isAddress, encodeFunctionData, type Hex } from 'viem';
+	import { onDestroy } from 'svelte';
+	import { isAddress, type Hex } from 'viem';
 	import { privateKeyToAccount } from 'viem/accounts';
 	import { publicClient } from '$lib/wallet.svelte';
 	import { SmartAccountAbi } from '$lib/contracts/SmartAccount';
 	import { sendSessionKeyUserOp } from '$lib/userOp';
 	import { etherscanTx, truncateHex } from '$lib/explorer';
 
-	// ── Known selectors (for display) ───────────────────────────────────
+	// ── Known selectors ─────────────────────────────────────────────────
+
+	/** Selectors that take no arguments — safe to execute with just the 4-byte selector. */
+	const NO_ARG_SELECTORS = new Set(['0xd09de08a', '0x4e71d92d']);
 
 	const SELECTOR_LABELS: Record<string, string> = {
 		'0xd09de08a': 'increment()',
@@ -41,18 +45,27 @@
 	let lastUserOpHash = $state<`0x${string}` | null>(null);
 	let lastTxHash = $state<`0x${string}` | null>(null);
 
+	// ── Live clock for expiry tracking ──────────────────────────────────
+
+	let now = $state(Date.now() / 1000);
+	const timer = setInterval(() => (now = Date.now() / 1000), 1000);
+	onDestroy(() => clearInterval(timer));
+
 	// ── Derived ─────────────────────────────────────────────────────────
 
 	const isActive = $derived(
 		keyInfo !== null &&
 			keyInfo.validUntil > 0 &&
-			Date.now() / 1000 >= keyInfo.validAfter &&
-			Date.now() / 1000 < keyInfo.validUntil
+			now >= keyInfo.validAfter &&
+			now < keyInfo.validUntil
 	);
 
 	const selectorLabel = $derived(
 		keyInfo ? (SELECTOR_LABELS[keyInfo.allowedSelector] ?? keyInfo.allowedSelector) : ''
 	);
+
+	/** Whether the allowed function can be executed (no-arg selectors only). */
+	const canExecute = $derived(keyInfo !== null && NO_ARG_SELECTORS.has(keyInfo.allowedSelector));
 
 	// ── Load session key from contract ──────────────────────────────────
 
@@ -77,7 +90,6 @@
 		try {
 			const account = privateKeyToAccount(privateKeyInput as `0x${string}`);
 
-			// Read session key data and owner in parallel.
 			const [skData, owner] = await Promise.all([
 				publicClient.readContract({
 					address: accountAddress as `0x${string}`,
@@ -118,7 +130,7 @@
 	// ── Execute allowed action ──────────────────────────────────────────
 
 	async function execute() {
-		if (!keyInfo || !ownerAddress) return;
+		if (!keyInfo || !ownerAddress || !canExecute) return;
 
 		const account = privateKeyToAccount(privateKeyInput as `0x${string}`);
 
@@ -128,22 +140,15 @@
 		lastTxHash = null;
 
 		try {
-			// Build the inner call data from the allowed selector.
-			// For no-arg functions (increment, claim), the selector IS the full calldata.
-			// For functions with args, this would need additional encoding.
-			const innerData: Hex = keyInfo.allowedSelector as Hex;
-
 			const result = await sendSessionKeyUserOp(
 				account,
 				ownerAddress,
 				accountAddress as `0x${string}`,
-				[
-					{
-						to: keyInfo.allowedTarget,
-						value: 0n,
-						data: innerData
-					}
-				]
+				{
+					to: keyInfo.allowedTarget,
+					value: 0n,
+					data: keyInfo.allowedSelector as Hex
+				}
 			);
 
 			lastUserOpHash = result.userOpHash;
@@ -288,16 +293,24 @@
 				<p class="mt-4 text-sm text-red-400">{sendError}</p>
 			{/if}
 
+			{#if !canExecute}
+				<p class="mt-4 text-sm text-yellow-400">
+					This function requires arguments — execution from this page is not supported.
+				</p>
+			{/if}
+
 			<button
 				type="button"
 				onclick={execute}
-				disabled={sending || !isActive}
+				disabled={sending || !isActive || !canExecute}
 				class="mt-4 w-full cursor-pointer rounded bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-50"
 			>
 				{#if sending}
 					Sending UserOp…
 				{:else if !isActive}
 					Key Expired
+				{:else if !canExecute}
+					Requires Arguments
 				{:else}
 					Execute {selectorLabel}
 				{/if}

--- a/frontend/src/routes/session/+page.svelte
+++ b/frontend/src/routes/session/+page.svelte
@@ -1,0 +1,307 @@
+<script lang="ts">
+	import { isAddress, encodeFunctionData, type Hex } from 'viem';
+	import { privateKeyToAccount } from 'viem/accounts';
+	import { publicClient } from '$lib/wallet.svelte';
+	import { SmartAccountAbi } from '$lib/contracts/SmartAccount';
+	import { sendSessionKeyUserOp } from '$lib/userOp';
+	import { etherscanTx, truncateHex } from '$lib/explorer';
+
+	// ── Known selectors (for display) ───────────────────────────────────
+
+	const SELECTOR_LABELS: Record<string, string> = {
+		'0xd09de08a': 'increment()',
+		'0x4e71d92d': 'claim()',
+		'0xa9059cbb': 'transfer(address,uint256)'
+	};
+
+	// ── Form state ──────────────────────────────────────────────────────
+
+	let accountAddress = $state('');
+	let privateKeyInput = $state('');
+
+	// ── Session key data (loaded from contract) ─────────────────────────
+
+	type SessionKeyInfo = {
+		address: `0x${string}`;
+		allowedTarget: `0x${string}`;
+		allowedSelector: `0x${string}`;
+		validAfter: number;
+		validUntil: number;
+	};
+
+	let keyInfo = $state<SessionKeyInfo | null>(null);
+	let ownerAddress = $state<`0x${string}` | null>(null);
+	let loading = $state(false);
+	let loadError = $state<string | null>(null);
+
+	// ── Execution state ─────────────────────────────────────────────────
+
+	let sending = $state(false);
+	let sendError = $state<string | null>(null);
+	let lastUserOpHash = $state<`0x${string}` | null>(null);
+	let lastTxHash = $state<`0x${string}` | null>(null);
+
+	// ── Derived ─────────────────────────────────────────────────────────
+
+	const isActive = $derived(
+		keyInfo !== null &&
+			keyInfo.validUntil > 0 &&
+			Date.now() / 1000 >= keyInfo.validAfter &&
+			Date.now() / 1000 < keyInfo.validUntil
+	);
+
+	const selectorLabel = $derived(
+		keyInfo ? (SELECTOR_LABELS[keyInfo.allowedSelector] ?? keyInfo.allowedSelector) : ''
+	);
+
+	// ── Load session key from contract ──────────────────────────────────
+
+	async function loadKey() {
+		if (!isAddress(accountAddress)) {
+			loadError = 'Enter a valid SmartAccount address';
+			return;
+		}
+		if (!privateKeyInput.startsWith('0x') || privateKeyInput.length !== 66) {
+			loadError = 'Enter a valid private key (0x + 64 hex chars)';
+			return;
+		}
+
+		loading = true;
+		loadError = null;
+		keyInfo = null;
+		ownerAddress = null;
+		lastUserOpHash = null;
+		lastTxHash = null;
+		sendError = null;
+
+		try {
+			const account = privateKeyToAccount(privateKeyInput as `0x${string}`);
+
+			// Read session key data and owner in parallel.
+			const [skData, owner] = await Promise.all([
+				publicClient.readContract({
+					address: accountAddress as `0x${string}`,
+					abi: SmartAccountAbi,
+					functionName: 'sessionKeys',
+					args: [account.address]
+				}),
+				publicClient.readContract({
+					address: accountAddress as `0x${string}`,
+					abi: SmartAccountAbi,
+					functionName: 'owner'
+				})
+			]);
+
+			const [allowedTarget, allowedSelector, validAfter, validUntil] = skData;
+
+			if (validUntil === 0) {
+				loadError = 'No session key registered for this address on the SmartAccount';
+				return;
+			}
+
+			ownerAddress = owner;
+			keyInfo = {
+				address: account.address,
+				allowedTarget,
+				allowedSelector,
+				validAfter,
+				validUntil
+			};
+		} catch (e: unknown) {
+			const err = e as { shortMessage?: string; message?: string };
+			loadError = err.shortMessage ?? err.message ?? 'Failed to load session key';
+		} finally {
+			loading = false;
+		}
+	}
+
+	// ── Execute allowed action ──────────────────────────────────────────
+
+	async function execute() {
+		if (!keyInfo || !ownerAddress) return;
+
+		const account = privateKeyToAccount(privateKeyInput as `0x${string}`);
+
+		sending = true;
+		sendError = null;
+		lastUserOpHash = null;
+		lastTxHash = null;
+
+		try {
+			// Build the inner call data from the allowed selector.
+			// For no-arg functions (increment, claim), the selector IS the full calldata.
+			// For functions with args, this would need additional encoding.
+			const innerData: Hex = keyInfo.allowedSelector as Hex;
+
+			const result = await sendSessionKeyUserOp(
+				account,
+				ownerAddress,
+				accountAddress as `0x${string}`,
+				[
+					{
+						to: keyInfo.allowedTarget,
+						value: 0n,
+						data: innerData
+					}
+				]
+			);
+
+			lastUserOpHash = result.userOpHash;
+			lastTxHash = result.txHash;
+
+			if (!result.success) {
+				sendError = 'UserOperation reverted on-chain';
+			}
+		} catch (e: unknown) {
+			const err = e as { shortMessage?: string; message?: string };
+			sendError = err.shortMessage ?? err.message ?? 'Execution failed';
+		} finally {
+			sending = false;
+		}
+	}
+
+	function formatTime(unix: number): string {
+		return new Date(unix * 1000).toLocaleString();
+	}
+</script>
+
+<div class="mx-auto max-w-xl">
+	<h1 class="mb-4 text-2xl font-bold">Session Key Demo</h1>
+	<p class="mb-6 text-sm text-zinc-400">
+		Use a session key to submit UserOperations on behalf of a SmartAccount — no owner wallet
+		required.
+	</p>
+
+	<!-- Load form -->
+	<div class="rounded-lg border border-zinc-800 bg-zinc-800/50 p-6">
+		<h2 class="text-lg font-semibold">Connect Session Key</h2>
+
+		<div class="mt-4 space-y-4">
+			<div>
+				<label for="sa-address" class="mb-1 block text-sm text-zinc-400">SmartAccount Address</label
+				>
+				<input
+					id="sa-address"
+					type="text"
+					bind:value={accountAddress}
+					placeholder="0x…"
+					class="w-full rounded border border-zinc-700 bg-zinc-900 px-3 py-2 font-mono text-sm text-zinc-100 placeholder-zinc-600 focus:border-indigo-500 focus:outline-none"
+				/>
+			</div>
+
+			<div>
+				<label for="sk-pk" class="mb-1 block text-sm text-zinc-400">Session Key Private Key</label>
+				<input
+					id="sk-pk"
+					type="password"
+					bind:value={privateKeyInput}
+					placeholder="0x…"
+					class="w-full rounded border border-zinc-700 bg-zinc-900 px-3 py-2 font-mono text-sm text-zinc-100 placeholder-zinc-600 focus:border-indigo-500 focus:outline-none"
+				/>
+			</div>
+
+			{#if loadError}
+				<p class="text-sm text-red-400">{loadError}</p>
+			{/if}
+
+			<button
+				type="button"
+				onclick={loadKey}
+				disabled={loading}
+				class="w-full cursor-pointer rounded bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-50"
+			>
+				{loading ? 'Loading…' : 'Load Session Key'}
+			</button>
+		</div>
+	</div>
+
+	<!-- Session key info + execute -->
+	{#if keyInfo}
+		<div class="mt-6 rounded-lg border border-zinc-800 bg-zinc-800/50 p-6">
+			<h2 class="text-lg font-semibold">Session Key Permissions</h2>
+
+			<dl class="mt-4 space-y-3">
+				<div class="flex justify-between">
+					<dt class="text-zinc-400">Key Address</dt>
+					<dd class="font-mono text-sm">{truncateHex(keyInfo.address)}</dd>
+				</div>
+				<div class="flex justify-between">
+					<dt class="text-zinc-400">Allowed Target</dt>
+					<dd class="font-mono text-sm">{truncateHex(keyInfo.allowedTarget)}</dd>
+				</div>
+				<div class="flex justify-between">
+					<dt class="text-zinc-400">Allowed Function</dt>
+					<dd class="font-mono text-sm">{selectorLabel}</dd>
+				</div>
+				<div class="flex justify-between">
+					<dt class="text-zinc-400">Valid From</dt>
+					<dd class="text-sm">{formatTime(keyInfo.validAfter)}</dd>
+				</div>
+				<div class="flex justify-between">
+					<dt class="text-zinc-400">Valid Until</dt>
+					<dd class="text-sm">{formatTime(keyInfo.validUntil)}</dd>
+				</div>
+				<div class="flex justify-between">
+					<dt class="text-zinc-400">Status</dt>
+					<dd>
+						{#if isActive}
+							<span class="text-green-400">Active</span>
+						{:else}
+							<span class="text-red-400">Expired</span>
+						{/if}
+					</dd>
+				</div>
+			</dl>
+
+			{#if lastUserOpHash || lastTxHash}
+				<div class="mt-4 space-y-1 text-xs text-zinc-500">
+					{#if lastUserOpHash}
+						<p>
+							UserOp:
+							<a
+								href="https://jiffyscan.xyz/userOpHash/{lastUserOpHash}?network=sepolia"
+								target="_blank"
+								rel="noopener noreferrer"
+								class="text-indigo-400 hover:text-indigo-300"
+							>
+								{truncateHex(lastUserOpHash)}
+							</a>
+						</p>
+					{/if}
+					{#if lastTxHash}
+						<p>
+							Tx:
+							<a
+								href={etherscanTx(lastTxHash)}
+								target="_blank"
+								rel="noopener noreferrer"
+								class="text-indigo-400 hover:text-indigo-300"
+							>
+								{truncateHex(lastTxHash)}
+							</a>
+						</p>
+					{/if}
+				</div>
+			{/if}
+
+			{#if sendError}
+				<p class="mt-4 text-sm text-red-400">{sendError}</p>
+			{/if}
+
+			<button
+				type="button"
+				onclick={execute}
+				disabled={sending || !isActive}
+				class="mt-4 w-full cursor-pointer rounded bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-50"
+			>
+				{#if sending}
+					Sending UserOp…
+				{:else if !isActive}
+					Key Expired
+				{:else}
+					Execute {selectorLabel}
+				{/if}
+			</button>
+		</div>
+	{/if}
+</div>

--- a/frontend/src/routes/session/+page.svelte
+++ b/frontend/src/routes/session/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { onDestroy } from 'svelte';
+	import { onDestroy, onMount } from 'svelte';
 	import { isAddress, type Hex } from 'viem';
 	import { privateKeyToAccount } from 'viem/accounts';
 	import { publicClient } from '$lib/wallet.svelte';
@@ -48,7 +48,10 @@
 	// ── Live clock for expiry tracking ──────────────────────────────────
 
 	let now = $state(Date.now() / 1000);
-	const timer = setInterval(() => (now = Date.now() / 1000), 1000);
+	let timer: ReturnType<typeof setInterval>;
+	onMount(() => {
+		timer = setInterval(() => (now = Date.now() / 1000), 1000);
+	});
 	onDestroy(() => clearInterval(timer));
 
 	// ── Derived ─────────────────────────────────────────────────────────

--- a/frontend/src/routes/session/+page.svelte
+++ b/frontend/src/routes/session/+page.svelte
@@ -48,7 +48,7 @@
 	// ── Live clock for expiry tracking ──────────────────────────────────
 
 	let now = $state(Date.now() / 1000);
-	let timer: ReturnType<typeof setInterval>;
+	let timer: ReturnType<typeof setInterval> | undefined;
 	onMount(() => {
 		timer = setInterval(() => (now = Date.now() / 1000), 1000);
 	});
@@ -61,6 +61,10 @@
 			keyInfo.validUntil > 0 &&
 			now >= keyInfo.validAfter &&
 			now < keyInfo.validUntil
+	);
+
+	const isPending = $derived(
+		keyInfo !== null && keyInfo.validUntil > 0 && now < keyInfo.validAfter
 	);
 
 	const selectorLabel = $derived(
@@ -254,6 +258,8 @@
 					<dd>
 						{#if isActive}
 							<span class="text-green-400">Active</span>
+						{:else if isPending}
+							<span class="text-yellow-400">Not yet active</span>
 						{:else}
 							<span class="text-red-400">Expired</span>
 						{/if}
@@ -305,11 +311,13 @@
 			<button
 				type="button"
 				onclick={execute}
-				disabled={sending || !isActive || !canExecute}
+				disabled={sending || !isActive || isPending || !canExecute}
 				class="mt-4 w-full cursor-pointer rounded bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-500 disabled:cursor-not-allowed disabled:opacity-50"
 			>
 				{#if sending}
 					Sending UserOp…
+				{:else if isPending}
+					Not Yet Active
 				{:else if !isActive}
 					Key Expired
 				{:else if !canExecute}


### PR DESCRIPTION
## What

Add the session key interaction flow — a separate \`/session\` page where a session key holder can submit UserOperations on behalf of a SmartAccount without the owner's wallet.

**New files:**
- \`/session/+page.svelte\` — enter SmartAccount address + session key private key, reads on-chain constraints (\`sessionKeys\` mapping), displays allowed target/function/validity, executes the allowed action via UserOp

**Modified files:**
- \`smartAccount.ts\` — refactored to extract shared \`buildSmartAccount\`, added \`toSessionKeySmartAccount\` that signs with a \`LocalAccount\` (private key) instead of a WalletClient
- \`userOp.ts\` — refactored \`createBundlerClient\` to accept a generic \`SmartAccount\`, added \`sendSessionKeyUserOp\`
- \`+layout.svelte\` — added "Session" nav link

## Why

The exam requires demonstrating that a second wallet (session key holder) can submit UserOps constrained to a specific target contract and function selector, within a time window — all without the owner's wallet. This is the core differentiator of the SmartAccount's session key system.

Key technical detail: session key validation requires the UserOp callData to be \`execute(target, value, data)\` — the standard \`calls\` encoding works. The adapter signs with the session key's private key locally via \`LocalAccount.signMessage\`, and the SmartAccount's \`_validateSignature\` falls through to \`_validateSessionKey\` when the recovered signer is not the owner.

## Scope

- [x] Frontend

## How to verify

\`\`\`sh
cd frontend && pnpm build
\`\`\`

Full demo flow:
1. Owner deploys SmartAccount and registers a session key (dashboard)
2. Copy the generated private key and SmartAccount address
3. Navigate to \`/session\`, paste both, click "Load Session Key"
4. See the on-chain constraints, click "Execute" to submit a UserOp signed by the session key

## Related issues

Closes #19.