### PR TITLE
feat(indexer): index AccountDeployed + UserOperationRevertReason events

### DIFF
--- a/frontend/src/lib/components/StatsPanel.svelte
+++ b/frontend/src/lib/components/StatsPanel.svelte
@@ -12,7 +12,7 @@
 	}
 </script>
 
-<div class="mb-6 grid grid-cols-2 gap-4 sm:grid-cols-4">
+<div class="mb-6 grid grid-cols-2 gap-4 sm:grid-cols-2 lg:grid-cols-5">
 	<!-- Total UserOps -->
 	<div class="rounded-lg border border-zinc-800 bg-zinc-800/50 px-4 py-4">
 		<p class="text-xs tracking-wider text-zinc-400 uppercase">Total UserOps</p>
@@ -63,6 +63,14 @@
 				{stats.sponsoredCount} paymaster-funded
 			</p>
 		{/if}
+	</div>
+
+	<!-- Accounts Deployed -->
+	<div class="rounded-lg border border-zinc-800 bg-zinc-800/50 px-4 py-4">
+		<p class="text-xs tracking-wider text-zinc-400 uppercase">Accounts Deployed</p>
+		<p class="mt-1 text-2xl font-semibold tabular-nums">
+			{stats ? stats.accountsDeployedCount.toLocaleString() : '\u2014'}
+		</p>
 	</div>
 
 	<!-- Unique Senders -->

--- a/frontend/src/lib/indexer.svelte.ts
+++ b/frontend/src/lib/indexer.svelte.ts
@@ -34,6 +34,8 @@ export interface UserOperation {
 	blockNumber: number;
 	blockTimestamp: number;
 	logIndex: number;
+	accountDeployed?: boolean;
+	revertReason?: string;
 }
 
 export type FeedStatus = 'disconnected' | 'connecting' | 'connected' | 'polling';
@@ -46,6 +48,7 @@ export interface IndexerStats {
 	sponsoredCount: number;
 	sponsoredRate: number;
 	uniqueSenders: number;
+	accountsDeployedCount: number;
 }
 
 /**

--- a/frontend/src/routes/indexer/+page.svelte
+++ b/frontend/src/routes/indexer/+page.svelte
@@ -39,6 +39,43 @@
 		return !!paymaster && paymaster !== '0x' && paymaster !== '0x' + '0'.repeat(40);
 	}
 
+	/**
+	 * Best-effort decode of revert reason bytes into a human-readable string.
+	 * Handles the standard Solidity Error(string) selector (0x08c379a0) plus
+	 * plain UTF-8 bytes. Falls back to raw hex when the decoded string would
+	 * contain control characters.
+	 */
+	function formatRevertReason(hex: string | undefined): string {
+		if (!hex || hex === '0x') return '';
+		const raw = hex.startsWith('0x') ? hex.slice(2) : hex;
+
+		// Solidity Error(string): 0x08c379a0 + abi.encode(string)
+		if (raw.startsWith('08c379a0') && raw.length >= 8 + 128) {
+			try {
+				// Skip selector (4 bytes) + offset word (32 bytes); next word = length
+				const lenHex = raw.slice(8 + 64, 8 + 128);
+				const strLen = parseInt(lenHex, 16);
+				const dataHex = raw.slice(8 + 128, 8 + 128 + strLen * 2);
+				const bytes = new Uint8Array(dataHex.match(/.{2}/g)?.map((b) => parseInt(b, 16)) ?? []);
+				const text = new TextDecoder('utf-8', { fatal: false }).decode(bytes);
+				if (!/[\x00-\x08\x0e-\x1f]/.test(text)) return text;
+			} catch {
+				// fall through to raw hex
+			}
+		}
+
+		// Plain UTF-8 sniff
+		try {
+			const bytes = new Uint8Array(raw.match(/.{2}/g)?.map((b) => parseInt(b, 16)) ?? []);
+			const text = new TextDecoder('utf-8', { fatal: false }).decode(bytes);
+			if (text.length > 0 && !/[\x00-\x08\x0e-\x1f]/.test(text)) return text;
+		} catch {
+			// fall through
+		}
+
+		return hex;
+	}
+
 	/** Auto-scroll: keep the page scrolled to top when new ops arrive (if user is near top). */
 	let prevCount = 0;
 
@@ -139,21 +176,32 @@
 								{/if}
 							</td>
 
-							<!-- Success -->
+							<!-- Status -->
 							<td class="px-4 py-3">
-								{#if op.success}
-									<span
-										class="inline-block rounded bg-green-900/60 px-2 py-0.5 text-xs font-medium text-green-300"
-									>
-										Success
-									</span>
-								{:else}
-									<span
-										class="inline-block rounded bg-red-900/60 px-2 py-0.5 text-xs font-medium text-red-300"
-									>
-										Reverted
-									</span>
-								{/if}
+								<div class="flex items-center gap-1.5">
+									{#if op.success}
+										<span
+											class="inline-block rounded bg-green-900/60 px-2 py-0.5 text-xs font-medium text-green-300"
+										>
+											Success
+										</span>
+									{:else}
+										<span
+											class="inline-block rounded bg-red-900/60 px-2 py-0.5 text-xs font-medium text-red-300"
+											title={op.revertReason ? formatRevertReason(op.revertReason) : undefined}
+										>
+											Reverted
+										</span>
+									{/if}
+									{#if op.accountDeployed}
+										<span
+											class="inline-block rounded bg-blue-900/60 px-2 py-0.5 text-xs font-medium text-blue-300"
+											title="Account deployed in this UserOp"
+										>
+											Deployed
+										</span>
+									{/if}
+								</div>
 							</td>
 
 							<!-- Gas Cost -->

--- a/indexer/internal/api/handler.go
+++ b/indexer/internal/api/handler.go
@@ -129,31 +129,34 @@ func (h *Handler) GetStats(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, http.StatusOK, statsResponse{
-		TotalOps:       s.TotalOps,
-		SuccessCount:   s.SuccessCount,
-		SuccessRate:    successRate,
-		SponsoredCount: s.SponsoredCount,
-		SponsoredRate:  sponsoredRate,
-		UniqueSenders:  s.UniqueSenders,
+		TotalOps:              s.TotalOps,
+		SuccessCount:          s.SuccessCount,
+		SuccessRate:           successRate,
+		SponsoredCount:        s.SponsoredCount,
+		SponsoredRate:         sponsoredRate,
+		UniqueSenders:         s.UniqueSenders,
+		AccountsDeployedCount: s.AccountsDeployedCount,
 	})
 }
 
 // --- response types ---
 
 type operationResponse struct {
-	UserOpHash     string `json:"userOpHash"`
-	Sender         string `json:"sender"`
-	Paymaster      string `json:"paymaster"`
-	Target         string `json:"target,omitempty"`
-	Calldata       string `json:"calldata,omitempty"`
-	Nonce          string `json:"nonce"`
-	Success        bool   `json:"success"`
-	ActualGasCost  string `json:"actualGasCost"`
-	ActualGasUsed  string `json:"actualGasUsed"`
-	TxHash         string `json:"txHash"`
-	BlockNumber    int64  `json:"blockNumber"`
-	BlockTimestamp int64  `json:"blockTimestamp"`
-	LogIndex       int32  `json:"logIndex"`
+	UserOpHash      string `json:"userOpHash"`
+	Sender          string `json:"sender"`
+	Paymaster       string `json:"paymaster"`
+	Target          string `json:"target,omitempty"`
+	Calldata        string `json:"calldata,omitempty"`
+	Nonce           string `json:"nonce"`
+	Success         bool   `json:"success"`
+	ActualGasCost   string `json:"actualGasCost"`
+	ActualGasUsed   string `json:"actualGasUsed"`
+	TxHash          string `json:"txHash"`
+	BlockNumber     int64  `json:"blockNumber"`
+	BlockTimestamp  int64  `json:"blockTimestamp"`
+	LogIndex        int32  `json:"logIndex"`
+	AccountDeployed bool   `json:"accountDeployed,omitempty"`
+	RevertReason    string `json:"revertReason,omitempty"`
 }
 
 type listResponse struct {
@@ -164,30 +167,39 @@ type listResponse struct {
 }
 
 type statsResponse struct {
-	TotalOps       int64   `json:"totalOps"`
-	SuccessCount   int64   `json:"successCount"`
-	SuccessRate    float64 `json:"successRate"`
-	SponsoredCount int64   `json:"sponsoredCount"`
-	SponsoredRate  float64 `json:"sponsoredRate"`
-	UniqueSenders  int64   `json:"uniqueSenders"`
+	TotalOps              int64   `json:"totalOps"`
+	SuccessCount          int64   `json:"successCount"`
+	SuccessRate           float64 `json:"successRate"`
+	SponsoredCount        int64   `json:"sponsoredCount"`
+	SponsoredRate         float64 `json:"sponsoredRate"`
+	UniqueSenders         int64   `json:"uniqueSenders"`
+	AccountsDeployedCount int64   `json:"accountsDeployedCount"`
 }
 
 func toResponse(op db.UserOperation) operationResponse {
-	return operationResponse{
-		UserOpHash:     encodeHex(op.UserOpHash),
-		Sender:         encodeHex(op.Sender),
-		Paymaster:      encodeHex(op.Paymaster),
-		Target:         encodeHex(op.Target),
-		Calldata:       encodeHex(op.Calldata),
-		Nonce:          op.Nonce,
-		Success:        op.Success,
-		ActualGasCost:  op.ActualGasCost,
-		ActualGasUsed:  op.ActualGasUsed,
-		TxHash:         encodeHex(op.TxHash),
-		BlockNumber:    op.BlockNumber,
-		BlockTimestamp: op.BlockTimestamp,
-		LogIndex:       op.LogIndex,
+	r := operationResponse{
+		UserOpHash:      encodeHex(op.UserOpHash),
+		Sender:          encodeHex(op.Sender),
+		Paymaster:       encodeHex(op.Paymaster),
+		Target:          encodeHex(op.Target),
+		Calldata:        encodeHex(op.Calldata),
+		Nonce:           op.Nonce,
+		Success:         op.Success,
+		ActualGasCost:   op.ActualGasCost,
+		ActualGasUsed:   op.ActualGasUsed,
+		TxHash:          encodeHex(op.TxHash),
+		BlockNumber:     op.BlockNumber,
+		BlockTimestamp:  op.BlockTimestamp,
+		LogIndex:        op.LogIndex,
+		AccountDeployed: op.AccountDeployed,
 	}
+	// Only emit revertReason when the log carried non-empty data — empty
+	// bytes from the chain are a legitimate "no reason supplied" and should
+	// render as absent rather than "0x".
+	if len(op.RevertReason) > 0 {
+		r.RevertReason = encodeHex(op.RevertReason)
+	}
+	return r
 }
 
 // --- helpers ---

--- a/indexer/internal/api/handler_test.go
+++ b/indexer/internal/api/handler_test.go
@@ -7,6 +7,7 @@ import (
 	"math"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/flwrenn/bastion/indexer/internal/db"
@@ -654,5 +655,55 @@ func TestGetStatsStoreError(t *testing.T) {
 
 	if w.Code != http.StatusInternalServerError {
 		t.Fatalf("status = %d, want %d", w.Code, http.StatusInternalServerError)
+	}
+}
+
+func TestToResponseIncludesEnrichmentFields(t *testing.T) {
+	t.Parallel()
+
+	op := db.UserOperation{
+		UserOpHash:      make([]byte, 32),
+		Sender:          make([]byte, 20),
+		Paymaster:       make([]byte, 20),
+		TxHash:          make([]byte, 32),
+		Nonce:           "0",
+		ActualGasCost:   "0",
+		ActualGasUsed:   "0",
+		AccountDeployed: true,
+		RevertReason:    []byte("boom"),
+	}
+
+	got := toResponse(op)
+	if !got.AccountDeployed {
+		t.Fatal("AccountDeployed not propagated")
+	}
+	if got.RevertReason != "0x626f6f6d" {
+		t.Fatalf("RevertReason = %q, want 0x626f6f6d", got.RevertReason)
+	}
+}
+
+func TestToResponseOmitsEmptyEnrichmentFields(t *testing.T) {
+	t.Parallel()
+
+	op := db.UserOperation{
+		UserOpHash:    make([]byte, 32),
+		Sender:        make([]byte, 20),
+		Paymaster:     make([]byte, 20),
+		TxHash:        make([]byte, 32),
+		Nonce:         "0",
+		ActualGasCost: "0",
+		ActualGasUsed: "0",
+	}
+
+	got := toResponse(op)
+	payload, err := json.Marshal(got)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(payload), "accountDeployed") {
+		t.Errorf("accountDeployed should be omitted when false; got %s", payload)
+	}
+	if strings.Contains(string(payload), "revertReason") {
+		t.Errorf("revertReason should be omitted when empty; got %s", payload)
 	}
 }

--- a/indexer/internal/db/migrations/002_create_account_deployments_and_reverts.sql
+++ b/indexer/internal/db/migrations/002_create_account_deployments_and_reverts.sql
@@ -5,6 +5,14 @@
 -- range deletes. No foreign key to user_operations — AccountDeployed emits
 -- before UserOperationEvent in the same tx, and the batch insert flow does
 -- not guarantee insert order between the two tables.
+--
+-- user_op_hash carries a UNIQUE constraint on each table. EntryPoint v0.7
+-- emits AccountDeployed and UserOperationRevertReason at most once per UserOp
+-- (by protocol), so enforcing this at the schema level is a real invariant
+-- rather than a defensive extra. It also lets the API LEFT JOIN enrichment
+-- queries stay straightforward: no DISTINCT ON, no LATERAL LIMIT 1, no risk
+-- of row multiplication inflating count(*) OVER() or breaking pagination.
+-- A unique index also replaces the plain user_op_hash lookup index.
 
 CREATE TABLE account_deployments (
     id               BIGSERIAL    PRIMARY KEY,
@@ -17,10 +25,10 @@ CREATE TABLE account_deployments (
     block_timestamp  BIGINT       NOT NULL,
     log_index        INTEGER      NOT NULL,
 
-    UNIQUE (tx_hash, log_index)
+    UNIQUE (tx_hash, log_index),
+    UNIQUE (user_op_hash)
 );
 
-CREATE INDEX idx_account_deployments_user_op_hash ON account_deployments (user_op_hash);
 CREATE INDEX idx_account_deployments_block_number ON account_deployments (block_number);
 
 CREATE TABLE user_operation_reverts (
@@ -34,8 +42,8 @@ CREATE TABLE user_operation_reverts (
     block_timestamp  BIGINT       NOT NULL,
     log_index        INTEGER      NOT NULL,
 
-    UNIQUE (tx_hash, log_index)
+    UNIQUE (tx_hash, log_index),
+    UNIQUE (user_op_hash)
 );
 
-CREATE INDEX idx_user_operation_reverts_user_op_hash ON user_operation_reverts (user_op_hash);
 CREATE INDEX idx_user_operation_reverts_block_number ON user_operation_reverts (block_number);

--- a/indexer/internal/db/migrations/002_create_account_deployments_and_reverts.sql
+++ b/indexer/internal/db/migrations/002_create_account_deployments_and_reverts.sql
@@ -1,0 +1,41 @@
+-- Migration 002: Index AccountDeployed and UserOperationRevertReason events
+--
+-- Both tables mirror the reorg-safe pattern used by user_operations:
+-- primary reorg key is (tx_hash, log_index), with block_number indexed for
+-- range deletes. No foreign key to user_operations — AccountDeployed emits
+-- before UserOperationEvent in the same tx, and the batch insert flow does
+-- not guarantee insert order between the two tables.
+
+CREATE TABLE account_deployments (
+    id               BIGSERIAL    PRIMARY KEY,
+    user_op_hash     BYTEA        NOT NULL CHECK (octet_length(user_op_hash) = 32),
+    sender           BYTEA        NOT NULL CHECK (octet_length(sender) = 20),
+    factory          BYTEA        NOT NULL CHECK (octet_length(factory) = 20),
+    paymaster        BYTEA        NOT NULL CHECK (octet_length(paymaster) = 20),
+    tx_hash          BYTEA        NOT NULL CHECK (octet_length(tx_hash) = 32),
+    block_number     BIGINT       NOT NULL,
+    block_timestamp  BIGINT       NOT NULL,
+    log_index        INTEGER      NOT NULL,
+
+    UNIQUE (tx_hash, log_index)
+);
+
+CREATE INDEX idx_account_deployments_user_op_hash ON account_deployments (user_op_hash);
+CREATE INDEX idx_account_deployments_block_number ON account_deployments (block_number);
+
+CREATE TABLE user_operation_reverts (
+    id               BIGSERIAL    PRIMARY KEY,
+    user_op_hash     BYTEA        NOT NULL CHECK (octet_length(user_op_hash) = 32),
+    sender           BYTEA        NOT NULL CHECK (octet_length(sender) = 20),
+    nonce            NUMERIC(78,0) NOT NULL CHECK (nonce >= 0),
+    revert_reason    BYTEA        NOT NULL,
+    tx_hash          BYTEA        NOT NULL CHECK (octet_length(tx_hash) = 32),
+    block_number     BIGINT       NOT NULL,
+    block_timestamp  BIGINT       NOT NULL,
+    log_index        INTEGER      NOT NULL,
+
+    UNIQUE (tx_hash, log_index)
+);
+
+CREATE INDEX idx_user_operation_reverts_user_op_hash ON user_operation_reverts (user_op_hash);
+CREATE INDEX idx_user_operation_reverts_block_number ON user_operation_reverts (block_number);

--- a/indexer/internal/db/models.go
+++ b/indexer/internal/db/models.go
@@ -20,3 +20,33 @@ type UserOperation struct {
 	BlockTimestamp int64
 	LogIndex       int32
 }
+
+// AccountDeployment represents a row in the account_deployments table.
+// Fields map to the EntryPoint v0.7 AccountDeployed event plus transaction-
+// level context (tx hash, block, timestamp, log index).
+type AccountDeployment struct {
+	ID             int64
+	UserOpHash     []byte
+	Sender         []byte
+	Factory        []byte
+	Paymaster      []byte
+	TxHash         []byte
+	BlockNumber    int64
+	BlockTimestamp int64
+	LogIndex       int32
+}
+
+// UserOperationRevert represents a row in the user_operation_reverts table.
+// Fields map to the EntryPoint v0.7 UserOperationRevertReason event plus
+// transaction-level context (tx hash, block, timestamp, log index).
+type UserOperationRevert struct {
+	ID             int64
+	UserOpHash     []byte
+	Sender         []byte
+	Nonce          string // DB NUMERIC — Go string for uint256 range
+	RevertReason   []byte
+	TxHash         []byte
+	BlockNumber    int64
+	BlockTimestamp int64
+	LogIndex       int32
+}

--- a/indexer/internal/db/models.go
+++ b/indexer/internal/db/models.go
@@ -4,6 +4,12 @@ package db
 // Fields map to the EntryPoint v0.7 UserOperationEvent plus
 // decoded inner-call fields (target, calldata) and transaction-
 // level context (tx hash, block, timestamp, log index).
+//
+// AccountDeployed and RevertReason are NOT persisted in the user_operations
+// table. They are denormalized fields populated either by an in-memory
+// enrichment pass (indexer broadcast path) or by a LEFT JOIN from the
+// read path (REST/WS list+get). Any `omitempty` JSON serialization must
+// live at the API layer, not here.
 type UserOperation struct {
 	ID             int64
 	UserOpHash     []byte
@@ -19,6 +25,10 @@ type UserOperation struct {
 	BlockNumber    int64
 	BlockTimestamp int64
 	LogIndex       int32
+
+	// Denormalized read-path fields — not in user_operations table.
+	AccountDeployed bool
+	RevertReason    []byte
 }
 
 // AccountDeployment represents a row in the account_deployments table.

--- a/indexer/internal/db/queries.go
+++ b/indexer/internal/db/queries.go
@@ -34,42 +34,44 @@ func ClampListParams(p *ListParams) {
 	}
 }
 
-// ListOperations returns a page of user operations ordered newest-first,
-// along with the total count matching the filter.
+// ListOperations returns a page of user operations enriched with the
+// denormalized accountDeployed / revertReason fields, ordered newest-first.
 func ListOperations(ctx context.Context, pool *pgxpool.Pool, p ListParams) ([]UserOperation, int64, error) {
 	if pool == nil {
 		return nil, 0, errors.New("pool is required")
 	}
 	ClampListParams(&p)
 
-	// Use count(*) OVER() as a window function so the total and page data
-	// come from a single query (atomic snapshot). When the page is empty
-	// (no matching rows or offset beyond total), total is 0.
+	const selectCols = `
+		uo.id, uo.user_op_hash, uo.sender, uo.paymaster, uo.target, uo.calldata,
+		uo.nonce, uo.success, uo.actual_gas_cost, uo.actual_gas_used,
+		uo.tx_hash, uo.block_number, uo.block_timestamp, uo.log_index,
+		(ad.user_op_hash IS NOT NULL) AS account_deployed,
+		ur.revert_reason,
+		count(*) OVER() AS total
+	`
+	const joinClause = `
+		FROM user_operations uo
+		LEFT JOIN account_deployments      ad ON ad.user_op_hash = uo.user_op_hash
+		LEFT JOIN user_operation_reverts   ur ON ur.user_op_hash = uo.user_op_hash
+	`
 
 	var rows pgx.Rows
 	var err error
 
 	if p.Sender != nil {
-		rows, err = pool.Query(ctx, `
-			SELECT id, user_op_hash, sender, paymaster, target, calldata,
-			       nonce, success, actual_gas_cost, actual_gas_used,
-			       tx_hash, block_number, block_timestamp, log_index,
-			       count(*) OVER() AS total
-			FROM user_operations
-			WHERE sender = $1
-			ORDER BY block_number DESC, log_index DESC
-			LIMIT $2 OFFSET $3`,
+		rows, err = pool.Query(ctx,
+			`SELECT `+selectCols+joinClause+`
+			 WHERE uo.sender = $1
+			 ORDER BY uo.block_number DESC, uo.log_index DESC
+			 LIMIT $2 OFFSET $3`,
 			p.Sender, p.Limit, p.Offset,
 		)
 	} else {
-		rows, err = pool.Query(ctx, `
-			SELECT id, user_op_hash, sender, paymaster, target, calldata,
-			       nonce, success, actual_gas_cost, actual_gas_used,
-			       tx_hash, block_number, block_timestamp, log_index,
-			       count(*) OVER() AS total
-			FROM user_operations
-			ORDER BY block_number DESC, log_index DESC
-			LIMIT $1 OFFSET $2`,
+		rows, err = pool.Query(ctx,
+			`SELECT `+selectCols+joinClause+`
+			 ORDER BY uo.block_number DESC, uo.log_index DESC
+			 LIMIT $1 OFFSET $2`,
 			p.Limit, p.Offset,
 		)
 	}
@@ -82,6 +84,7 @@ func ListOperations(ctx context.Context, pool *pgxpool.Pool, p ListParams) ([]Us
 	var ops []UserOperation
 	for rows.Next() {
 		var op UserOperation
+		var revertReason []byte // nullable
 		if err := rows.Scan(
 			&op.ID,
 			&op.UserOpHash,
@@ -97,10 +100,13 @@ func ListOperations(ctx context.Context, pool *pgxpool.Pool, p ListParams) ([]Us
 			&op.BlockNumber,
 			&op.BlockTimestamp,
 			&op.LogIndex,
+			&op.AccountDeployed,
+			&revertReason,
 			&total,
 		); err != nil {
 			return nil, 0, fmt.Errorf("scan operation: %w", err)
 		}
+		op.RevertReason = revertReason
 		ops = append(ops, op)
 	}
 	if err := rows.Err(); err != nil {
@@ -110,20 +116,25 @@ func ListOperations(ctx context.Context, pool *pgxpool.Pool, p ListParams) ([]Us
 	return ops, total, nil
 }
 
-// GetOperationByHash returns a single user operation by its userOpHash.
-// Returns nil, nil when no matching row exists.
+// GetOperationByHash returns a single user operation enriched with
+// accountDeployed / revertReason. Returns nil, nil when no match.
 func GetOperationByHash(ctx context.Context, pool *pgxpool.Pool, hash []byte) (*UserOperation, error) {
 	if pool == nil {
 		return nil, errors.New("pool is required")
 	}
 	var op UserOperation
+	var revertReason []byte
 	err := pool.QueryRow(ctx, `
-		SELECT id, user_op_hash, sender, paymaster, target, calldata,
-		       nonce, success, actual_gas_cost, actual_gas_used,
-		       tx_hash, block_number, block_timestamp, log_index
-		FROM user_operations
-		WHERE user_op_hash = $1
-		ORDER BY block_number DESC, log_index DESC
+		SELECT uo.id, uo.user_op_hash, uo.sender, uo.paymaster, uo.target, uo.calldata,
+		       uo.nonce, uo.success, uo.actual_gas_cost, uo.actual_gas_used,
+		       uo.tx_hash, uo.block_number, uo.block_timestamp, uo.log_index,
+		       (ad.user_op_hash IS NOT NULL) AS account_deployed,
+		       ur.revert_reason
+		FROM user_operations uo
+		LEFT JOIN account_deployments     ad ON ad.user_op_hash = uo.user_op_hash
+		LEFT JOIN user_operation_reverts  ur ON ur.user_op_hash = uo.user_op_hash
+		WHERE uo.user_op_hash = $1
+		ORDER BY uo.block_number DESC, uo.log_index DESC
 		LIMIT 1`,
 		hash,
 	).Scan(
@@ -141,6 +152,8 @@ func GetOperationByHash(ctx context.Context, pool *pgxpool.Pool, hash []byte) (*
 		&op.BlockNumber,
 		&op.BlockTimestamp,
 		&op.LogIndex,
+		&op.AccountDeployed,
+		&revertReason,
 	)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
@@ -148,6 +161,7 @@ func GetOperationByHash(ctx context.Context, pool *pgxpool.Pool, hash []byte) (*
 		}
 		return nil, fmt.Errorf("query operation by hash: %w", err)
 	}
+	op.RevertReason = revertReason
 	return &op, nil
 }
 

--- a/indexer/internal/db/queries.go
+++ b/indexer/internal/db/queries.go
@@ -167,10 +167,11 @@ func GetOperationByHash(ctx context.Context, pool *pgxpool.Pool, hash []byte) (*
 
 // Stats holds aggregate statistics for indexed user operations.
 type Stats struct {
-	TotalOps       int64
-	SuccessCount   int64
-	SponsoredCount int64
-	UniqueSenders  int64
+	TotalOps              int64
+	SuccessCount          int64
+	SponsoredCount        int64
+	UniqueSenders         int64
+	AccountsDeployedCount int64
 }
 
 // zeroPaymaster is the 20-byte zero address used to identify self-funded
@@ -180,6 +181,8 @@ type Stats struct {
 var zeroPaymaster = [20]byte{}
 
 // GetStats returns aggregate statistics across all indexed operations.
+// AccountsDeployedCount counts user_operations rows that have a matching
+// account_deployments row, joined on user_op_hash.
 func GetStats(ctx context.Context, pool *pgxpool.Pool) (Stats, error) {
 	if pool == nil {
 		return Stats{}, errors.New("pool is required")
@@ -187,12 +190,14 @@ func GetStats(ctx context.Context, pool *pgxpool.Pool) (Stats, error) {
 	var s Stats
 	err := pool.QueryRow(ctx, `
 		SELECT count(*),
-		       count(*) FILTER (WHERE success),
-		       count(*) FILTER (WHERE paymaster != $1),
-		       count(DISTINCT sender)
-		FROM user_operations`,
+		       count(*) FILTER (WHERE uo.success),
+		       count(*) FILTER (WHERE uo.paymaster != $1),
+		       count(DISTINCT uo.sender),
+		       count(*) FILTER (WHERE ad.user_op_hash IS NOT NULL)
+		FROM user_operations uo
+		LEFT JOIN account_deployments ad ON ad.user_op_hash = uo.user_op_hash`,
 		zeroPaymaster[:],
-	).Scan(&s.TotalOps, &s.SuccessCount, &s.SponsoredCount, &s.UniqueSenders)
+	).Scan(&s.TotalOps, &s.SuccessCount, &s.SponsoredCount, &s.UniqueSenders, &s.AccountsDeployedCount)
 	if err != nil {
 		return Stats{}, fmt.Errorf("query stats: %w", err)
 	}

--- a/indexer/internal/db/queries_integration_test.go
+++ b/indexer/internal/db/queries_integration_test.go
@@ -126,6 +126,87 @@ func TestGetStatsIntegration(t *testing.T) {
 	}
 }
 
+func TestListOperationsEnrichmentIntegration(t *testing.T) {
+	pool := testPool(t)
+	ctx := context.Background()
+
+	sender := make([]byte, 20)
+	sender[19] = 0x01
+	paymaster := make([]byte, 20)
+	factory := make([]byte, 20)
+	factory[19] = 0xFA
+
+	op := testIntOp(sender, paymaster, false, 900000, 0)
+	op.UserOpHash = bytes32("deadbeef")
+
+	dep := AccountDeployment{
+		UserOpHash:     op.UserOpHash,
+		Sender:         sender,
+		Factory:        factory,
+		Paymaster:      paymaster,
+		TxHash:         op.TxHash,
+		BlockNumber:    op.BlockNumber,
+		BlockTimestamp: op.BlockTimestamp,
+		LogIndex:       1, // different from UserOp's log_index
+	}
+	rev := UserOperationRevert{
+		UserOpHash:     op.UserOpHash,
+		Sender:         sender,
+		Nonce:          "0",
+		RevertReason:   []byte("boom"),
+		TxHash:         op.TxHash,
+		BlockNumber:    op.BlockNumber,
+		BlockTimestamp: op.BlockTimestamp,
+		LogIndex:       2,
+	}
+
+	if err := ReplaceEventsAndSetCursor(
+		ctx, pool, "test_cursor", 900000, 900000, 900000,
+		[]UserOperation{op},
+		[]AccountDeployment{dep},
+		[]UserOperationRevert{rev},
+	); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	got, total, err := ListOperations(ctx, pool, ListParams{Limit: 10})
+	if err != nil {
+		t.Fatalf("ListOperations: %v", err)
+	}
+	if total != 1 {
+		t.Fatalf("total = %d, want 1", total)
+	}
+	if len(got) != 1 {
+		t.Fatalf("len = %d, want 1", len(got))
+	}
+	if !got[0].AccountDeployed {
+		t.Errorf("AccountDeployed = false, want true")
+	}
+	if string(got[0].RevertReason) != "boom" {
+		t.Errorf("RevertReason = %q, want %q", got[0].RevertReason, "boom")
+	}
+
+	byHash, err := GetOperationByHash(ctx, pool, op.UserOpHash)
+	if err != nil {
+		t.Fatalf("GetOperationByHash: %v", err)
+	}
+	if byHash == nil {
+		t.Fatal("GetOperationByHash returned nil")
+	}
+	if !byHash.AccountDeployed || string(byHash.RevertReason) != "boom" {
+		t.Errorf("GetOperationByHash enrichment missing: deployed=%v, reason=%q",
+			byHash.AccountDeployed, byHash.RevertReason)
+	}
+}
+
+// bytes32 returns a 32-byte slice with the given ASCII label in the leading
+// bytes and zero padding. Handy for distinguishing fixtures.
+func bytes32(label string) []byte {
+	out := make([]byte, 32)
+	copy(out, label)
+	return out
+}
+
 // testIntOp builds a minimal UserOperation for integration testing.
 func testIntOp(sender, paymaster []byte, success bool, block int64, logIdx int32) UserOperation {
 	hash := make([]byte, 32)

--- a/indexer/internal/db/queries_integration_test.go
+++ b/indexer/internal/db/queries_integration_test.go
@@ -102,7 +102,32 @@ func TestGetStatsIntegration(t *testing.T) {
 		testIntOp(senderB, paymaster1, false, 900001, 2),
 	}
 
-	err := ReplaceEventsAndSetCursor(ctx, pool, "test_cursor", 900000, 900001, 900001, ops, nil, nil)
+	// After the existing five-op setup, also insert two deployments keyed to
+	// ops #1 and #3 (senderA's first op and senderB's first op).
+	deployments := []AccountDeployment{
+		{
+			UserOpHash:     ops[0].UserOpHash,
+			Sender:         senderA,
+			Factory:        make([]byte, 20),
+			Paymaster:      make([]byte, 20),
+			TxHash:         ops[0].TxHash,
+			BlockNumber:    ops[0].BlockNumber,
+			BlockTimestamp: ops[0].BlockTimestamp,
+			LogIndex:       99, // deploy log before userOp log in the same tx
+		},
+		{
+			UserOpHash:     ops[2].UserOpHash,
+			Sender:         senderB,
+			Factory:        make([]byte, 20),
+			Paymaster:      make([]byte, 20),
+			TxHash:         ops[2].TxHash,
+			BlockNumber:    ops[2].BlockNumber,
+			BlockTimestamp: ops[2].BlockTimestamp,
+			LogIndex:       98,
+		},
+	}
+
+	err := ReplaceEventsAndSetCursor(ctx, pool, "test_cursor", 900000, 900001, 900001, ops, deployments, nil)
 	if err != nil {
 		t.Fatalf("insert test operations: %v", err)
 	}
@@ -123,6 +148,9 @@ func TestGetStatsIntegration(t *testing.T) {
 	}
 	if got.UniqueSenders != 3 {
 		t.Errorf("UniqueSenders = %d, want 3", got.UniqueSenders)
+	}
+	if got.AccountsDeployedCount != 2 {
+		t.Errorf("AccountsDeployedCount = %d, want 2", got.AccountsDeployedCount)
 	}
 }
 

--- a/indexer/internal/db/queries_integration_test.go
+++ b/indexer/internal/db/queries_integration_test.go
@@ -102,7 +102,7 @@ func TestGetStatsIntegration(t *testing.T) {
 		testIntOp(senderB, paymaster1, false, 900001, 2),
 	}
 
-	err := ReplaceOperationsAndSetCursor(ctx, pool, "test_cursor", 900000, 900001, 900001, ops)
+	err := ReplaceEventsAndSetCursor(ctx, pool, "test_cursor", 900000, 900001, 900001, ops, nil, nil)
 	if err != nil {
 		t.Fatalf("insert test operations: %v", err)
 	}

--- a/indexer/internal/db/state.go
+++ b/indexer/internal/db/state.go
@@ -62,7 +62,12 @@ func setStateTx(ctx context.Context, tx pgx.Tx, key, value string) error {
 	return nil
 }
 
-func TrimOperationsAboveBlockAndSetCursor(
+// TrimEventsAboveBlockAndSetCursor deletes rows above the safe head across
+// all three event tables (user_operations, account_deployments,
+// user_operation_reverts) and resets the cursor to the safe head. Used when
+// the indexer detects its cursor has advanced past the safe head (rare,
+// happens after local RPC provider switches / state rewinds).
+func TrimEventsAboveBlockAndSetCursor(
 	ctx context.Context,
 	pool *pgxpool.Pool,
 	stateKey string,
@@ -85,11 +90,13 @@ func TrimOperationsAboveBlockAndSetCursor(
 	}
 	defer tx.Rollback(ctx)
 
-	if _, err := tx.Exec(ctx,
-		"DELETE FROM user_operations WHERE block_number > $1",
-		int64(safeHead),
-	); err != nil {
-		return fmt.Errorf("delete operations above safe head %d: %w", safeHead, err)
+	for _, table := range []string{"user_operations", "account_deployments", "user_operation_reverts"} {
+		if _, err := tx.Exec(ctx,
+			fmt.Sprintf("DELETE FROM %s WHERE block_number > $1", table),
+			int64(safeHead),
+		); err != nil {
+			return fmt.Errorf("delete %s above safe head %d: %w", table, safeHead, err)
+		}
 	}
 
 	if err := setStateTx(ctx, tx, stateKey, strconv.FormatUint(safeHead, 10)); err != nil {

--- a/indexer/internal/db/state_test.go
+++ b/indexer/internal/db/state_test.go
@@ -20,10 +20,10 @@ func TestGetStateRejectsNilPool(t *testing.T) {
 	}
 }
 
-func TestTrimOperationsAboveBlockAndSetCursorRejectsNilPool(t *testing.T) {
+func TestTrimEventsAboveBlockAndSetCursorRejectsNilPool(t *testing.T) {
 	t.Parallel()
 
-	err := TrimOperationsAboveBlockAndSetCursor(context.Background(), nil, "cursor", 1)
+	err := TrimEventsAboveBlockAndSetCursor(context.Background(), nil, "cursor", 1)
 	if err == nil {
 		t.Fatal("expected nil-pool error")
 	}
@@ -32,10 +32,10 @@ func TestTrimOperationsAboveBlockAndSetCursorRejectsNilPool(t *testing.T) {
 	}
 }
 
-func TestTrimOperationsAboveBlockAndSetCursorRejectsEmptyStateKey(t *testing.T) {
+func TestTrimEventsAboveBlockAndSetCursorRejectsEmptyStateKey(t *testing.T) {
 	t.Parallel()
 
-	err := TrimOperationsAboveBlockAndSetCursor(context.Background(), nil, "", 1)
+	err := TrimEventsAboveBlockAndSetCursor(context.Background(), nil, "", 1)
 	if err == nil {
 		t.Fatal("expected state key error")
 	}
@@ -44,10 +44,10 @@ func TestTrimOperationsAboveBlockAndSetCursorRejectsEmptyStateKey(t *testing.T) 
 	}
 }
 
-func TestTrimOperationsAboveBlockAndSetCursorRejectsOverflow(t *testing.T) {
+func TestTrimEventsAboveBlockAndSetCursorRejectsOverflow(t *testing.T) {
 	t.Parallel()
 
-	err := TrimOperationsAboveBlockAndSetCursor(
+	err := TrimEventsAboveBlockAndSetCursor(
 		context.Background(),
 		&pgxpool.Pool{},
 		"cursor",

--- a/indexer/internal/db/user_operations.go
+++ b/indexer/internal/db/user_operations.go
@@ -43,7 +43,54 @@ const upsertUserOperationSQL = `
 		block_timestamp = EXCLUDED.block_timestamp
 `
 
-func ReplaceOperationsAndSetCursor(
+const upsertAccountDeploymentSQL = `
+	INSERT INTO account_deployments (
+		user_op_hash,
+		sender,
+		factory,
+		paymaster,
+		tx_hash,
+		block_number,
+		block_timestamp,
+		log_index
+	)
+	VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+	ON CONFLICT (tx_hash, log_index) DO UPDATE SET
+		user_op_hash = EXCLUDED.user_op_hash,
+		sender = EXCLUDED.sender,
+		factory = EXCLUDED.factory,
+		paymaster = EXCLUDED.paymaster,
+		block_number = EXCLUDED.block_number,
+		block_timestamp = EXCLUDED.block_timestamp
+`
+
+const upsertUserOperationRevertSQL = `
+	INSERT INTO user_operation_reverts (
+		user_op_hash,
+		sender,
+		nonce,
+		revert_reason,
+		tx_hash,
+		block_number,
+		block_timestamp,
+		log_index
+	)
+	VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+	ON CONFLICT (tx_hash, log_index) DO UPDATE SET
+		user_op_hash = EXCLUDED.user_op_hash,
+		sender = EXCLUDED.sender,
+		nonce = EXCLUDED.nonce,
+		revert_reason = EXCLUDED.revert_reason,
+		block_number = EXCLUDED.block_number,
+		block_timestamp = EXCLUDED.block_timestamp
+`
+
+// ReplaceEventsAndSetCursor atomically reindexes the given block range across
+// the three event tables (user_operations, account_deployments,
+// user_operation_reverts) and advances the cursor. Existing rows in the range
+// are deleted before the new rows are inserted, which gives us reorg-safety
+// without requiring any per-table ordering or foreign keys.
+func ReplaceEventsAndSetCursor(
 	ctx context.Context,
 	pool *pgxpool.Pool,
 	stateKey string,
@@ -51,6 +98,8 @@ func ReplaceOperationsAndSetCursor(
 	toBlock uint64,
 	cursor uint64,
 	operations []UserOperation,
+	deployments []AccountDeployment,
+	reverts []UserOperationRevert,
 ) error {
 	if stateKey == "" {
 		return fmt.Errorf("state key is required")
@@ -58,7 +107,6 @@ func ReplaceOperationsAndSetCursor(
 	if pool == nil {
 		return fmt.Errorf("pool is required")
 	}
-
 	if fromBlock > toBlock {
 		return fmt.Errorf("invalid block range: from %d > to %d", fromBlock, toBlock)
 	}
@@ -78,14 +126,18 @@ func ReplaceOperationsAndSetCursor(
 	}
 	defer tx.Rollback(ctx)
 
-	if _, err := tx.Exec(ctx,
-		"DELETE FROM user_operations WHERE block_number BETWEEN $1 AND $2",
-		from,
-		to,
-	); err != nil {
-		return fmt.Errorf("delete operations in range [%d,%d]: %w", fromBlock, toBlock, err)
+	// Delete existing rows in the range across all three tables.
+	for _, table := range []string{"user_operations", "account_deployments", "user_operation_reverts"} {
+		if _, err := tx.Exec(ctx,
+			fmt.Sprintf("DELETE FROM %s WHERE block_number BETWEEN $1 AND $2", table),
+			from,
+			to,
+		); err != nil {
+			return fmt.Errorf("delete %s in range [%d,%d]: %w", table, fromBlock, toBlock, err)
+		}
 	}
 
+	// Batch-upsert each table.
 	if len(operations) > 0 {
 		batch := &pgx.Batch{}
 		for i := range operations {
@@ -107,16 +159,71 @@ func ReplaceOperationsAndSetCursor(
 				op.LogIndex,
 			)
 		}
-
 		results := tx.SendBatch(ctx, batch)
 		for i := range operations {
 			if _, err := results.Exec(); err != nil {
 				_ = results.Close()
-				return fmt.Errorf("insert operation at index %d: %w", i, err)
+				return fmt.Errorf("insert user_operation at index %d: %w", i, err)
 			}
 		}
 		if err := results.Close(); err != nil {
-			return fmt.Errorf("close operation batch: %w", err)
+			return fmt.Errorf("close user_operations batch: %w", err)
+		}
+	}
+
+	if len(deployments) > 0 {
+		batch := &pgx.Batch{}
+		for i := range deployments {
+			d := deployments[i]
+			batch.Queue(
+				upsertAccountDeploymentSQL,
+				d.UserOpHash,
+				d.Sender,
+				d.Factory,
+				d.Paymaster,
+				d.TxHash,
+				d.BlockNumber,
+				d.BlockTimestamp,
+				d.LogIndex,
+			)
+		}
+		results := tx.SendBatch(ctx, batch)
+		for i := range deployments {
+			if _, err := results.Exec(); err != nil {
+				_ = results.Close()
+				return fmt.Errorf("insert account_deployment at index %d: %w", i, err)
+			}
+		}
+		if err := results.Close(); err != nil {
+			return fmt.Errorf("close account_deployments batch: %w", err)
+		}
+	}
+
+	if len(reverts) > 0 {
+		batch := &pgx.Batch{}
+		for i := range reverts {
+			r := reverts[i]
+			batch.Queue(
+				upsertUserOperationRevertSQL,
+				r.UserOpHash,
+				r.Sender,
+				r.Nonce,
+				r.RevertReason,
+				r.TxHash,
+				r.BlockNumber,
+				r.BlockTimestamp,
+				r.LogIndex,
+			)
+		}
+		results := tx.SendBatch(ctx, batch)
+		for i := range reverts {
+			if _, err := results.Exec(); err != nil {
+				_ = results.Close()
+				return fmt.Errorf("insert user_operation_revert at index %d: %w", i, err)
+			}
+		}
+		if err := results.Close(); err != nil {
+			return fmt.Errorf("close user_operation_reverts batch: %w", err)
 		}
 	}
 

--- a/indexer/internal/db/user_operations_test.go
+++ b/indexer/internal/db/user_operations_test.go
@@ -6,17 +6,17 @@ import (
 	"testing"
 )
 
-func TestReplaceOperationsAndSetCursorRejectsNilPool(t *testing.T) {
+func TestReplaceEventsAndSetCursorRejectsNilPool(t *testing.T) {
 	t.Parallel()
 
-	err := ReplaceOperationsAndSetCursor(
+	err := ReplaceEventsAndSetCursor(
 		context.Background(),
 		nil,
 		"user_operations.last_indexed_block",
 		0,
 		0,
 		0,
-		nil,
+		nil, nil, nil,
 	)
 	if err == nil {
 		t.Fatal("expected nil-pool error")
@@ -26,17 +26,17 @@ func TestReplaceOperationsAndSetCursorRejectsNilPool(t *testing.T) {
 	}
 }
 
-func TestReplaceOperationsAndSetCursorRejectsEmptyStateKey(t *testing.T) {
+func TestReplaceEventsAndSetCursorRejectsEmptyStateKey(t *testing.T) {
 	t.Parallel()
 
-	err := ReplaceOperationsAndSetCursor(
+	err := ReplaceEventsAndSetCursor(
 		context.Background(),
 		nil,
 		"",
 		0,
 		0,
 		0,
-		nil,
+		nil, nil, nil,
 	)
 	if err == nil {
 		t.Fatal("expected state key error")

--- a/indexer/internal/indexer/decode.go
+++ b/indexer/internal/indexer/decode.go
@@ -9,9 +9,11 @@ import (
 )
 
 var (
-	userOperationEventTopic = "0x49628fd1471006c1482da88028e9ce4dbb080b815c9b0344d39e5a8e6ec1419f"
-	handleOpsSelector       = []byte{0x76, 0x5e, 0x82, 0x7f}
-	executeSelector         = []byte{0xb6, 0x1d, 0x27, 0xf6}
+	userOperationEventTopic        = "0x49628fd1471006c1482da88028e9ce4dbb080b815c9b0344d39e5a8e6ec1419f"
+	accountDeployedTopic           = "0xd51a9c61267aa6196961883ecf5ff2da6619c37dac0fa92122513fb32c032d2d"
+	userOperationRevertReasonTopic = "0x1c4fada7374c0a9ee8841fc38afe82932dc0f8e69012e927f061a8bae611a201"
+	handleOpsSelector              = []byte{0x76, 0x5e, 0x82, 0x7f}
+	executeSelector                = []byte{0xb6, 0x1d, 0x27, 0xf6}
 )
 
 type decodedEvent struct {
@@ -26,6 +28,26 @@ type decodedEvent struct {
 	TxHashHex     string
 	BlockNumber   uint64
 	LogIndex      int32
+}
+
+type decodedAccountDeployedEvent struct {
+	UserOpHash  []byte
+	Sender      []byte
+	Factory     []byte
+	Paymaster   []byte
+	TxHash      []byte
+	BlockNumber uint64
+	LogIndex    int32
+}
+
+type decodedUserOperationRevertReasonEvent struct {
+	UserOpHash   []byte
+	Sender       []byte
+	Nonce        string
+	RevertReason []byte
+	TxHash       []byte
+	BlockNumber  uint64
+	LogIndex     int32
 }
 
 type operationCall struct {
@@ -369,4 +391,172 @@ func bytesEqual(a []byte, b []byte) bool {
 		}
 	}
 	return true
+}
+
+// decodeAccountDeployedLog parses an EntryPoint v0.7 AccountDeployed log.
+//
+// Event signature:
+//
+//	AccountDeployed(bytes32 indexed userOpHash, address indexed sender,
+//	                address factory, address paymaster)
+//
+// Topics[0] is the event signature hash; topics[1] is userOpHash;
+// topics[2] is the indexed sender (right-aligned in a 32-byte word).
+// data is exactly 64 bytes: factory (right-aligned) + paymaster (right-aligned).
+func decodeAccountDeployedLog(log rpcLog) (decodedAccountDeployedEvent, error) {
+	if len(log.Topics) != 3 {
+		return decodedAccountDeployedEvent{}, fmt.Errorf("expected 3 topics, got %d", len(log.Topics))
+	}
+
+	if !strings.EqualFold(log.Topics[0], accountDeployedTopic) {
+		return decodedAccountDeployedEvent{}, fmt.Errorf("unexpected topic0 %q", log.Topics[0])
+	}
+
+	userOpHash, err := decodeHexFixed(log.Topics[1], 32)
+	if err != nil {
+		return decodedAccountDeployedEvent{}, fmt.Errorf("decode userOpHash topic: %w", err)
+	}
+
+	sender, err := decodeIndexedAddress(log.Topics[2])
+	if err != nil {
+		return decodedAccountDeployedEvent{}, fmt.Errorf("decode sender topic: %w", err)
+	}
+
+	data, err := decodeHex(log.Data)
+	if err != nil {
+		return decodedAccountDeployedEvent{}, fmt.Errorf("decode log data: %w", err)
+	}
+	if len(data) != 32*2 {
+		return decodedAccountDeployedEvent{}, fmt.Errorf("expected 64 bytes of log data, got %d", len(data))
+	}
+
+	factoryWord, err := wordAt(data, 0)
+	if err != nil {
+		return decodedAccountDeployedEvent{}, fmt.Errorf("read factory word: %w", err)
+	}
+	paymasterWord, err := wordAt(data, 32)
+	if err != nil {
+		return decodedAccountDeployedEvent{}, fmt.Errorf("read paymaster word: %w", err)
+	}
+
+	factory := append([]byte(nil), factoryWord[12:32]...)
+	paymaster := append([]byte(nil), paymasterWord[12:32]...)
+
+	txHash, err := decodeHexFixed(log.TransactionHash, 32)
+	if err != nil {
+		return decodedAccountDeployedEvent{}, fmt.Errorf("decode transaction hash: %w", err)
+	}
+
+	blockNumber, err := parseHexUint64(log.BlockNumber)
+	if err != nil {
+		return decodedAccountDeployedEvent{}, fmt.Errorf("parse block number: %w", err)
+	}
+
+	logIndexValue, err := parseHexUint64(log.LogIndex)
+	if err != nil {
+		return decodedAccountDeployedEvent{}, fmt.Errorf("parse log index: %w", err)
+	}
+	if logIndexValue > math.MaxInt32 {
+		return decodedAccountDeployedEvent{}, fmt.Errorf("log index %d overflows int32", logIndexValue)
+	}
+
+	return decodedAccountDeployedEvent{
+		UserOpHash:  userOpHash,
+		Sender:      sender,
+		Factory:     factory,
+		Paymaster:   paymaster,
+		TxHash:      txHash,
+		BlockNumber: blockNumber,
+		LogIndex:    int32(logIndexValue),
+	}, nil
+}
+
+// decodeUserOperationRevertReasonLog parses an EntryPoint v0.7
+// UserOperationRevertReason log.
+//
+// Event signature:
+//
+//	UserOperationRevertReason(bytes32 indexed userOpHash, address indexed sender,
+//	                          uint256 nonce, bytes revertReason)
+//
+// Topics[0] is the event signature hash; topics[1] is userOpHash;
+// topics[2] is the indexed sender. Data layout:
+//
+//	word 0  — nonce (uint256)
+//	word 1  — offset to revertReason dynamic bytes (relative to start of data)
+//	word 2+ — revertReason length word followed by padded bytes
+func decodeUserOperationRevertReasonLog(log rpcLog) (decodedUserOperationRevertReasonEvent, error) {
+	if len(log.Topics) != 3 {
+		return decodedUserOperationRevertReasonEvent{}, fmt.Errorf("expected 3 topics, got %d", len(log.Topics))
+	}
+
+	if !strings.EqualFold(log.Topics[0], userOperationRevertReasonTopic) {
+		return decodedUserOperationRevertReasonEvent{}, fmt.Errorf("unexpected topic0 %q", log.Topics[0])
+	}
+
+	userOpHash, err := decodeHexFixed(log.Topics[1], 32)
+	if err != nil {
+		return decodedUserOperationRevertReasonEvent{}, fmt.Errorf("decode userOpHash topic: %w", err)
+	}
+
+	sender, err := decodeIndexedAddress(log.Topics[2])
+	if err != nil {
+		return decodedUserOperationRevertReasonEvent{}, fmt.Errorf("decode sender topic: %w", err)
+	}
+
+	data, err := decodeHex(log.Data)
+	if err != nil {
+		return decodedUserOperationRevertReasonEvent{}, fmt.Errorf("decode log data: %w", err)
+	}
+	if len(data) < 32*2 {
+		return decodedUserOperationRevertReasonEvent{}, fmt.Errorf("data too short for revert reason: %d bytes", len(data))
+	}
+
+	nonceWord, err := wordAt(data, 0)
+	if err != nil {
+		return decodedUserOperationRevertReasonEvent{}, fmt.Errorf("read nonce: %w", err)
+	}
+	nonce := uint256ToDecimal(nonceWord)
+
+	offsetWord, err := wordAt(data, 32)
+	if err != nil {
+		return decodedUserOperationRevertReasonEvent{}, fmt.Errorf("read bytes offset: %w", err)
+	}
+	offset, err := wordToOffset(offsetWord)
+	if err != nil {
+		return decodedUserOperationRevertReasonEvent{}, fmt.Errorf("parse bytes offset: %w", err)
+	}
+
+	revertReason, err := readDynamicBytes(data, 0, offset)
+	if err != nil {
+		return decodedUserOperationRevertReasonEvent{}, fmt.Errorf("read revertReason bytes: %w", err)
+	}
+
+	txHash, err := decodeHexFixed(log.TransactionHash, 32)
+	if err != nil {
+		return decodedUserOperationRevertReasonEvent{}, fmt.Errorf("decode transaction hash: %w", err)
+	}
+
+	blockNumber, err := parseHexUint64(log.BlockNumber)
+	if err != nil {
+		return decodedUserOperationRevertReasonEvent{}, fmt.Errorf("parse block number: %w", err)
+	}
+
+	logIndexValue, err := parseHexUint64(log.LogIndex)
+	if err != nil {
+		return decodedUserOperationRevertReasonEvent{}, fmt.Errorf("parse log index: %w", err)
+	}
+	if logIndexValue > math.MaxInt32 {
+		return decodedUserOperationRevertReasonEvent{}, fmt.Errorf("log index %d overflows int32", logIndexValue)
+	}
+
+	return decodedUserOperationRevertReasonEvent{
+		UserOpHash:   userOpHash,
+		Sender:       sender,
+		Nonce:        nonce,
+		RevertReason: revertReason,
+		TxHash:       txHash,
+		BlockNumber:  blockNumber,
+		LogIndex:     int32(logIndexValue),
+	}, nil
 }

--- a/indexer/internal/indexer/decode_test.go
+++ b/indexer/internal/indexer/decode_test.go
@@ -139,6 +139,134 @@ func TestDecodeHandleOpsInputRejectsTupleOffsetOutOfBounds(t *testing.T) {
 	}
 }
 
+func TestDecodeAccountDeployedLog(t *testing.T) {
+	t.Parallel()
+
+	factory := mustAddressBytes("00000000000000000000000000000000000000ff")
+	paymaster := mustAddressBytes("00000000000000000000000000000000000000aa")
+
+	log := rpcLog{
+		Topics: []string{
+			accountDeployedTopic,
+			"0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+			"0x0000000000000000000000001111111111111111111111111111111111111111",
+		},
+		Data:            "0x" + hex.EncodeToString(addressWord(factory)) + hex.EncodeToString(addressWord(paymaster)),
+		TransactionHash: "0xdddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+		BlockNumber:     "0x42",
+		LogIndex:        "0x3",
+	}
+
+	decoded, err := decodeAccountDeployedLog(log)
+	if err != nil {
+		t.Fatalf("decodeAccountDeployedLog returned error: %v", err)
+	}
+
+	if hex.EncodeToString(decoded.UserOpHash) != "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc" {
+		t.Fatalf("unexpected userOpHash: %x", decoded.UserOpHash)
+	}
+	if hex.EncodeToString(decoded.Sender) != "1111111111111111111111111111111111111111" {
+		t.Fatalf("unexpected sender: %x", decoded.Sender)
+	}
+	if !bytes.Equal(decoded.Factory, factory) {
+		t.Fatalf("unexpected factory: %x", decoded.Factory)
+	}
+	if !bytes.Equal(decoded.Paymaster, paymaster) {
+		t.Fatalf("unexpected paymaster: %x", decoded.Paymaster)
+	}
+	if decoded.BlockNumber != 0x42 {
+		t.Fatalf("expected block number 0x42, got %d", decoded.BlockNumber)
+	}
+	if decoded.LogIndex != 3 {
+		t.Fatalf("expected log index 3, got %d", decoded.LogIndex)
+	}
+}
+
+func TestDecodeAccountDeployedLogRejectsWrongTopicCount(t *testing.T) {
+	t.Parallel()
+
+	log := rpcLog{
+		Topics: []string{accountDeployedTopic, "0x00"},
+	}
+	if _, err := decodeAccountDeployedLog(log); err == nil {
+		t.Fatal("expected topic-count error")
+	}
+}
+
+func TestDecodeUserOperationRevertReasonLog(t *testing.T) {
+	t.Parallel()
+
+	// revert reason = UTF-8 "boom"
+	reason := []byte("boom")
+	reasonEncoded := encodeBytes(reason) // length word + padded bytes
+
+	// data layout: nonce (word) + offset (word) + dynamic bytes
+	data := make([]byte, 0, 64+len(reasonEncoded))
+	data = append(data, uintWord(7)...)  // nonce = 7
+	data = append(data, uintWord(64)...) // offset = 64 (skip nonce + offset words)
+	data = append(data, reasonEncoded...)
+
+	log := rpcLog{
+		Topics: []string{
+			userOperationRevertReasonTopic,
+			"0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+			"0x0000000000000000000000002222222222222222222222222222222222222222",
+		},
+		Data:            "0x" + hex.EncodeToString(data),
+		TransactionHash: "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+		BlockNumber:     "0x100",
+		LogIndex:        "0x5",
+	}
+
+	decoded, err := decodeUserOperationRevertReasonLog(log)
+	if err != nil {
+		t.Fatalf("decodeUserOperationRevertReasonLog returned error: %v", err)
+	}
+
+	if decoded.Nonce != "7" {
+		t.Fatalf("expected nonce 7, got %s", decoded.Nonce)
+	}
+	if !bytes.Equal(decoded.RevertReason, reason) {
+		t.Fatalf("unexpected revert reason: %x", decoded.RevertReason)
+	}
+	if decoded.BlockNumber != 0x100 {
+		t.Fatalf("expected block number 0x100, got %d", decoded.BlockNumber)
+	}
+	if decoded.LogIndex != 5 {
+		t.Fatalf("expected log index 5, got %d", decoded.LogIndex)
+	}
+}
+
+func TestDecodeUserOperationRevertReasonLogAcceptsEmptyBytes(t *testing.T) {
+	t.Parallel()
+
+	// Empty revertReason: length word = 0, no padding bytes.
+	data := make([]byte, 0, 64+32)
+	data = append(data, uintWord(0)...)  // nonce
+	data = append(data, uintWord(64)...) // offset
+	data = append(data, uintWord(0)...)  // bytes length = 0
+
+	log := rpcLog{
+		Topics: []string{
+			userOperationRevertReasonTopic,
+			"0x0000000000000000000000000000000000000000000000000000000000000001",
+			"0x0000000000000000000000002222222222222222222222222222222222222222",
+		},
+		Data:            "0x" + hex.EncodeToString(data),
+		TransactionHash: "0x0000000000000000000000000000000000000000000000000000000000000001",
+		BlockNumber:     "0x1",
+		LogIndex:        "0x0",
+	}
+
+	decoded, err := decodeUserOperationRevertReasonLog(log)
+	if err != nil {
+		t.Fatalf("unexpected error for empty revert reason: %v", err)
+	}
+	if len(decoded.RevertReason) != 0 {
+		t.Fatalf("expected empty revert reason, got %x", decoded.RevertReason)
+	}
+}
+
 func hexWord(value uint64) string {
 	return fmt.Sprintf("%064x", value)
 }

--- a/indexer/internal/indexer/indexer.go
+++ b/indexer/internal/indexer/indexer.go
@@ -715,7 +715,9 @@ func (s *Service) indexRangeAttempt(ctx context.Context, fromBlock uint64, toBlo
 
 	// Enrichment pass: join deployments and reverts onto UserOperations by
 	// user_op_hash so the broadcast payload already carries the denormalized
-	// fields. Uses hex-encoded key to match map key semantics.
+	// fields. Map keys are the raw 32-byte hash stringified (string([]byte) —
+	// the canonical Go pattern for byte-slice keys), giving byte-equality
+	// lookup without the cost of hex encoding.
 	if len(operations) > 0 && (len(deployments) > 0 || len(reverts) > 0) {
 		deployedByHash := make(map[string]struct{}, len(deployments))
 		for i := range deployments {

--- a/indexer/internal/indexer/indexer.go
+++ b/indexer/internal/indexer/indexer.go
@@ -550,42 +550,69 @@ func (s *Service) indexRangeAttempt(ctx context.Context, fromBlock uint64, toBlo
 		return fmt.Errorf("fetch logs [%d,%d]: %w", fromBlock, toBlock, err)
 	}
 
-	activeLogs := make([]rpcLog, 0, len(logs))
+	// Filter out removed logs; group by topic0 so we can dispatch each to its
+	// specialized decoder and enrich UserOps in-memory before broadcast.
+	var (
+		activeUserOpLogs []rpcLog
+		activeDeployLogs []rpcLog
+		activeRevertLogs []rpcLog
+	)
 	for i := range logs {
 		if logs[i].Removed {
 			continue
 		}
-		activeLogs = append(activeLogs, logs[i])
+		if len(logs[i].Topics) == 0 {
+			continue
+		}
+		switch strings.ToLower(logs[i].Topics[0]) {
+		case userOperationEventTopic:
+			activeUserOpLogs = append(activeUserOpLogs, logs[i])
+		case accountDeployedTopic:
+			activeDeployLogs = append(activeDeployLogs, logs[i])
+		case userOperationRevertReasonTopic:
+			activeRevertLogs = append(activeRevertLogs, logs[i])
+		default:
+			// Unknown topic — ignore. Should not happen given the RPC filter
+			// but defensive against provider bugs.
+			slog.Warn("unknown log topic from eth_getLogs", "topic0", logs[i].Topics[0])
+		}
 	}
+
+	// Collect all logs that need tx metadata / block timestamps.
+	allActive := make([]rpcLog, 0, len(activeUserOpLogs)+len(activeDeployLogs)+len(activeRevertLogs))
+	allActive = append(allActive, activeUserOpLogs...)
+	allActive = append(allActive, activeDeployLogs...)
+	allActive = append(allActive, activeRevertLogs...)
 
 	txMetaByHash := make(map[string]map[string][]operationMeta)
 	blockTimestamps := make(map[uint64]int64)
-	if len(activeLogs) > 0 {
+	if len(allActive) > 0 {
 		if s.cfg.EnableTxEnrichment {
-			txMetaByHash, err = s.loadTransactionOperationMeta(ctx, activeLogs)
+			// Only UserOp logs need tx metadata enrichment (target / calldata).
+			// The other two event types don't use the per-op target lookup, so
+			// we narrow the tx-fetch set to the UserOp logs to avoid wasting RPC.
+			txMetaByHash, err = s.loadTransactionOperationMeta(ctx, activeUserOpLogs)
 			if err != nil {
 				return fmt.Errorf("load transaction metadata: %w", err)
 			}
 		}
 
-		blockTimestamps, err = s.loadBlockTimestamps(ctx, activeLogs)
+		// Block timestamps are needed for all three event types.
+		blockTimestamps, err = s.loadBlockTimestamps(ctx, allActive)
 		if err != nil {
 			return fmt.Errorf("load block timestamps: %w", err)
 		}
 	}
 
-	operations := make([]db.UserOperation, 0, len(activeLogs))
-	for i := range activeLogs {
-		log := activeLogs[i]
+	operations := make([]db.UserOperation, 0, len(activeUserOpLogs))
+	for i := range activeUserOpLogs {
+		log := activeUserOpLogs[i]
 
 		event, err := decodeUserOperationEventLog(log)
 		if err != nil {
 			return fmt.Errorf(
 				"decode user operation event tx %s block %s log_index %s: %w",
-				log.TransactionHash,
-				log.BlockNumber,
-				log.LogIndex,
-				err,
+				log.TransactionHash, log.BlockNumber, log.LogIndex, err,
 			)
 		}
 
@@ -618,6 +645,97 @@ func (s *Service) indexRangeAttempt(ctx context.Context, fromBlock uint64, toBlo
 		})
 	}
 
+	deployments := make([]db.AccountDeployment, 0, len(activeDeployLogs))
+	for i := range activeDeployLogs {
+		log := activeDeployLogs[i]
+
+		event, err := decodeAccountDeployedLog(log)
+		if err != nil {
+			return fmt.Errorf(
+				"decode account deployed event tx %s block %s log_index %s: %w",
+				log.TransactionHash, log.BlockNumber, log.LogIndex, err,
+			)
+		}
+
+		blockTimestamp, ok := blockTimestamps[event.BlockNumber]
+		if !ok {
+			return fmt.Errorf("missing timestamp for block %d", event.BlockNumber)
+		}
+
+		blockNumberInt64, err := toInt64(event.BlockNumber)
+		if err != nil {
+			return fmt.Errorf("convert block number %d: %w", event.BlockNumber, err)
+		}
+
+		deployments = append(deployments, db.AccountDeployment{
+			UserOpHash:     event.UserOpHash,
+			Sender:         event.Sender,
+			Factory:        event.Factory,
+			Paymaster:      event.Paymaster,
+			TxHash:         event.TxHash,
+			BlockNumber:    blockNumberInt64,
+			BlockTimestamp: blockTimestamp,
+			LogIndex:       event.LogIndex,
+		})
+	}
+
+	reverts := make([]db.UserOperationRevert, 0, len(activeRevertLogs))
+	for i := range activeRevertLogs {
+		log := activeRevertLogs[i]
+
+		event, err := decodeUserOperationRevertReasonLog(log)
+		if err != nil {
+			return fmt.Errorf(
+				"decode user operation revert reason event tx %s block %s log_index %s: %w",
+				log.TransactionHash, log.BlockNumber, log.LogIndex, err,
+			)
+		}
+
+		blockTimestamp, ok := blockTimestamps[event.BlockNumber]
+		if !ok {
+			return fmt.Errorf("missing timestamp for block %d", event.BlockNumber)
+		}
+
+		blockNumberInt64, err := toInt64(event.BlockNumber)
+		if err != nil {
+			return fmt.Errorf("convert block number %d: %w", event.BlockNumber, err)
+		}
+
+		reverts = append(reverts, db.UserOperationRevert{
+			UserOpHash:     event.UserOpHash,
+			Sender:         event.Sender,
+			Nonce:          event.Nonce,
+			RevertReason:   event.RevertReason,
+			TxHash:         event.TxHash,
+			BlockNumber:    blockNumberInt64,
+			BlockTimestamp: blockTimestamp,
+			LogIndex:       event.LogIndex,
+		})
+	}
+
+	// Enrichment pass: join deployments and reverts onto UserOperations by
+	// user_op_hash so the broadcast payload already carries the denormalized
+	// fields. Uses hex-encoded key to match map key semantics.
+	if len(operations) > 0 && (len(deployments) > 0 || len(reverts) > 0) {
+		deployedByHash := make(map[string]struct{}, len(deployments))
+		for i := range deployments {
+			deployedByHash[string(deployments[i].UserOpHash)] = struct{}{}
+		}
+		revertByHash := make(map[string][]byte, len(reverts))
+		for i := range reverts {
+			revertByHash[string(reverts[i].UserOpHash)] = reverts[i].RevertReason
+		}
+		for i := range operations {
+			key := string(operations[i].UserOpHash)
+			if _, ok := deployedByHash[key]; ok {
+				operations[i].AccountDeployed = true
+			}
+			if reason, ok := revertByHash[key]; ok {
+				operations[i].RevertReason = reason
+			}
+		}
+	}
+
 	if err := db.ReplaceEventsAndSetCursor(
 		ctx,
 		s.pool,
@@ -626,20 +744,19 @@ func (s *Service) indexRangeAttempt(ctx context.Context, fromBlock uint64, toBlo
 		toBlock,
 		toBlock,
 		operations,
-		nil, // deployments — populated in Task 3.1
-		nil, // reverts      — populated in Task 3.1
+		deployments,
+		reverts,
 	); err != nil {
 		return fmt.Errorf("persist range [%d,%d]: %w", fromBlock, toBlock, err)
 	}
 
 	slog.Info(
 		"indexed block range",
-		"from",
-		fromBlock,
-		"to",
-		toBlock,
-		"events",
-		len(operations),
+		"from", fromBlock,
+		"to", toBlock,
+		"user_ops", len(operations),
+		"deployments", len(deployments),
+		"reverts", len(reverts),
 	)
 
 	if len(operations) > 0 && s.OnOperationsIndexed != nil {

--- a/indexer/internal/indexer/indexer.go
+++ b/indexer/internal/indexer/indexer.go
@@ -618,7 +618,7 @@ func (s *Service) indexRangeAttempt(ctx context.Context, fromBlock uint64, toBlo
 		})
 	}
 
-	if err := db.ReplaceOperationsAndSetCursor(
+	if err := db.ReplaceEventsAndSetCursor(
 		ctx,
 		s.pool,
 		s.cfg.StateKey,
@@ -626,6 +626,8 @@ func (s *Service) indexRangeAttempt(ctx context.Context, fromBlock uint64, toBlo
 		toBlock,
 		toBlock,
 		operations,
+		nil, // deployments — populated in Task 3.1
+		nil, // reverts      — populated in Task 3.1
 	); err != nil {
 		return fmt.Errorf("persist range [%d,%d]: %w", fromBlock, toBlock, err)
 	}

--- a/indexer/internal/indexer/indexer.go
+++ b/indexer/internal/indexer/indexer.go
@@ -535,7 +535,17 @@ func (s *Service) indexRange(ctx context.Context, fromBlock uint64, toBlock uint
 }
 
 func (s *Service) indexRangeAttempt(ctx context.Context, fromBlock uint64, toBlock uint64) error {
-	logs, err := s.rpc.getLogs(ctx, s.entryPoint, userOperationEventTopic, fromBlock, toBlock)
+	logs, err := s.rpc.getLogs(
+		ctx,
+		s.entryPoint,
+		[]string{
+			userOperationEventTopic,
+			accountDeployedTopic,
+			userOperationRevertReasonTopic,
+		},
+		fromBlock,
+		toBlock,
+	)
 	if err != nil {
 		return fmt.Errorf("fetch logs [%d,%d]: %w", fromBlock, toBlock, err)
 	}

--- a/indexer/internal/indexer/indexer.go
+++ b/indexer/internal/indexer/indexer.go
@@ -371,7 +371,7 @@ func (s *Service) indexOnce(ctx context.Context) error {
 			"delta",
 			delta,
 		)
-		if err := db.TrimOperationsAboveBlockAndSetCursor(ctx, s.pool, s.cfg.StateKey, safeHead); err != nil {
+		if err := db.TrimEventsAboveBlockAndSetCursor(ctx, s.pool, s.cfg.StateKey, safeHead); err != nil {
 			return fmt.Errorf("reconcile cursor to safe head: %w", err)
 		}
 		cursor = safeHead

--- a/indexer/internal/indexer/rpc.go
+++ b/indexer/internal/indexer/rpc.go
@@ -334,12 +334,20 @@ func (c *rpcClient) latestBlockNumber(ctx context.Context) (uint64, error) {
 	return value, nil
 }
 
-func (c *rpcClient) getLogs(ctx context.Context, address string, topic0 string, fromBlock uint64, toBlock uint64) ([]rpcLog, error) {
+// getLogs fetches event logs for the given address across the block range.
+// topic0s is an OR-filter: a log is returned if its Topics[0] matches any of
+// the supplied values. Passing an empty slice means no topic filter, which is
+// usually not what you want — pass the exact topic0 hashes you care about.
+func (c *rpcClient) getLogs(ctx context.Context, address string, topic0s []string, fromBlock uint64, toBlock uint64) ([]rpcLog, error) {
 	filter := map[string]any{
 		"address":   address,
 		"fromBlock": fmt.Sprintf("0x%x", fromBlock),
 		"toBlock":   fmt.Sprintf("0x%x", toBlock),
-		"topics":    []any{topic0},
+	}
+	if len(topic0s) > 0 {
+		// JSON-RPC spec: topics is an array-of-arrays. Nested array at position 0
+		// is an OR filter across topic0.
+		filter["topics"] = []any{topic0s}
 	}
 
 	var logs []rpcLog


### PR DESCRIPTION
## What

Closes #23.

Extends the indexer to capture two additional EntryPoint v0.7 events alongside `UserOperationEvent`:

- **`AccountDeployed(bytes32 userOpHash, address sender, address factory, address paymaster)`** — fires once per account creation (first UserOp with `initCode`)
- **`UserOperationRevertReason(bytes32 userOpHash, address sender, uint256 nonce, bytes revertReason)`** — fires when the inner UserOp call reverts

Both are persisted in dedicated tables and surfaced on the existing `UserOperation` API payload via LEFT JOIN enrichment. Frontend displays a "Deployed" badge on the relevant row and a best-effort revert-reason tooltip on reverted rows.

## Why

Exam bonus criterion: *"all 3 event types indexed + displayed"*. The two new events let the indexer show the full lifecycle of a UserOp — deployment, execution, revert reason — instead of just the gas/success summary.

## Scope

- [ ] Contracts
- [x] Backend
- [ ] Frontend
- [ ] Tooling / CI
- [ ] Documentation
- [x] Test

_(Frontend touched in 3 small commits but primary work is backend + DB.)_

## Architecture

- **One RPC call per range.** `eth_getLogs` now OR's three topic0s in a single `topics: [[…]]` filter. No increase in RPC pressure.
- **Two new tables** (`account_deployments`, `user_operation_reverts`), both keyed `(tx_hash, log_index)` — inherits the existing reorg-safe delete-by-block-range pattern for free.
- **Shared transaction.** `ReplaceEventsAndSetCursor` (renamed from `ReplaceOperationsAndSetCursor`) deletes + upserts across all three tables atomically with the cursor update.
- **No new endpoints.** `UserOperation` payload gains two optional fields: `accountDeployed: boolean` and `revertReason: string` (hex). Stats response gains `accountsDeployedCount`.
- **No FK between tables.** `AccountDeployed` is emitted *before* `UserOperationEvent` in the same tx; FKs would force insert ordering. Correlation is by `userOpHash`.
- **Single WebSocket stream.** The existing `OnOperationsIndexed` hook now receives enriched `UserOperation`s — no new WS channels, no message discriminator.

## Commits

14 commits in 6 dependency-ordered batches (see `thoughts/shared/plans/2026-04-18-index-account-deployed-revert-reason.md`).

Build passes at every commit. Between `2e5e7ed` and `8306540` behavior is split (new RPC signature ready but decoders not yet dispatched) — this is intentional per the plan to keep each commit scoped to one logical change.

## How to verify

### Unit + integration tests (automated)

```sh
make db-up                                          # start postgres
cd indexer
TEST_DATABASE_URL="postgres://bastion:bastion@localhost:5432/bastion?sslmode=disable" \
  go test ./... -count=1                            # includes integration tests
```

Covers decoders (real-event fixtures), atomic delete+insert across all 3 tables, LEFT JOIN enrichment, and stats aggregate.

### Manual end-to-end (against Sepolia)

1. Start stack: `make db-up && make indexer-dev` (in one tab), `cd frontend && pnpm dev` (in another).
2. Deploy a fresh SmartAccount from `/` → observe the UserOp appear in `/indexer` with a blue **Deployed** badge.
3. Intentionally revert a UserOp (e.g. send a UserOp with malformed calldata) → observe red **Reverted** badge with a hover tooltip showing the decoded revert reason (UTF-8 or `Error(string)` decoded when possible, raw hex otherwise).
4. Stats panel now shows **Accounts Deployed** count as a 5th card.

## Related issues

closes #23