### PR TITLE
Code review hardening: paymaster client, broadcast panic, eslint, owner rotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,10 @@ One bullet per decision, in the order an evaluator is likely to ask about them.
 
 ## Limitations & Trade-offs
 
+- **No upgrade path.** Accounts sit behind ERC1967 proxies, but no UUPS upgrade authorization is exposed — the implementation address is fixed at deploy time. A bug in the implementation cannot be patched for existing accounts.
+- **No recovery mechanism.** `transferOwnership` requires the current owner's authorization, so a lost owner key still bricks the account — there is no social recovery or guardian scheme. A compromised-but-not-lost key, however, can be rotated out via `transferOwnership`.
+- **Session key fee surface.** Session keys don't constrain UserOp gas fields or paymaster choice. An in-scope compromised session key can grief a self-funded account's EntryPoint deposit by submitting ops with inflated gas parameters — the prefund is drawn from the account's deposit.
+- **Selector-level scoping only.** Session key scope stops at the 4-byte selector — there are no argument-level constraints. A key scoped to `transfer(address,uint256)` on a token can send the full balance to any address.
 - **Session keys are single-call only.** The account validates that the outer call is `execute`, not `executeBatch`. Lifting this would require scoping every inner call individually during `validateUserOp`.
 - **Session-key list is not enumerable on-chain.** Registered keys are stored in a non-iterable mapping; the UI tracks the set in memory and relies on `SessionKeyAdded` / `SessionKeyRevoked` events as the source of truth. A production UI would index these.
 - **Single EntryPoint on a single chain.** The indexer is configured for one `ENTRYPOINT` on one `RPC_URL`. Scaling to multiple contracts or chains would need a worker-per-chain model sharing the Postgres instance — orthogonal to the rest of the design, but not implemented.

--- a/contracts/src/SmartAccount.sol
+++ b/contracts/src/SmartAccount.sol
@@ -50,6 +50,9 @@ contract SmartAccount is BaseAccount, Initializable {
     /// @notice Emitted when the owner revokes a session key (exam spec name).
     event SessionKeyRevoked(address indexed key);
 
+    /// @notice Emitted when ownership of the account is transferred.
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
     // ───────────────────────────── Errors ──────────────────────────────
 
     error InvalidEntryPoint();
@@ -58,6 +61,7 @@ contract SmartAccount is BaseAccount, Initializable {
     error SessionKeyAlreadyRegistered(address key);
     error SessionKeyNotRegistered(address key);
     error InvalidSessionKeyParams();
+    error InvalidNewOwner();
 
     // ───────────────────────────── Modifiers ───────────────────────────
 
@@ -179,6 +183,24 @@ contract SmartAccount is BaseAccount, Initializable {
 
         delete sessionKeys[key];
         emit SessionKeyRevoked(key);
+    }
+
+    // ──────────────────────────── Ownership ────────────────────────────
+
+    /// @notice Transfer ownership of this account to a new EOA. Callable by the
+    ///         current owner directly or via the EntryPoint (owner-signed UserOp).
+    ///         Session keys cannot reach this function — same rationale as
+    ///         registerSessionKey: a self-call via execute has msg.sender =
+    ///         address(this), which fails the modifier.
+    /// @dev    Note: SmartAccountFactory.getAddress(owner, salt) derives the
+    ///         counterfactual address from the INITIAL owner — after a transfer,
+    ///         the factory mapping no longer corresponds to the current owner.
+    /// @param newOwner The EOA that will own this account. Must not be address(0).
+    function transferOwnership(address newOwner) external onlyOwnerOrEntryPoint {
+        if (newOwner == address(0)) revert InvalidNewOwner();
+        address previousOwner = owner;
+        owner = newOwner;
+        emit OwnershipTransferred(previousOwner, newOwner);
     }
 
     // ──────────────────────────── Execution ────────────────────────────

--- a/contracts/test/SmartAccount.t.sol
+++ b/contracts/test/SmartAccount.t.sol
@@ -833,6 +833,149 @@ contract SmartAccountTest is Test {
         assertEq(evilValidUntil, 0, "evil session key must not be registered");
     }
 
+    // ───────────────────── Ownership transfer tests ────────────────────
+
+    function test_transferOwnership_updatesOwnerAndEmitsEvent() public {
+        address newOwner = makeAddr("newOwner");
+
+        vm.expectEmit(true, true, false, false);
+        emit SmartAccount.OwnershipTransferred(owner, newOwner);
+
+        vm.prank(owner);
+        account.transferOwnership(newOwner);
+
+        assertEq(account.owner(), newOwner);
+    }
+
+    function test_transferOwnership_revertsZeroAddress() public {
+        vm.prank(owner);
+        vm.expectRevert(SmartAccount.InvalidNewOwner.selector);
+        account.transferOwnership(address(0));
+    }
+
+    function test_transferOwnership_revertsFromStranger() public {
+        vm.prank(stranger);
+        vm.expectRevert(SmartAccount.OnlyOwnerOrEntryPoint.selector);
+        account.transferOwnership(stranger);
+    }
+
+    function test_transferOwnership_viaEntryPoint() public {
+        address newOwner = makeAddr("newOwner");
+
+        bytes memory callData = abi.encodeCall(SmartAccount.transferOwnership, (newOwner));
+        PackedUserOperation memory userOp = _buildUserOp(callData);
+        userOp.signature = _signUserOp(userOp, ownerKey);
+
+        PackedUserOperation[] memory ops = new PackedUserOperation[](1);
+        ops[0] = userOp;
+        entryPoint.handleOps(ops, beneficiary);
+
+        assertEq(account.owner(), newOwner);
+    }
+
+    function test_transferOwnership_sessionKeyCannotEscalateViaSelfCall() public {
+        (address sessionKey, uint256 sessionPrivKey) = makeAddrAndKey("sessionKey");
+        address attacker = makeAddr("attacker");
+
+        // Deliberately scope the session key to target the account itself with
+        // transferOwnership's selector. _validateSessionKey passes (target, selector,
+        // and time bounds all match), but the self-call during execution hits
+        // onlyOwnerOrEntryPoint because msg.sender is address(account), not the
+        // EntryPoint or owner. Defense-in-depth: validation alone doesn't prevent
+        // this; the modifier does.
+        vm.prank(owner);
+        account.registerSessionKey(
+            sessionKey,
+            address(account),
+            SmartAccount.transferOwnership.selector,
+            uint48(block.timestamp),
+            uint48(block.timestamp + 1 hours)
+        );
+
+        bytes memory innerData = abi.encodeCall(SmartAccount.transferOwnership, (attacker));
+        bytes memory callData = abi.encodeCall(SmartAccount.execute, (address(account), 0, innerData));
+        PackedUserOperation memory userOp = _buildUserOp(callData);
+        userOp.signature = _signUserOp(userOp, sessionPrivKey);
+        bytes32 userOpHash = this.getUserOpHash(userOp);
+
+        // Validation succeeds — target and selector match the session key scope.
+        vm.prank(address(entryPoint));
+        uint256 validationData = account.validateUserOp(userOp, userOpHash, 0);
+        assertNotEq(validationData, 1, "validation should pass for scoped self-call");
+
+        // But the full flow through handleOps records success=false: the inner
+        // self-call reverts with OnlyOwnerOrEntryPoint because msg.sender is
+        // address(account) during the delegated call.
+        PackedUserOperation[] memory ops = new PackedUserOperation[](1);
+        ops[0] = userOp;
+
+        vm.recordLogs();
+        entryPoint.handleOps(ops, beneficiary);
+
+        // The UserOperationEvent's success field (2nd non-indexed param) should be false.
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        bool foundEvent = false;
+        for (uint256 i = 0; i < logs.length; i++) {
+            if (
+                logs[i].topics[0]
+                    == keccak256("UserOperationEvent(bytes32,address,address,uint256,bool,uint256,uint256)")
+            ) {
+                (, bool success,,) = abi.decode(logs[i].data, (uint256, bool, uint256, uint256));
+                assertFalse(success, "self-call should fail at execution time");
+                foundEvent = true;
+                break;
+            }
+        }
+        assertTrue(foundEvent, "UserOperationEvent not emitted");
+
+        // Confirm the escalation had no effect: owner is unchanged.
+        assertEq(account.owner(), owner, "owner must not change via session key self-call");
+    }
+
+    function test_transferOwnership_newOwnerSignatureValidAfterTransfer() public {
+        (address newOwner, uint256 newOwnerKey) = makeAddrAndKey("newOwner");
+
+        vm.prank(owner);
+        account.transferOwnership(newOwner);
+
+        bytes memory callData =
+            abi.encodeCall(SmartAccount.execute, (address(counter), 0, abi.encodeCall(Counter.increment, ())));
+        PackedUserOperation memory userOp = _buildUserOp(callData);
+        userOp.signature = _signUserOp(userOp, newOwnerKey);
+        bytes32 userOpHash = this.getUserOpHash(userOp);
+
+        vm.prank(address(entryPoint));
+        uint256 validationData = account.validateUserOp(userOp, userOpHash, 0);
+        assertEq(validationData, 0); // SIG_VALIDATION_SUCCESS
+
+        // Full flow: the nonce is only consumed by handleOps (a direct
+        // validateUserOp call doesn't touch the EntryPoint's NonceManager),
+        // so the same op can go through the real path.
+        PackedUserOperation[] memory ops = new PackedUserOperation[](1);
+        ops[0] = userOp;
+        entryPoint.handleOps(ops, beneficiary);
+
+        assertEq(counter.getCount(address(account)), 1);
+    }
+
+    function test_transferOwnership_oldOwnerSignatureRejectedAfterTransfer() public {
+        address newOwner = makeAddr("newOwner");
+
+        vm.prank(owner);
+        account.transferOwnership(newOwner);
+
+        // The old owner is neither the current owner nor a registered session key.
+        bytes memory callData =
+            abi.encodeCall(SmartAccount.execute, (address(counter), 0, abi.encodeCall(Counter.increment, ())));
+        PackedUserOperation memory userOp = _buildUserOp(callData);
+        userOp.signature = _signUserOp(userOp, ownerKey);
+        bytes32 userOpHash = this.getUserOpHash(userOp);
+
+        vm.prank(address(entryPoint));
+        uint256 validationData = account.validateUserOp(userOp, userOpHash, 0);
+        assertEq(validationData, 1); // SIG_VALIDATION_FAILED
+    }
+
     // ─────────────── Execution: ETH forwarding & reverts ──────────────
 
     function test_execute_forwardsEthValue() public {

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,0 +1,23 @@
+node_modules
+
+# Output
+.output
+.vercel
+.netlify
+.wrangler
+/.svelte-kit
+/build
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Env
+.env
+.env.*
+!.env.example
+!.env.test
+
+# Vite
+vite.config.js.timestamp-*
+vite.config.ts.timestamp-*

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -22,7 +22,15 @@ export default defineConfig(
 		rules: {
 			// typescript-eslint strongly recommend that you do not use the no-undef lint rule on TypeScript projects.
 			// see: https://typescript-eslint.io/troubleshooting/faqs/eslint/#i-get-errors-from-the-no-undef-rule-about-global-variables-not-being-defined-even-though-there-are-no-typescript-errors
-			'no-undef': 'off'
+			'no-undef': 'off',
+			'@typescript-eslint/no-unused-vars': [
+				'error',
+				{
+					argsIgnorePattern: '^_',
+					varsIgnorePattern: '^_',
+					caughtErrorsIgnorePattern: '^_'
+				}
+			]
 		}
 	},
 	{

--- a/frontend/src/lib/account.svelte.ts
+++ b/frontend/src/lib/account.svelte.ts
@@ -1,11 +1,8 @@
-import { http } from 'viem';
-import { sepolia } from 'viem/chains';
-import { createPaymasterClient } from 'viem/account-abstraction';
-import { createSmartAccountClient } from 'permissionless';
 import { publicClient, wallet } from '$lib/wallet.svelte';
 import { SmartAccountFactoryAbi } from '$lib/contracts/SmartAccountFactory';
 import { toBastionSmartAccount } from '$lib/smartAccount';
-import { factoryAddress, pimlicoUrl } from '$lib/config';
+import { createBundlerClientFor } from '$lib/userOp';
+import { factoryAddress } from '$lib/config';
 
 class AccountState {
 	smartAccountAddress = $state<`0x${string}` | null>(null);
@@ -91,18 +88,7 @@ class AccountState {
 
 			if (id !== this.deployId) return;
 
-			const pimlico = pimlicoUrl();
-
-			const paymaster = createPaymasterClient({
-				transport: http(pimlico)
-			});
-
-			const bundlerClient = createSmartAccountClient({
-				account: smartAccount,
-				paymaster,
-				chain: sepolia,
-				bundlerTransport: http(pimlico)
-			});
+			const bundlerClient = await createBundlerClientFor(smartAccount);
 
 			// Send a no-op call to self — the first UserOp auto-deploys via initCode.
 			const hash = await bundlerClient.sendUserOperation({

--- a/frontend/src/lib/components/CounterCard.svelte
+++ b/frontend/src/lib/components/CounterCard.svelte
@@ -74,8 +74,8 @@
 	}
 
 	$effect(() => {
-		// Reload when accountAddress changes.
-		accountAddress;
+		// Reload when accountAddress changes (void read registers the dependency).
+		void accountAddress;
 		loadCount();
 	});
 </script>
@@ -116,6 +116,7 @@
 			{#if lastTxHash}
 				<p>
 					Tx:
+					<!-- eslint-disable svelte/no-navigation-without-resolve -- external Etherscan URL, not app navigation -->
 					<a
 						href={etherscanTx(lastTxHash)}
 						target="_blank"
@@ -124,6 +125,7 @@
 					>
 						{truncateHex(lastTxHash)}
 					</a>
+					<!-- eslint-enable svelte/no-navigation-without-resolve -->
 				</p>
 			{/if}
 		</div>

--- a/frontend/src/lib/components/FaucetTokenCard.svelte
+++ b/frontend/src/lib/components/FaucetTokenCard.svelte
@@ -104,7 +104,8 @@
 	}
 
 	$effect(() => {
-		accountAddress;
+		// Reload when accountAddress changes (void read registers the dependency).
+		void accountAddress;
 		loadBalance();
 	});
 </script>
@@ -146,6 +147,7 @@
 			{#if lastTxHash}
 				<p>
 					Tx:
+					<!-- eslint-disable svelte/no-navigation-without-resolve -- external Etherscan URL, not app navigation -->
 					<a
 						href={etherscanTx(lastTxHash)}
 						target="_blank"
@@ -154,6 +156,7 @@
 					>
 						{truncateHex(lastTxHash)}
 					</a>
+					<!-- eslint-enable svelte/no-navigation-without-resolve -->
 				</p>
 			{/if}
 		</div>

--- a/frontend/src/lib/components/SessionKeyManager.svelte
+++ b/frontend/src/lib/components/SessionKeyManager.svelte
@@ -69,9 +69,9 @@
 		selectedTarget.functions[selectedFnIndex] ?? selectedTarget.functions[0]
 	);
 
-	// Reset function index when target changes.
+	// Reset function index when target changes (void read registers the dependency).
 	$effect(() => {
-		selectedTargetId;
+		void selectedTargetId;
 		selectedFnIndex = 0;
 	});
 
@@ -274,7 +274,7 @@
 					bind:value={selectedTargetId}
 					class="w-full rounded border border-zinc-700 bg-zinc-900 px-3 py-2 text-sm text-zinc-100 focus:border-indigo-500 focus:outline-none"
 				>
-					{#each TARGETS as target}
+					{#each TARGETS as target (target.id)}
 						<option value={target.id}>{target.label}</option>
 					{/each}
 				</select>
@@ -288,7 +288,7 @@
 					bind:value={selectedFnIndex}
 					class="w-full rounded border border-zinc-700 bg-zinc-900 px-3 py-2 font-mono text-sm text-zinc-100 focus:border-indigo-500 focus:outline-none"
 				>
-					{#each selectedTarget.functions as fn, i}
+					{#each selectedTarget.functions as fn, i (fn.selector)}
 						<option value={i}>{fn.label}</option>
 					{/each}
 				</select>
@@ -332,7 +332,7 @@
 			</p>
 
 			<div class="mt-4 space-y-3">
-				{#each keys as entry, i}
+				{#each keys as entry, i (i)}
 					{@const status = keyStatus(entry)}
 					<div
 						class="rounded border p-3"

--- a/frontend/src/lib/components/StatsPanel.svelte
+++ b/frontend/src/lib/components/StatsPanel.svelte
@@ -36,7 +36,7 @@
 					{pct(stats.successRate)}
 				</span>
 			{:else}
-				{'\u2014'}
+				—
 			{/if}
 		</p>
 		{#if stats && stats.totalOps > 0}
@@ -55,7 +55,7 @@
 					{pct(stats.sponsoredRate)}
 				</span>
 			{:else}
-				{'\u2014'}
+				—
 			{/if}
 		</p>
 		{#if stats && stats.totalOps > 0}

--- a/frontend/src/lib/userOp.ts
+++ b/frontend/src/lib/userOp.ts
@@ -8,9 +8,9 @@
 import type { Account, Address, Chain, Hex, LocalAccount, Transport, WalletClient } from 'viem';
 import { http } from 'viem';
 import { sepolia } from 'viem/chains';
-import type { SmartAccount } from 'viem/account-abstraction';
-import { createPaymasterClient } from 'viem/account-abstraction';
+import { entryPoint07Address, type SmartAccount } from 'viem/account-abstraction';
 import { createSmartAccountClient } from 'permissionless';
+import { createPimlicoClient } from 'permissionless/clients/pimlico';
 import { publicClient } from '$lib/wallet.svelte';
 import { toBastionSmartAccount, toSessionKeySmartAccount } from '$lib/smartAccount';
 import { factoryAddress, pimlicoUrl } from '$lib/config';
@@ -27,19 +27,28 @@ export type UserOpResult = {
 	success: boolean;
 };
 
-/** Create a SmartAccountClient (bundler + paymaster) for a given SmartAccount adapter. */
-async function createBundlerClientFor(account: SmartAccount) {
+/** Create a SmartAccountClient (bundler + paymaster) for a given SmartAccount adapter.
+ *
+ * Uses Pimlico's `pimlico_*` paymaster methods (free-tier compatible) via
+ * `createPimlicoClient`, NOT the ERC-7677 `pm_*` methods that viem's
+ * `createPaymasterClient` would call (those are paid-tier on Pimlico).
+ */
+export async function createBundlerClientFor(account: SmartAccount) {
 	const pimlico = pimlicoUrl();
 
-	const paymaster = createPaymasterClient({
-		transport: http(pimlico)
+	const pimlicoClient = createPimlicoClient({
+		transport: http(pimlico),
+		entryPoint: { address: entryPoint07Address, version: '0.7' }
 	});
 
 	return createSmartAccountClient({
 		account,
-		paymaster,
+		paymaster: pimlicoClient,
 		chain: sepolia,
-		bundlerTransport: http(pimlico)
+		bundlerTransport: http(pimlico),
+		userOperation: {
+			estimateFeesPerGas: async () => (await pimlicoClient.getUserOperationGasPrice()).fast
+		}
 	});
 }
 

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import './layout.css';
+	import { resolve } from '$app/paths';
 	import favicon from '$lib/assets/favicon.svg';
 	import ConnectButton from '$lib/components/ConnectButton.svelte';
 
@@ -11,9 +12,9 @@
 <div class="flex min-h-screen flex-col bg-zinc-900 text-zinc-100">
 	<header class="flex items-center justify-between border-b border-zinc-800 px-6 py-4">
 		<nav class="flex items-center gap-6">
-			<a href="/" class="text-lg font-semibold tracking-tight">Bastion</a>
-			<a href="/session" class="text-sm text-zinc-400 hover:text-zinc-200">Session</a>
-			<a href="/indexer" class="text-sm text-zinc-400 hover:text-zinc-200">Indexer</a>
+			<a href={resolve('/')} class="text-lg font-semibold tracking-tight">Bastion</a>
+			<a href={resolve('/session')} class="text-sm text-zinc-400 hover:text-zinc-200">Session</a>
+			<a href={resolve('/indexer')} class="text-sm text-zinc-400 hover:text-zinc-200">Indexer</a>
 		</nav>
 		<ConnectButton />
 	</header>

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -39,6 +39,7 @@
 						<div class="flex justify-between">
 							<dt class="text-zinc-400">Account Address</dt>
 							<dd class="font-mono text-sm">
+								<!-- eslint-disable svelte/no-navigation-without-resolve -- external Etherscan URL, not app navigation -->
 								<a
 									href={etherscanAddress(account.smartAccountAddress)}
 									target="_blank"
@@ -47,6 +48,7 @@
 								>
 									{truncateHex(account.smartAccountAddress)}
 								</a>
+								<!-- eslint-enable svelte/no-navigation-without-resolve -->
 							</dd>
 						</div>
 						<div class="flex justify-between">

--- a/frontend/src/routes/indexer/+page.svelte
+++ b/frontend/src/routes/indexer/+page.svelte
@@ -58,6 +58,7 @@
 				const dataHex = raw.slice(8 + 128, 8 + 128 + strLen * 2);
 				const bytes = new Uint8Array(dataHex.match(/.{2}/g)?.map((b) => parseInt(b, 16)) ?? []);
 				const text = new TextDecoder('utf-8', { fatal: false }).decode(bytes);
+				// eslint-disable-next-line no-control-regex -- deliberate control-character detection for revert-reason sanitization
 				if (!/[\x00-\x08\x0e-\x1f]/.test(text)) return text;
 			} catch {
 				// fall through to raw hex
@@ -68,6 +69,7 @@
 		try {
 			const bytes = new Uint8Array(raw.match(/.{2}/g)?.map((b) => parseInt(b, 16)) ?? []);
 			const text = new TextDecoder('utf-8', { fatal: false }).decode(bytes);
+			// eslint-disable-next-line no-control-regex -- deliberate control-character detection for revert-reason sanitization
 			if (text.length > 0 && !/[\x00-\x08\x0e-\x1f]/.test(text)) return text;
 		} catch {
 			// fall through
@@ -145,6 +147,7 @@
 
 							<!-- Sender -->
 							<td class="px-4 py-3 font-mono text-xs">
+								<!-- eslint-disable svelte/no-navigation-without-resolve -- external Etherscan URL, not app navigation -->
 								<a
 									href={etherscanAddress(op.sender)}
 									target="_blank"
@@ -153,11 +156,13 @@
 								>
 									{truncateHex(op.sender)}
 								</a>
+								<!-- eslint-enable svelte/no-navigation-without-resolve -->
 							</td>
 
 							<!-- Paymaster -->
 							<td class="px-4 py-3 font-mono text-xs">
 								{#if isSponsored(op.paymaster)}
+									<!-- eslint-disable svelte/no-navigation-without-resolve -- external Etherscan URL, not app navigation -->
 									<a
 										href={etherscanAddress(op.paymaster)}
 										target="_blank"
@@ -166,6 +171,7 @@
 									>
 										{truncateHex(op.paymaster)}
 									</a>
+									<!-- eslint-enable svelte/no-navigation-without-resolve -->
 									<span
 										class="ml-1.5 inline-block rounded bg-emerald-900/60 px-1.5 py-0.5 text-[10px] font-medium text-emerald-300"
 									>
@@ -211,6 +217,7 @@
 
 							<!-- Block -->
 							<td class="px-4 py-3 text-right font-mono text-xs">
+								<!-- eslint-disable svelte/no-navigation-without-resolve -- external Etherscan URL, not app navigation -->
 								<a
 									href={etherscanBlock(op.blockNumber)}
 									target="_blank"
@@ -219,6 +226,7 @@
 								>
 									{op.blockNumber}
 								</a>
+								<!-- eslint-enable svelte/no-navigation-without-resolve -->
 							</td>
 
 							<!-- Timestamp -->
@@ -228,6 +236,7 @@
 
 							<!-- Tx Link -->
 							<td class="px-4 py-3">
+								<!-- eslint-disable svelte/no-navigation-without-resolve -- external Etherscan URL, not app navigation -->
 								<a
 									href={etherscanTx(op.txHash)}
 									target="_blank"
@@ -237,6 +246,7 @@
 								>
 									{truncateHex(op.txHash)}
 								</a>
+								<!-- eslint-enable svelte/no-navigation-without-resolve -->
 							</td>
 						</tr>
 					{/each}

--- a/frontend/src/routes/session/+page.svelte
+++ b/frontend/src/routes/session/+page.svelte
@@ -287,6 +287,7 @@
 					{#if lastTxHash}
 						<p>
 							Tx:
+							<!-- eslint-disable svelte/no-navigation-without-resolve -- external Etherscan URL, not app navigation -->
 							<a
 								href={etherscanTx(lastTxHash)}
 								target="_blank"
@@ -295,6 +296,7 @@
 							>
 								{truncateHex(lastTxHash)}
 							</a>
+							<!-- eslint-enable svelte/no-navigation-without-resolve -->
 						</p>
 					{/if}
 				</div>

--- a/indexer/internal/api/hub.go
+++ b/indexer/internal/api/hub.go
@@ -68,14 +68,17 @@ func (h *Hub) Broadcast(ops []db.UserOperation) {
 	var slow []*wsClient
 
 	h.mu.Lock()
+clients:
 	for c := range h.clients {
 		for _, msg := range messages {
 			select {
 			case c.send <- msg:
 			default:
+				// removeClientLocked closes c.send; skip the rest of
+				// the batch so we never send on the closed channel.
 				h.removeClientLocked(c)
 				slow = append(slow, c)
-				break
+				continue clients
 			}
 		}
 	}

--- a/indexer/internal/api/hub_test.go
+++ b/indexer/internal/api/hub_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"testing"
 	"time"
 
@@ -97,6 +98,63 @@ func TestBroadcastDropsSlowClient(t *testing.T) {
 
 	if exists {
 		t.Fatal("expected slow client to be removed")
+	}
+}
+
+func TestBroadcastMultipleMessagesDropsSlowClientOnce(t *testing.T) {
+	t.Parallel()
+
+	hub := NewHub()
+	slow := &wsClient{send: make(chan []byte)} // unbuffered = always full
+	healthy := &wsClient{send: make(chan []byte, clientSendBuffer)}
+	hub.mu.Lock()
+	hub.clients[slow] = struct{}{}
+	hub.clients[healthy] = struct{}{}
+	hub.mu.Unlock()
+
+	ops := make([]db.UserOperation, 5)
+	for i := range ops {
+		ops[i] = testOp()
+		ops[i].Nonce = strconv.Itoa(i)
+	}
+
+	// Before the labeled-continue fix this panicked: the slow client's
+	// first failed send closed its channel, and the next message in the
+	// batch was sent on the closed channel.
+	hub.Broadcast(ops)
+
+	hub.mu.Lock()
+	_, exists := hub.clients[slow]
+	hub.mu.Unlock()
+	if exists {
+		t.Fatal("expected slow client to be removed")
+	}
+
+	// Slow client's send channel must be closed; nothing was ever
+	// delivered on it, so a receive returns immediately with ok=false.
+	if _, ok := <-slow.send; ok {
+		t.Fatal("expected slow client send channel to be closed")
+	}
+
+	// Healthy client must receive all messages in order.
+	for i := range ops {
+		select {
+		case msg := <-healthy.send:
+			var resp operationResponse
+			if err := json.Unmarshal(msg, &resp); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			if want := strconv.Itoa(i); resp.Nonce != want {
+				t.Fatalf("nonce = %q, want %q", resp.Nonce, want)
+			}
+		default:
+			t.Fatalf("expected message %d on healthy client send channel", i)
+		}
+	}
+	select {
+	case msg := <-healthy.send:
+		t.Fatalf("unexpected extra message: %s", msg)
+	default:
 	}
 }
 


### PR DESCRIPTION
## What

Post-review hardening across all three components, plus owner rotation:

- **fix(frontend)**: use Pimlico paymaster client with fee estimation — switches from ERC-7677 `pm_*` methods (paid tier) to `pimlico_*` methods via `createPimlicoClient`, with a shared bundler-client helper deduplicating `deploy()` and `sendUserOp` setup
- **fix(indexer)**: prevent broadcast panic on slow WebSocket clients — `break` in the select only exited the select, so the next iteration sent on a closed channel and killed the whole process; now a labeled continue, with a multi-message regression test
- **chore(frontend)**: restore `.gitignore` required by eslint config — `includeIgnoreFile` crashed on ENOENT, so lint had been silently broken
- **fix(frontend)**: resolve eslint errors across app — 23 accumulated errors down to 0
- **feat(contracts)**: add owner rotation via `transferOwnership` — mirrors the existing `onlyOwnerOrEntryPoint` auth, emits `OwnershipTransferred`, 7 new tests including a session-key self-call escalation negative
- **docs**: document account limitations (upgradeability, recovery, session key fee surface, selector-level scoping)

## Why

A full code review found a process-killing crash in the indexer hub, a paymaster integration on the paid-tier API path, silently broken lint tooling, and no way to rotate a compromised owner key. This PR fixes all four and documents the remaining known gaps.

## Scope

- [x] Contracts
- [x] Backend
- [x] Frontend
- [x] Tooling / CI
- [x] Documentation
- [x] Test

## How to verify

- `cd contracts && forge test -vvv` — 100 passed (was 93)
- `cd indexer && go test ./...` — all pass; the new `TestBroadcastMultipleMessagesDropsSlowClientOnce` panics against the pre-fix hub
- `cd frontend && pnpm lint && pnpm build` — 0 errors, clean build
- Manual: deploy flow on Sepolia lands a sponsored UserOp via the Pimlico free tier

## Related issues

None closed. #65, #66, #67 were filed from the same review as deferred low-severity follow-ups.